### PR TITLE
fix: Restauration du support des scripts permettant le support par clavardage (crisp).

### DIFF
--- a/app/elm.json
+++ b/app/elm.json
@@ -1,30 +1,28 @@
 {
-    "type": "application",
-    "source-directories": [
-        "elm"
-    ],
-    "elm-version": "0.19.1",
-    "dependencies": {
-        "direct": {
-            "elm/browser": "1.0.2",
-            "elm/core": "1.0.5",
-            "elm/html": "1.0.0",
-            "elm/http": "2.0.0",
-            "elm/json": "1.1.3",
-            "elm-community/json-extra": "4.3.0"
-        },
-        "indirect": {
-            "elm/bytes": "1.0.8",
-            "elm/file": "1.0.5",
-            "elm/parser": "1.1.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.3",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
-        }
-    },
-    "test-dependencies": {
-        "direct": {},
-        "indirect": {}
-    }
+	"type": "application",
+	"source-directories": ["elm"],
+	"elm-version": "0.19.1",
+	"dependencies": {
+		"direct": {
+			"elm/browser": "1.0.2",
+			"elm/core": "1.0.5",
+			"elm/html": "1.0.0",
+			"elm/http": "2.0.0",
+			"elm/json": "1.1.3",
+			"elm-community/json-extra": "4.3.0"
+		},
+		"indirect": {
+			"elm/bytes": "1.0.8",
+			"elm/file": "1.0.5",
+			"elm/parser": "1.1.0",
+			"elm/time": "1.0.0",
+			"elm/url": "1.0.0",
+			"elm/virtual-dom": "1.0.3",
+			"rtfeldman/elm-iso8601-date-strings": "1.1.4"
+		}
+	},
+	"test-dependencies": {
+		"direct": {},
+		"indirect": {}
+	}
 }

--- a/app/svelte.config.js
+++ b/app/svelte.config.js
@@ -2,6 +2,8 @@ import preprocess from 'svelte-preprocess';
 import adapter from '@sveltejs/adapter-node';
 import { resolve } from 'path';
 
+const defaultSrc = ['self', '*.fabrique.social.gouv.fr', '*.crisp.chat'];
+
 const config = {
 	kit: {
 		env: {
@@ -10,11 +12,12 @@ const config = {
 		csp: {
 			mode: 'auto',
 			directives: {
-				'default-src': ['self', '*.fabrique.social.gouv.fr', '*.crisp.chat'],
+				'default-src': defaultSrc,
 				'font-src': ['self', 'data:', 'blob:', '*.crisp.chat'],
 				'img-src': ['self', 'data:', '*.fabrique.social.gouv.fr', '*.crisp.chat'],
 				'style-src': ['self', '*.crisp.chat', 'unsafe-inline'],
-				'script-src': [process.env.NODE_ENV === 'production' ? '' : 'unsafe-eval'],
+				'script-src':
+					process.env.NODE_ENV === 'production' ? defaultSrc : [...defaultSrc, 'unsafe-eval'],
 				'connect-src': [
 					'self',
 					'wss:',


### PR DESCRIPTION
## :wrench: Problème

Le support par clavardage n'est plus opérationnel sur l'environnement de préproduction.

## :cake: Solution

Avant on n'avait pas de `script-src` donc on retombait sur `default-src` qui autorise bien ``*.crisp.chat`.
Avec la PR sur le tooling ELM, on a désormais un `script-src` vide en production (et juste `unsafe-eval` en dev) et donc crisp.chat ne se charge plus.

Dans la configuration `svelte`, on autorise les scripts dont l'origine est une valeur comprise parmis celles autorisées pour le `default-src`.

## :rotating_light:  Points d'attention / Remarques

On profite de la PR pour passer prettier sur le fichier `elm.json`.

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1213.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

Vérifier que le support par clavardage est opérationnel.

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->

## 🛎️ Résultat

![QuickTime movie](https://user-images.githubusercontent.com/2989532/199120228-8016f0a0-b89e-4824-bfd4-05f22bae5777.gif)
