### PR TITLE
feat: Préciser l'action attendue dans le mail de notification de demande de création de compte

### DIFF
--- a/app/src/lib/emailing/emails.ts
+++ b/app/src/lib/emailing/emails.ts
@@ -136,6 +136,7 @@ export function accountRequest({
 		  ${pro.mobileNumber && `<li>téléphone: ${pro.mobileNumber}</li>`}
 		  ${pro.position && `<li>position: ${pro.position}</li>`}
     ${requester ? `<p>Cette demande a été soumise par ${displayFullName(requester)}.</p>` : ''}
+    <p>Vous recevez ce message parce que vous êtes manager de ce déploiement. Veuillez vous connecter à Carnet de bord pour confirmer cette inscription.</p>
     ${createAccessButton(url)}
     ${footer()}
   `;

--- a/app/src/routes/(public)/inscription/+page.svelte
+++ b/app/src/routes/(public)/inscription/+page.svelte
@@ -55,8 +55,8 @@
 			<h1>Demande d'inscription envoyée</h1>
 			<p>Nous avons bien pris en compte votre demande de nouvelle inscription.</p>
 			<p>
-				Vous recevrez un courriel de confirmation, avec un lien pour vous connecter au Carnet de
-				bord.
+				Si votre inscription est validée, vous recevrez un courriel de confirmation, avec un lien
+				pour vous connecter à Carnet de bord.
 			</p>
 		</div>
 	{/if}


### PR DESCRIPTION
## :wrench: Problème

Voir #1215 :
> La https://github.com/gip-inclusion/carnet-de-bord/issues/814 a permis de mieux identifier d'où provient la demande de création de compte reçue par le manager d'un territoire. Néanmoins, ce mail continue de faire naître des incompréhensions / de la confusion chez les manager car l'action qui est attendue d'eux n'est pas claire.

## :cake: Solution

On enrichit le texte du courriel pour préciser pourquoi ce courriel est reçu et quelle est l'action attendue :

>  <img width="858" alt="image" src="https://user-images.githubusercontent.com/300823/199542646-f9bc3838-b3ca-4645-aadb-590b5cc823b0.png">

## :rotating_light:  Points d'attention / Remarques

Le message de confirmation affiché à la personne qui demande son inscription a aussi été enrichi pour préciser qu'un courriel de confirmation ne sera reçu que si sa demande est validée.

> <img width="1028" alt="image" src="https://user-images.githubusercontent.com/300823/199523153-2adcb7e4-8182-4ff2-9180-757bb1733203.png">


## :desert_island: Comment tester

Visiter la _review app_, faire une demande d'inscription, observer le message de confirmation et le courriel reçu (dans [mailtrap](https://mailtrap.io/inboxes/1830891/messages)) par l'Admin PDI.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1217.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

Fix #1215 .
