### PR TITLE
fix: redirection après connexion

### DIFF
--- a/app/src/routes/auth/+layout.svelte
+++ b/app/src/routes/auth/+layout.svelte
@@ -1,59 +1,13 @@
 <script lang="ts">
 	import Footer from '$lib/ui/base/Footer.svelte';
 	import Header from '$lib/ui/base/Header.svelte';
-
-	import { Video } from '$lib/ui/base';
-
-	const videoOptions = {
-		sources: [
-			/**
-			 * Video with neither subtitles nor voiceover
-			 * {
-			 *   url: 'https://nextcloud.fabrique.social.gouv.fr/s/TtM2A7KkD55MqZ3/download/intro-cdb.mp4',
-			 *   type: 'video/mp4',
-			 * },
-			 */
-
-			/**
-			 * Video with voiceover
-			 */
-			{
-				url: 'https://nextcloud.fabrique.social.gouv.fr/s/KjFZxq4CFE76fyD/download/intro-cdb-voiceover.mp4',
-				type: 'video/mp4',
-			},
-
-			/**
-			 * Video with embedded subtitles
-			 * {
-			 *   url: 'https://nextcloud.fabrique.social.gouv.fr/s/Nx3wbt6LTMrNqGE/download/intro-cdb-with-subs.mp4',
-			 *   type: 'video/mp4',
-			 * },
-			 */
-		],
-		tracks: [
-			{
-				url: '/videos/intro-cdb.websrt',
-				label: 'Français',
-				lang: 'fr',
-			},
-		],
-		title: 'Découvrez Carnet de bord en vidéo !',
-		preload: 'none',
-		hideControls: true,
-		poster: '/videos/intro-cdb.png',
-	};
 </script>
 
 <Header menuItems={[]} />
 
 <div class="fr-container" style="min-height: calc(100vh - 142.5px)">
 	<div class="flex flex-row">
-		<div class="w-1/2 py-20 pr-10">
-			<Video {...videoOptions} />
-		</div>
-		<div class="w-1/2 py-20 pl-10">
-			<slot />
-		</div>
+		<slot />
 	</div>
 </div>
 

--- a/app/src/routes/auth/jwt/[uuid]/+error.svelte
+++ b/app/src/routes/auth/jwt/[uuid]/+error.svelte
@@ -6,7 +6,7 @@
 	<title>Validation du token de connexion - Carnet de bord</title>
 </svelte:head>
 
-<div class="pt-28 flex flex-col items-center">
+<div class="pt-28 flex flex-col grow items-center">
 	<p class="pb-12 text-xl">Désolé, ce lien n'est plus valide...</p>
 	<Link classNames="fr-btn" href="/auth/login">Accéder à la page de connexion</Link>
 </div>

--- a/app/src/routes/auth/jwt/[uuid]/+page.server.ts
+++ b/app/src/routes/auth/jwt/[uuid]/+page.server.ts
@@ -1,4 +1,4 @@
-import { error, redirect } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import { createJwt } from '$lib/utils/getJwt';
 
 import { createClient } from '@urql/core';
@@ -85,7 +85,9 @@ export const load: PageServerLoad = async ({ url, params, cookies, setHeaders })
 		.mutation(ResetAccountAccessKeyDocument, { id, now: new Date().toISOString() })
 		.toPromise();
 
-	cookies.set('jwt', token, { path: '/', httpOnly: true, secure: true, sameSite: 'strict' });
+	cookies.set('jwt', token, { path: '/', httpOnly: true, /* secure: true, */ sameSite: 'strict' });
+
 	setHeaders({ 'Cache-Control': 'private' });
-	throw redirect(302, redirectAfterLogin ?? '/');
+
+	return { redirectAfterLogin };
 };

--- a/app/src/routes/auth/jwt/[uuid]/+page.svelte
+++ b/app/src/routes/auth/jwt/[uuid]/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	import type { PageServerData } from './$types';
+	export let data: PageServerData;
+
+	onMount(() => {
+		window.location.replace(data.redirectAfterLogin ?? '/');
+	});
+</script>
+
+<div class="pt-28 flex flex-col grow items-center">
+	<p class="pb-12 text-xl">Chargement en cours…</p>
+</div>

--- a/app/src/routes/auth/login/+layout.svelte
+++ b/app/src/routes/auth/login/+layout.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { Video } from '$lib/ui/base';
+
+	const videoOptions = {
+		sources: [
+			/**
+			 * Video with neither subtitles nor voiceover
+			 * {
+			 *   url: 'https://nextcloud.fabrique.social.gouv.fr/s/TtM2A7KkD55MqZ3/download/intro-cdb.mp4',
+			 *   type: 'video/mp4',
+			 * },
+			 */
+
+			/**
+			 * Video with voiceover
+			 */
+			{
+				url: 'https://nextcloud.fabrique.social.gouv.fr/s/KjFZxq4CFE76fyD/download/intro-cdb-voiceover.mp4',
+				type: 'video/mp4',
+			},
+
+			/**
+			 * Video with embedded subtitles
+			 * {
+			 *   url: 'https://nextcloud.fabrique.social.gouv.fr/s/Nx3wbt6LTMrNqGE/download/intro-cdb-with-subs.mp4',
+			 *   type: 'video/mp4',
+			 * },
+			 */
+		],
+		tracks: [
+			{
+				url: '/videos/intro-cdb.websrt',
+				label: 'Français',
+				lang: 'fr',
+			},
+		],
+		title: 'Découvrez Carnet de bord en vidéo !',
+		preload: 'none',
+		hideControls: true,
+		poster: '/videos/intro-cdb.png',
+	};
+</script>
+
+<div class="w-1/2 py-20 pr-10">
+	<Video {...videoOptions} />
+</div>
+<div class="w-1/2 py-20 pl-10">
+	<slot />
+</div>

--- a/app/src/routes/auth/logout/+server.ts
+++ b/app/src/routes/auth/logout/+server.ts
@@ -1,6 +1,6 @@
 import { redirect, type RequestHandler } from '@sveltejs/kit';
 
-export const GET: RequestHandler = (event) => {
-	event.cookies.set('jwt', '', { path: '/', expires: new Date() });
+export const GET: RequestHandler = ({ cookies }) => {
+	cookies.set('jwt', '', { path: '/', expires: new Date() });
 	throw redirect(302, '/');
 };

--- a/scripts/launch_tests.sh
+++ b/scripts/launch_tests.sh
@@ -104,7 +104,11 @@ function start_svelte() {
   # Need to listen on all addresses (0.0.0.0) to be reachable from Hasura in Docker on all platforms.
   # Piping through "cat" to disable annoying terminal control codes from svelte-kit that mess up the
   # output.
-  npm run dev --prefix app -- --port 3001 | cat &
+  # npm run dev --prefix app -- --port 3001 &
+  cd app
+  npm run build
+  PORT=3001 ORIGIN=http://localhost:3001 node build &
+  cd ..
 
   until curl -s http://localhost:3001/ > /dev/null ; do
     >&2 echo "-> Svelte kit is still unavailable - sleeping"


### PR DESCRIPTION
## :wrench: Problème

Certains utilisateurs, en cliquant sur le lien de connexion reçu par courriel, ne sont pas correctement authentifiés et arrivent sur la page d'accueil non connecté.

## :cake: Solution

Après analyse, il s'avère que le cookie qui est installé par la réponse à `/auth/jwt/[uuid]` dans le cadre d'une réponse de redirection (302), n'est pas toujours immédiatement renvoyé par le navigateur lorsque celui-ci suit la redirection (peut-être une manifestation de https://bugs.chromium.org/p/chromium/issues/detail?id=696204 par exemple), en particulier quand la requête initiale est _cross-site_, ce qui est généralement le cas quand le lien a été cliqué dans un Webmail.

Pour éviter cette situation, avec cette PR on change la route `/auth/jwt/[uuid]` pour faire une réponse normale (200), et la redirection est faite dans le code JavaScript côté client.

## :rotating_light:  Points d'attention / Remarques

On a remarqué que les cookies installés par SvelteKit utilisent par défaut le flag `Secure` ce qui est bien mais quand on teste sur `http://localhost` le cookie peut être ignoré si le navigateur ne fait pas une exception pour considérer `localhost` comme "securisé". En particulier Safari ne fait pas cette exception.

En regardant de plus près, SvelteKit ne devrait pas appliquer le flag `Secure` pour les requêtes arrivant sur `http://localhost` : https://github.com/sveltejs/kit/blob/11950e00ac57919b09e6148b78004bbeb002a446/packages/kit/src/runtime/server/cookie.js#L54

Mais on a constaté qu'à cet endroit, si l'application a été construite avec `npm run build` (donc pas en utilisant le serveur de dev) alors la requête semble provenir de `https://localhost:3000`. Cela vient de la détermination d'origine faite par `adapter-node` (https://github.com/sveltejs/kit/blob/master/packages/adapter-node/README.md#origin-protocol_header-and-host_header) qui suppose par défaut que la requête a été faite en HTTPS.

On peut contourner ce comportement en ajoutant `ORIGIN=http://localhost:3000` dans l'environnement (fichier `.env`).

## :desert_island: Comment tester

Renseigner un nom d'utilisateur dans le champ login puis, allez sur mailtrap et cliquer sur le bouton de connexion. 
Vous devez tombez sur la page d'accueil de l'utilisateur 

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1225.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
fix #1224
