### PR TITLE
fix: allow partial-re-import

### DIFF
--- a/backend/api/db/models/validator.py
+++ b/backend/api/db/models/validator.py
@@ -87,7 +87,7 @@ def is_bool(value):
     elif type(value) == bool:
         return value
     else:
-        return False
+        return None
 
 
 def is_bool_validator(*args, **kwargs):

--- a/backend/api/v1/routers/beneficiaries.py
+++ b/backend/api/v1/routers/beneficiaries.py
@@ -72,6 +72,11 @@ async def import_beneficiary(
             records: list[Beneficiary] = await get_beneficiaries_like(
                 db, beneficiary, deployment_id
             )
+            # todo:
+            # handle None Value for insert / update
+            # If a None value is provided, do not update the cell
+            # Get the list of cells where value is not None
+            # build the update / insert request accordingly
 
             if no_matching_beneficiary(records):
                 beneficiary_id = await create_beneficiary_with_notebook_and_referent(


### PR DESCRIPTION
## :wrench: Problème

Actuellement, on peut créer des carnets sur la base d'un import de fichier partiel, c'est à dire qui ne contient qu'une partie des champs supportés en plus des champs obligatoire (nom / prénom / date de naissance / id_interne)
Or depuis que l'on supporte le ré-import, ré-importer un fichier partiel écrase les données existante en mettant les champs à null pour chaque colonne manquante

## :cake: Solution

Pour le réimport, permettre de supporter le ré-import partiel. c'est à dire ne modifier que les colonnes présentes dans le fichier


## :rotating_light:  Points d'attention / Remarques

Cela pourrait poser problème si l'on souhaite remettre des colonnes à `NULL`

## :desert_island: Comment tester

Ré-importer le fichier suivant 
[import_beneficiaires_partial.csv](https://github.com/gip-inclusion/carnet-de-bord/files/10035569/import_beneficiaires_partial.csv)
Aucune données du carnet de sophie tifour ne devrait etre perdue.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1265.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


fix #1264
