### PR TITLE
ci: Corriger l'étape de login dans les tests e2e

### DIFF
--- a/e2e/codecept.conf.js
+++ b/e2e/codecept.conf.js
@@ -44,24 +44,6 @@ exports.config = {
 			enabled: true,
 		},
 	},
-	// rerun is not working anymore in codecept3
-	rerun: {
-		// how many times to try to rerun all tests
-		maxReruns: 3,
-		// how many times all tests should pass
-		minSuccess: 1,
-	},
-	stepTimeout: 0,
-	stepTimeoutOverride: [
-		{
-			pattern: 'wait.*',
-			timeout: 0,
-		},
-		{
-			pattern: 'amOnPage',
-			timeout: 0,
-		},
-	],
 	teardown: null,
 	tests: './__tests__/*.ts',
 	timeout: null,

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -18,10 +18,19 @@ Soit("un utilisateur sur la page d'accueil", () => {
 	I.amOnPage('/');
 });
 
+// This function is similar to the I.amOnPage step, except that it does not
+// try to collect page load timings, which can cause the step to fail if
+// the page automatically navigates away from the requested URL.
+function plainGoto(url) {
+	return I.usePlaywrightTo('go to URL', async ({ page, options }) => {
+		await page.goto(`${options.url}${url}`);
+	});
+}
+
 Soit("un {string} authentifié avec l'email {string}", async (userType, email) => {
 	await onBoardingSetup(userType, email, true);
 	const uuid = await loginStub(userType, email);
-	I.amOnPage(`/auth/jwt/${uuid}`);
+	plainGoto(`/auth/jwt/${uuid}`);
 });
 
 Soit(
@@ -29,7 +38,7 @@ Soit(
 	async (userType, email) => {
 		await onBoardingSetup(userType, email, false);
 		const uuid = await loginStub(userType, email);
-		I.amOnPage(`/auth/jwt/${uuid}`);
+		plainGoto(`/auth/jwt/${uuid}`);
 	}
 );
 
@@ -39,13 +48,13 @@ Soit('un utilisateur sur la page {string}', (page) => {
 
 Soit('le pro {string} qui a cliqué sur le lien de connexion', async (email) => {
 	const uuid = await loginStub('pro', email);
-	I.amOnPage(`/auth/jwt/${uuid}`);
+	plainGoto(`/auth/jwt/${uuid}`);
 });
 
 Soit('le pro {string} sur le carnet de {string}', async (email, lastname) => {
 	const uuid = await loginStub('pro', email);
 	const notebookId = await goToNotebookForLastName(lastname);
-	I.amOnPage(`/auth/jwt/${uuid}?url=/pro/carnet/${notebookId}`);
+	plainGoto(`/auth/jwt/${uuid}?url=/pro/carnet/${notebookId}`);
 });
 
 Soit(
@@ -55,7 +64,7 @@ Soit(
 		const uuid = await loginStub("chargé d'orientation", email);
 		const notebookId = await goToNotebookForLastName(lastname);
 		await addMember(email, notebookId);
-		I.amOnPage(`/auth/jwt/${uuid}?url=/orientation/carnets/edition/${notebookId}`);
+		plainGoto(`/auth/jwt/${uuid}?url=/orientation/carnets/edition/${notebookId}`);
 	}
 );
 
@@ -63,7 +72,7 @@ Soit("le chargé d'orientation {string} sur le carnet de {string}", async (email
 	await onBoardingSetup("chargé d'orientation", email, true);
 	const uuid = await loginStub("chargé d'orientation", email);
 	const notebookId = await goToNotebookForLastName(lastname);
-	I.amOnPage(`/auth/jwt/${uuid}?url=/orientation/carnets/${notebookId}`);
+	plainGoto(`/auth/jwt/${uuid}?url=/orientation/carnets/${notebookId}`);
 });
 
 //

--- a/scripts/launch_tests.sh
+++ b/scripts/launch_tests.sh
@@ -93,9 +93,7 @@ done
 >&2 echo ""
 >&2 echo "-> Hasura is up and running on port 5001!"
 
-cd hasura
-HASURA_GRAPHQL_ENDPOINT=http://localhost:5001 hasura seed apply --database-name carnet_de_bord
-cd $ROOT_DIR
+HASURA_GRAPHQL_ENDPOINT=http://localhost:5001 hasura --project hasura seed apply --database-name carnet_de_bord
 
 function start_svelte() {
   >&2 echo "-> Starting Svelte kit"


### PR DESCRIPTION
## :wrench: Problème

Depuis la mise à jour Svelte, les tests end-to-end (CodeceptJS) sont instables.

On constate que CodeceptJS retente parfois la navigation vers la page `/auth/jwt/[uuid]`, or le code fourni dans cette URL ne peut être utilisé qu'une seule fois, ce qui fait échouer le test.

Après analyse il s'avère que l'échec de l'étape `I.amOnPage` est causé par une tentative d'exécuter un script dans la page après navigation pour collecter des statistiques de performances : https://github.com/codeceptjs/CodeceptJS/blob/37d1dc47029aea8294eef161b75a7e8f2f49d4a1/lib/helper/Playwright.js#L822

Cette exécution échoue quand elle intervient après la navigation déclenchée automatiquement par la page `/auth/jwt/[uuid]` depuis #1225.

## :cake: Solution

On évite d'utiliser `I.amOnPage` pour cette navigation, en utilisant directement l'API Playwright.

## :rotating_light:  Points d'attention / Remarques

Cette ligne de commande a bien aidé à diagnostiquer l'interaction entre CodeceptJS et Playwright :

```bash
DEBUG='codecept:* pw:api' ./scripts/launch_tests.sh e2e --debug --steps --verbose --bail
```

## :desert_island: Comment tester

Observer le résultat de l'exécution des tests en CI. En local, lancer `scripts/launch_tests.sh`.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1233.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
