### PR TITLE
feat: add nir to validation report during beneficiary import

### DIFF
--- a/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
+++ b/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
@@ -221,6 +221,7 @@
 		{ label: 'Prénom*', key: 'firstname' },
 		{ label: 'Nom*', key: 'lastname' },
 		{ label: 'Date de naissance*', key: 'dateOfBirth' },
+		{ label: 'NIR', key: 'nir' },
 		{ label: 'Lieu de naissance', key: 'placeOfBirth' },
 		{ label: 'Téléphone', key: 'phoneNumber' },
 		{ label: 'Courriel', key: 'email' },


### PR DESCRIPTION
## :wrench: Problème

Le NIR n'apparait pas dans les données validées lors de l'import bénéficiaire.

## :cake: Solution

Ajout d'une ligne NIR dans l'écran de validation.

## :rotating_light:  Points d'attention / Remarques

> _Précisez si il y a des cas particuliers ou des sujets connexes à partager ?_

## :desert_island: Comment tester

Lors de l'import bénéficiaire du département, le NIR apparait dans les données validées avant de confirmer l'import.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1218.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
