### PR TITLE
ci: Ne plus dépendre d'un token de `SocialGouv` pour la création de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
             @semantic-release/git@10.0.1
             @semantic-release/exec@6.0.3
         env:
-          GITHUB_TOKEN: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,11 +1,9 @@
 ## DOCUMENTATION mise en prod
 
-Afficher la [liste des workflows de production](https://github.com/SocialGouv/carnet-de-bord/actions/workflows/production.yml)
-et sélectionner le dernier.
+Afficher la [liste des workflows de déploiement](../../actions/workflows/deploy.yml)
+et sélectionner le plus récent.
 
-![image](https://user-images.githubusercontent.com/160320/173361957-bddf7d16-c567-47e5-8756-8225aa6be27c.png)
-
-cliquer sur le bouton `Review deployments`
+Cliquer sur le bouton `Review deployments`
 
 ![image](https://user-images.githubusercontent.com/160320/173357836-f79557fa-9678-48ce-a34c-2d3a04a1de8c.png)
 
@@ -17,28 +15,26 @@ et cocher la case `production` avant de finaliser le process en cliquant sur `Ap
 
 Préambule : Pour lancer les commandes de l'outils en ligne de commande hasura, il faut avoir la variable d'environnement suivante `HASURA_GRAPHQL_ADMIN_SECRET`
 
-(disponible dans [rancher](https://rancher.fabrique.social.gouv.fr/dashboard/c/c-5rj5b/explorer/secret/carnet-de-bord/hasura-sealed-secret#data), ou via l'équipe SRE)
+(disponible dans les variables d'environnement de l'application Scalingo)
 
 Lorsque suite à une mise en production, le modèle de données évolue, il est utile de vérifier que les migrations ont été appliquées. En local, lancer:
 
 ```
-hasura migrate status --endpoint https://hasura-carnet-de-bord.fabrique.social.gouv.fr --project=./hasura
+hasura migrate status --endpoint https://hasura-carnet-de-bord.fabrique.social.gouv.fr --project=./hasura
 ```
 
 qui permet de voir les migrations de la production et leur état d'application
 
 ![image](https://user-images.githubusercontent.com/160320/173358907-1d275f2d-d31c-4e0d-a7f6-dd45898bc949.png)
 
-Dans le cas d'une migration qui a échoué, on utilise [grafana](https://grafana.fabrique.social.gouv.fr/explore?orgId=1&left=%7B%22datasource%22:%22Loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bnamespace%3D%5C%22carnet-de-bord%5C%22,%20job%3D%5C%22carnet-de-bord%2Fhasura%5C%22%7D%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D) pour avoir les log du container `hasura` et déterminé la cause de l'erreur.
+Dans le cas d'une migration qui a échoué, consulter les logs sur Scalingo.
 
-Soit l'erreur est liée à des données et dans ce cas il faut corriger les données depuis le l'admin `hasura`
+Soit l'erreur est liée à des données et dans ce cas il faut corriger les données depuis l'admin `hasura`
 
 ```
-hasura console --endpoint https://hasura-carnet-de-bord.fabrique.social.gouv.fr --project=./hasura
+hasura console --endpoint https://hasura-carnet-de-bord.fabrique.social.gouv.fr --project=./hasura
 ```
 
-et relancer le container `hasura` (depuis [rancher](https://rancher.fabrique.social.gouv.fr/dashboard/c/c-5rj5b/explorer/workload) )
-
-![image](https://user-images.githubusercontent.com/160320/173360950-ed8542f3-4e01-4555-b7ea-04425fd37cda.png)
+et relancer l'application Scalingo Hasura (`cdb-hasura-production`).
 
 Soit l'erreur vient du contenu de la migration (problème SQL) et dans ce cas, il faut corriger les fichiers sources et refaire une mise en production.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ Vous devez au préalable avoir correctement installé les logiciels suivants :
 **1/** Récupérer les sources du projet
 
 ```sh
-git clone git@github.com:SocialGouv/carnet-de-bord.git
+git clone git@github.com:gip-inclusion/carnet-de-bord.git
 cd carnet-de-bord
 ```
 

--- a/app/package.json
+++ b/app/package.json
@@ -5,9 +5,9 @@
 		"node": "16"
 	},
 	"private": true,
-	"repository": "git@github.com:SocialGouv/carnet-de-bord.git",
-	"author": "Incubateur des Ministères Sociaux <dsi-incubateur@sg.social.gouv.fr> (https://incubateur.social.gouv.fr)",
-	"bugs": "https://github.com/SocialGouv/carnet-de-bord/issues",
+	"repository": "git@github.com:gip-inclusion/carnet-de-bord.git",
+	"author": "GIP Plateforme de l'inclusion (https://inclusion.beta.gouv.fr)",
+	"bugs": "https://github.com/gip-inclusion/carnet-de-bord/issues",
 	"license": "Apache-2.0",
 	"scripts": {
 		"hasura:console": "hasura console --project ../hasura",

--- a/app/src/lib/ui/base/Footer.svelte
+++ b/app/src/lib/ui/base/Footer.svelte
@@ -40,7 +40,7 @@
 				<li class="fr-footer__bottom-item">
 					<a
 						class="fr-footer__bottom-link"
-						href="https://github.com/SocialGouv/carnet-de-bord/blob/master/CHANGELOG.md"
+						href="https://github.com/gip-inclusion/carnet-de-bord/blob/master/CHANGELOG.md"
 						target="_blank"
 					>
 						Version {appVersion}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,9 +2,9 @@
 	"name": "@cdb/e2e",
 	"version": "1.0.0",
 	"description": "e2e tests for carnet-de-bord",
-	"repository": "git@github.com:SocialGouv/carnet-de-bord.git",
-	"author": "Incubateur des Ministères Sociaux <dsi-incubateur@sg.social.gouv.fr> (https://incubateur.social.gouv.fr)",
-	"bugs": "https://github.com/SocialGouv/carnet-de-bord/issues",
+	"repository": "git@github.com:gip-inclusion/carnet-de-bord.git",
+	"author": "GIP Plateforme de l'inclusion (https://inclusion.beta.gouv.fr)",
+	"bugs": "https://github.com/gip-inclusion/carnet-de-bord/issues",
 	"main": "codecept.conf.js",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/scripts/create-review-apps.sh
+++ b/scripts/create-review-apps.sh
@@ -111,8 +111,8 @@ function deploy_app() {
   #   Application: cdb-app-review-pr1194 (6356af2f623d3a0010ba5db2)
   #   Integration: GitHub (185f8b27-5abb-49f0-9d27-18add5460eb8)
   #   Linker: service-dev
-  #   Repository: SocialGouv/carnet-de-bord
-  #   Auto Deploy: ✔ SocialGouv:chore/move-back-jest-test-folder
+  #   Repository: gip-inclusion/carnet-de-bord
+  #   Auto Deploy: ✔ gip-inclusion:chore/move-back-jest-test-folder
   #   Review Apps Deploy: ✘
 
   local branch="$(scalingo -a "$app" integration-link | awk -F: '/Auto/{print $3}')"


### PR DESCRIPTION
## :wrench: Problème

Le workflow de release ne tourne plus suite au déménagement du repo dans l'organisation `gip-inclusion`.

## :cake: Solution

Le workflow `release.yml` passait à l'action `semantic-release` un token GitHub (nécessaire pour pousser le commit de release dans le repo) trouvé dans un secret nommé `SOCIALGROOVYBOT_BOTO_PAT`, or ce secret était hérité de l'organisation `SocialGouv`.

Pour débloquer la création de release dans un premier temps, nous avons créé un secret de ce même nom au niveau de ce repo, mais dans cette PR on renomme le secret `SEMANTIC_RELEASE_GITHUB_TOKEN`.

## :rotating_light:  Points d'attention / Remarques

Cette PR met également à jour les références restantes à `SocialGouv/carnet-de-bord`.

