### PR TITLE
fix: supprime la référence invalide à un webmanifest

### DIFF
--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -5,7 +5,6 @@
 	import appleTouchFavicon from '@gouvfr/dsfr/dist/favicon/apple-touch-icon.png';
 	import svgFavicon from '@gouvfr/dsfr/dist/favicon/favicon.svg';
 	import icoFavicon from '@gouvfr/dsfr/dist/favicon/favicon.ico';
-	import manifest from '@gouvfr/dsfr/dist/favicon/manifest.webmanifest';
 	import { onDestroy, onMount } from 'svelte';
 	import { env } from '$env/dynamic/public';
 	import * as Matomo from '$lib/tracking/matomo';
@@ -96,9 +95,8 @@
 	<link rel="apple-touch-icon" href={appleTouchFavicon} />
 	<!-- 180×180 -->
 	<link rel="icon" href={svgFavicon} type="image/svg+xml" />
-	<link rel="shortcut icon" href={icoFavicon} type="image/x-icon" />
 	<!-- 32×32 -->
-	<link rel="manifest" href={manifest} crossorigin="use-credentials" />
+	<link rel="shortcut icon" href={icoFavicon} type="image/x-icon" />
 </svelte:head>
 
 <slot />


### PR DESCRIPTION
## :wrench: Problème

Actuellement lors du chargement de l'application on a une erreur dans la console du navigateur :

```
Refused to load data:application/manifest+json;base64,ewogICAgImljb25zIjogWwogICAgICAgIHsKICAgICAgICAgICAgInNyYyI6ICJhbmRyb2lkLWNocm9tZS0xOTJ4MTkyLnBuZyIsCiAgICAgICAgICAgICJzaXplcyI6ICIxOTJ4MTkyIiwKICAgICAgICAgICAgInR5cGUiOiAiaW1hZ2UvcG5nIgogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAic3JjIjogImFuZHJvaWQtY2hyb21lLTUxMng1MTIucG5nIiwKICAgICAgICAgICAgInNpemVzIjogIjUxMng1MTIiLAogICAgICAgICAgICAidHlwZSI6ICJpbWFnZS9wbmciCiAgICAgICAgfQogICAgXQp9Cg== because it appears in neither the manifest-src directive nor the default-src directive of the Content Security Policy.
content.js:328
```

Qui nous indique donc que le `webmanifest` déclaré par l'application n'est pas chargé car en violation de la _content security policy_.

## :cake: Solution

On supprime la référence à un `webmanifest`. Carnet de Bord n'a pas vraiment vocation à être utilisée comme _Progressive Web App_ et quoi qu'il en soit, le manifeste actuel n'étant jamais chargé, sa suppression ne peut entraîner de régression.

D'ailleurs le manifeste en question (importé depuis le DSFR) contient ceci :

```json
{
    "icons": [
        {
            "src": "android-chrome-192x192.png",
            "sizes": "192x192",
            "type": "image/png"
        },
        {
            "src": "android-chrome-512x512.png",
            "sizes": "512x512",
            "type": "image/png"
        }
    ]
}
```

C'est-à-dire qu'il fait lui-même référence à des images qui ne sont pas publiées par l'application. Et qui elles-mêmes existent dans le DSFR mais sont des icônes génériques n'ayant probablement que peu d'intérêt pour Carnet de Bord même si elles étaient effectivement chargées.

## :desert_island: Comment tester

Charger la _review app_ ci-dessous et constater l'absence d'erreur concernant le manifeste dans la console du navigateur.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1210.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
