### PR TITLE
ci: création d'une release à chaque merge sur master

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,9 @@
 plugins:
-  - "@semantic-release/commit-analyzer"
+  - - "@semantic-release/commit-analyzer"
+    - releaseRules:
+      - type: feat
+        release: minor
+      - release: patch
   - "@semantic-release/release-notes-generator"
   - "@semantic-release/changelog"
 # bump frontend version (package.json)


### PR DESCRIPTION
## :wrench: Problème

Les règles de création de release actuellement appliquées par `semantic-release` ne déclenchent pas la création de release quand on intègre des changements qui ne sont pas marqués `fix` ou `feat`. Par conséquent, ces changements ne sont pas automatiquement déployés en pré-production, alors qu'ils peuvent souvent avoir un intérêt à être testés puis déployés en production.

Bien sûr, en théorie un changement qui n'est pas censé avoir d'impact visible sur le produit (donc qui n'est pas marqué `feat` ni `fix`) n'a pas besoin d'être déployé indépendamment, mais dans la pratique on constate souvent que ce qui est pour l'essentiel un _refactoring_ dans l'intention, intègre des impacts mineurs comme des corrections de fautes de frappe, etc.

## :cake: Solution

On modifie les règles de création de release (cf. https://github.com/semantic-release/commit-analyzer#releaserules) pour déclencher :
 - une release de type `minor` (1.x.0) pour chaque commit sur `master` marqué `feat`;
 - une release de type `patch` (1.1.x) pour tout autre commit sur `master`.

## :rotating_light:  Points d'attention / Remarques

On s'attend à une légère augmentation du nombre de releases créées, mais au vu de l'historique de `master` ça ne devrait pas être démesuré.

## :desert_island: Comment tester

Le comportement a été vérifié sur un _fork_ de ce repo (https://github.com/ut7/carnet-de-bord).

En principe, l'intégration de cette PR (marquée `ci`) devrait donner lieu à la création d'une release.
