### PR TITLE
fix: Ré-import partiel de bénéficiaires

### DIFF
--- a/app/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/app/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -22,15 +22,17 @@
 
 <div class="flex flex-col space-y-6">
 	<div class="flex flex-row flex-wrap">
-		{#if notebook.workSituationDate && notebook.workSituation}
+		{#if notebook.workSituation}
 			<div class="w-1/2">
 				<strong>{workSituationKeys.byKey[notebook.workSituation]}</strong>
-				{contractDatesTemplating(notebook.workSituationDate, notebook.workSituationEndDate)}
-				{#if notebook.workSituationEndDate}
-					-
-					<span class="italic font-bold">
-						({dateInterval(notebook.workSituationDate, notebook.workSituationEndDate)})
-					</span>
+				{#if notebook.workSituationDate}
+					{contractDatesTemplating(notebook.workSituationDate, notebook.workSituationEndDate)}
+					{#if notebook.workSituationEndDate}
+						-
+						<span class="italic font-bold">
+							({dateInterval(notebook.workSituationDate, notebook.workSituationEndDate)})
+						</span>
+					{/if}
 				{/if}
 			</div>
 		{/if}

--- a/app/src/lib/ui/BeneficiaryList/AddOrientationForm.svelte
+++ b/app/src/lib/ui/BeneficiaryList/AddOrientationForm.svelte
@@ -47,7 +47,7 @@
 		);
 		if (updateResponse.error) {
 			error = true;
-			console.log(updateResponse.error);
+			console.error(updateResponse.error);
 			return;
 		}
 		if (onClose) onClose();

--- a/app/src/lib/ui/BeneficiaryList/AddOrientationManagerForm.svelte
+++ b/app/src/lib/ui/BeneficiaryList/AddOrientationManagerForm.svelte
@@ -50,7 +50,7 @@
 		);
 		if (updateResponse.error) {
 			error = true;
-			console.log(updateResponse.error);
+			console.error(updateResponse.error);
 			return;
 		}
 		if (onClose) onClose();

--- a/app/src/lib/ui/BeneficiaryList/AddProfessionnalForm.svelte
+++ b/app/src/lib/ui/BeneficiaryList/AddProfessionnalForm.svelte
@@ -47,7 +47,7 @@
 			});
 			if (deleteResponse.error) {
 				error = true;
-				console.log(deleteResponse.error);
+				console.error(deleteResponse.error);
 				return;
 			}
 		}
@@ -65,7 +65,7 @@
 		);
 		if (updateResponse.error) {
 			error = true;
-			console.log(updateResponse.error);
+			console.error(updateResponse.error);
 			return;
 		}
 		if (onClose) onClose();

--- a/app/src/lib/ui/BeneficiaryList/AddStructureProfessionnalForm.svelte
+++ b/app/src/lib/ui/BeneficiaryList/AddStructureProfessionnalForm.svelte
@@ -55,7 +55,7 @@
 			});
 			if (deleteResponse.error) {
 				error = true;
-				console.log(deleteResponse.error);
+				console.error(deleteResponse.error);
 				return;
 			}
 		}
@@ -81,7 +81,7 @@
 		);
 		if (updateResponse.error) {
 			error = true;
-			console.log(updateResponse.error);
+			console.error(updateResponse.error);
 			return;
 		}
 		if (onClose) onClose();

--- a/app/src/lib/ui/BeneficiaryList/FilterOrientation.svelte
+++ b/app/src/lib/ui/BeneficiaryList/FilterOrientation.svelte
@@ -29,7 +29,6 @@
 		});
 	}
 	function updateFilters() {
-		console.log(withoutOrientationManager);
 		dispatch('filter-update', {
 			orientationStatusFilter,
 			withoutOrientationManager,

--- a/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
+++ b/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
@@ -179,7 +179,7 @@
 		{ label: 'Droits ARE', key: 'Droits ARE', mandatory: false },
 		{ label: 'Droits ASS', key: 'Droits ASS', mandatory: false },
 		{ label: "Prime d'activité", key: "Prime d'activité", mandatory: false },
-		{ label: 'RQTH', key: 'Droits RQTH', mandatory: false },
+		{ label: 'RQTH', key: 'RQTH', mandatory: false },
 		{ label: 'Zone de mobilité', key: 'Zone de mobilité', mandatory: false },
 		{
 			label: 'Emplois recherchés (texte + code ROME)',
@@ -195,6 +195,13 @@
 		beneficiariesToImport = [];
 		parsePromise = undefined;
 		insertPromise = undefined;
+	}
+
+	function displayBoolean(value: unknown): string | null {
+		console.log(value);
+		if (typeof value === 'boolean') {
+			return value ? 'Oui' : 'Non';
+		}
 	}
 </script>
 
@@ -302,8 +309,8 @@
 											{#if beneficiary.valid}
 												{#if key === 'Date de naissance*'}
 													<Text value={formatDateLocale(beneficiary.data[key])} defaultValue="" />
-												{:else if ["Prime d'activité", 'Droits ARE', 'Droits ASS', 'Droits RQTH'].includes(key)}
-													<Text value={beneficiary.data[key] ? 'Oui' : 'Non'} defaultValue="" />
+												{:else if ["Prime d'activité", 'Droits ARE', 'Droits ASS', 'RQTH'].includes(key)}
+													<Text value={displayBoolean(beneficiary.data[key])} defaultValue="" />
 												{:else}
 													<Text value={beneficiary.data[key]} defaultValue="" />
 												{/if}

--- a/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
+++ b/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
@@ -15,7 +15,7 @@
 	import { GroupCheckbox as Checkbox } from '$lib/ui/base';
 	import { Text } from '$lib/ui/utils';
 	import { Alert, Button } from '$lib/ui/base';
-	import { displayFullName } from '$lib/ui/format';
+	import { displayBoolean, displayFullName } from '$lib/ui/format';
 	import { pluralize } from '$lib/helpers';
 	import { formatDateLocale } from '$lib/utils/date';
 	import { v4 as uuidv4 } from 'uuid';
@@ -195,13 +195,6 @@
 		beneficiariesToImport = [];
 		parsePromise = undefined;
 		insertPromise = undefined;
-	}
-
-	function displayBoolean(value: unknown): string | null {
-		console.log(value);
-		if (typeof value === 'boolean') {
-			return value ? 'Oui' : 'Non';
-		}
 	}
 </script>
 

--- a/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
+++ b/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
@@ -390,7 +390,6 @@
 					beneficiariesToImport.length
 				)} en cours...`}
 			/>
-			/>
 		{:then insertResults}
 			{@const nbBeneficiaryError = insertResults.filter(({ valid }) => !valid).length}
 			{@const nbBeneficiaryInserted = insertResults.filter(

--- a/app/src/lib/ui/Manager/errorMessage.ts
+++ b/app/src/lib/ui/Manager/errorMessage.ts
@@ -35,6 +35,9 @@ export function translateError(error = ''): string {
 	if (/value unknown/i.test(error)) {
 		return 'Valeur non supportée';
 	}
+	if (/allowed value/i.test(error)) {
+		return 'Valeur non supportée';
+	}
 	console.error('unhandle import error message', error);
 	return `Une erreur s'est produite lors de la lecture du fichier.`;
 }

--- a/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusCreate.svelte
+++ b/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusCreate.svelte
@@ -46,7 +46,7 @@
 			linkedTo: formData.linkedTo,
 		});
 		if (store.error) {
-			console.log('createFocus error', {
+			console.error('createFocus error', {
 				error: store.error,
 				creatorId: $connectedUser.id,
 			});

--- a/app/src/lib/ui/ProNotebookMember/ProAppointment.svelte
+++ b/app/src/lib/ui/ProNotebookMember/ProAppointment.svelte
@@ -128,8 +128,6 @@
 
 	function showDeleteButton(index: number) {
 		const appointment = appointments[index];
-		console.log({ index });
-		console.log({ appointment: JSON.stringify(appointment) });
 		return appointment.id;
 	}
 

--- a/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProROME.svelte
+++ b/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProROME.svelte
@@ -42,7 +42,7 @@
 				return data.search_rome_codes;
 			})
 			.catch((error) => {
-				console.log('Error fetching ROME codes', { error, search });
+				console.error('Error fetching ROME codes', { error, search });
 				return [];
 			});
 </script>

--- a/app/src/lib/ui/format.ts
+++ b/app/src/lib/ui/format.ts
@@ -40,3 +40,10 @@ export const displayFullAddress = ({
 		[address1, address2].filter((field) => notNullish(field)).join(', '),
 		[postalCode, city].join(' - '),
 	].join(' - ');
+
+export function displayBoolean(value: unknown): string | null {
+	if (typeof value === 'boolean') {
+		return value ? 'Oui' : 'Non';
+	}
+	return null;
+}

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -3,19 +3,6 @@
 	import Header from '$lib/ui/base/Header.svelte';
 
 	import { Link } from '$lib/ui/base';
-
-	//import { Elm } from '../../elm/MainApp/Main.elm';
-
-	//import { onMount } from 'svelte';
-
-	//let node;
-	//onMount(() => {
-	//	let app = Elm.MainApp.Main.init({ node, flags: null });
-	//	app.ports.sendMessage.subscribe(function (message) {
-	//		console.log('Received from Elm: ' + message);
-	//		app.ports.messageReceiver.send('Msg from Svelte');
-	//	});
-	//});
 </script>
 
 <svelte:head>

--- a/backend/api/db/crud/account.py
+++ b/backend/api/db/crud/account.py
@@ -113,7 +113,7 @@ async def get_accounts_from_email(
     connection: Connection, email: str
 ) -> List[AccountDB]:
     """
-    Since email are store in different tables (manager / professionnal / orientation_manager)
+    Since email are store in different tables (manager / professional / orientation_manager)
     And since there is no unicity constraint accross multiple table
     we could have multiple results given a single email (ex: one for pro and one for orientation_manager)
     """

--- a/backend/api/db/crud/notebook.py
+++ b/backend/api/db/crud/notebook.py
@@ -582,38 +582,18 @@ async def insert_notebook(
     beneficiary: BeneficiaryImport,
 ) -> UUID | None:
 
-    INSERTABLE_VALUE = [
-        "right_rsa",
-        "right_rqth",
-        "right_are",
-        "right_ass",
-        "right_bonus",
-        "work_situation",
-        "education_level",
-        "geographical_area",
-    ]
-
-    fields_to_insert = [
-        (fieldname, value)
-        for (fieldname, value) in beneficiary.dict().items()
-        if value is not None and fieldname in INSERTABLE_VALUE
-    ]
-    fields_to_insert.append(("beneficiary_id", beneficiary_id))
-
-    sql_fields: list[str] = [key for (key, _) in fields_to_insert]
-    sql_values: list[str] = [value for (_, value) in fields_to_insert]
-
-    created_notebook: Record | None = await connection.fetchrow(
-        f"""
-INSERT INTO public.notebook (
-
-    {", ".join(sql_fields)}
-    )
-VALUES (  {", ".join([f"${x+1}" for x in range(len(sql_fields))])})
-returning id
-        """,
-        *sql_values,
-    )
+    keys_to_insert = beneficiary.get_notebook_editable_keys()
+    sql_values = beneficiary.get_values_for_keys(keys_to_insert)
+    # manually add beneficiary_id and its value for insert request
+    # since we do not want to add it to editable_fields
+    keys_to_insert.append("beneficiary_id")
+    sql_values.append(beneficiary_id)
+    sql = f"""
+        INSERT INTO public.notebook ({", ".join(keys_to_insert)})
+        VALUES ({", ".join([f"${x+1}" for x in range(len(keys_to_insert))])})
+            returning id
+"""
+    created_notebook: Record | None = await connection.fetchrow(sql, *sql_values)
 
     if created_notebook:
         return created_notebook["id"]
@@ -621,40 +601,29 @@ returning id
 
 async def update_notebook(
     connection: Connection,
+    beneficiary: BeneficiaryImport,
     beneficiary_id: UUID,
-    fields: list[tuple[str, str]],
 ) -> UUID | None:
 
-    ALLOWED_FIELDS_UPDATE = [
-        "right_rsa",
-        "right_rqth",
-        "right_are",
-        "right_ass",
-        "right_bonus",
-        "work_situation",
-        "education_level",
-        "geographical_area",
-    ]
+    keys_to_update = beneficiary.get_notebook_editable_keys()
 
-    fields_to_update = [
-        (key, value) for (key, value) in fields if key in ALLOWED_FIELDS_UPDATE
-    ]
-
-    if len(fields_to_update) == 0:
-        logger.info("trying to udpate notebook but no fields where updated.")
+    if len(keys_to_update) == 0:
+        logger.info("trying to update notebook but no fields where updated.")
         return None
 
-    sql_fields: list[str] = [
-        f"{key} = ${index+2}" for (index, (key, _)) in enumerate(fields_to_update)
-    ]
-    sql_values: list[str] = [value for (_, value) in fields_to_update]
+    sql_fields = [f"{key} = ${index+2}" for (index, key) in enumerate(keys_to_update)]
+
     sql = f"""
-            UPDATE notebook
-                SET {", ".join(sql_fields)}
-                WHERE beneficiary_id=$1
-                returning id
-        """
-    result = await connection.fetchrow(sql, beneficiary_id, *sql_values)
+        UPDATE notebook
+        SET {", ".join(sql_fields)}
+        WHERE beneficiary_id=$1
+            returning id
+"""
+    result = await connection.fetchrow(
+        sql,
+        beneficiary_id,
+        *beneficiary.get_values_for_keys(keys_to_update),
+    )
 
     if result:
         return result["id"]

--- a/backend/api/db/models/beneficiary.py
+++ b/backend/api/db/models/beneficiary.py
@@ -60,12 +60,12 @@ def is_same_name(firstname1, firstname2, lastname1, lastname2):
 
 
 class BeneficiaryImport(BaseModel):
-    si_id: str = Field(..., alias="Identifiant dans le SI*")
+    internal_id: str = Field(..., alias="Identifiant dans le SI*")
     firstname: str = Field(..., alias="Prénom*")
     lastname: str = Field(..., alias="Nom*")
     date_of_birth: date = Field(..., alias="Date de naissance*")
     place_of_birth: str | None = Field(None, alias="Lieu de naissance")
-    phone_number: str | None = Field(None, alias="Téléphone")
+    mobile_number: str | None = Field(None, alias="Téléphone")
     email: EmailStr | None = Field(None, alias="Email")
     address1: str | None = Field(None, alias="Adresse")
     address2: str | None = Field(None, alias="Adresse (complément)")
@@ -92,7 +92,7 @@ class BeneficiaryImport(BaseModel):
         anystr_strip_whitespace = True
         allow_population_by_field_name = True
 
-    _phone_validator = phone_validator("phone_number")
+    _phone_validator = phone_validator("mobile_number")
     _postal_code_validator = postal_code_validator("postal_code")
     _is_bool_validator = is_bool_validator(
         "right_are", "right_ass", "right_bonus", "right_rqth", pre=True

--- a/backend/api/db/models/beneficiary.py
+++ b/backend/api/db/models/beneficiary.py
@@ -78,7 +78,7 @@ class BeneficiaryImport(BaseModel):
     right_are: bool | None = Field(None, alias="Droits ARE")
     right_ass: bool | None = Field(None, alias="Droits ASS")
     right_bonus: bool | None = Field(None, alias="Prime d'activité")
-    right_rqth: bool | None = Field(None, alias="Droits RQTH")
+    right_rqth: bool | None = Field(None, alias="RQTH")
     geographical_area: str | None = Field(None, alias="Zone de mobilité")
     rome_code_description: str | None = Field(
         None, alias="Emploi recherché (code ROME)"

--- a/backend/api/db/models/validator.py
+++ b/backend/api/db/models/validator.py
@@ -80,6 +80,7 @@ def postal_code_validator(*args, **kwargs):
 
 def is_bool(value):
     if type(value) == str:
+        print(value, value.lower() in ["oui", "o"])
         if value.lower() in ["oui", "o"]:
             return True
         else:

--- a/backend/api/db/models/validator.py
+++ b/backend/api/db/models/validator.py
@@ -87,7 +87,7 @@ def is_bool(value):
     elif type(value) == bool:
         return value
     else:
-        return False
+        return None
 
 
 def is_bool_validator(*args, **kwargs):

--- a/backend/api/db/models/validator.py
+++ b/backend/api/db/models/validator.py
@@ -78,20 +78,21 @@ def postal_code_validator(*args, **kwargs):
     return decorated
 
 
-def is_bool(value):
+def parse_bool(value):
     if type(value) == str:
-        print(value, value.lower() in ["oui", "o"])
         if value.lower() in ["oui", "o"]:
             return True
-        else:
+        elif value.lower() in ["non", "n"]:
             return False
+        else:
+            return None
     elif type(value) == bool:
         return value
     else:
         return None
 
 
-def is_bool_validator(*args, **kwargs):
+def parse_bool_validator(*args, **kwargs):
     decorator = validator(*args, **kwargs, allow_reuse=True)
-    decorated = decorator(is_bool)
+    decorated = decorator(parse_bool)
     return decorated

--- a/backend/api/v1/routers/beneficiaries.py
+++ b/backend/api/v1/routers/beneficiaries.py
@@ -81,26 +81,23 @@ async def import_beneficiary(
                 )
 
                 if not beneficiary_id:
-                    raise UpdateFailError(f"fail to insert beneficiary {records[0].id}")
+                    raise UpdateFailError(
+                        f"failed to insert beneficiary {records[0].id}"
+                    )
 
                 logger.info("inserted new beneficiary %s", beneficiary_id)
                 return BeneficiaryCsvRowResponse(valid=True, data=beneficiary)
 
             elif one_matching_beneficiary(records, beneficiary):
-                # pour chaque ligne, on renvoie une liste de tuple [nom, valeur] si valeur != none
-                fieldsToUpdate = [
-                    (fieldname, value)
-                    for (fieldname, value) in beneficiary.dict().items()
-                    if value is not None
-                ]
                 beneficiary_id = await update_beneficiary(
-                    db, fieldsToUpdate, records[0].id
+                    db, beneficiary, records[0].id
                 )
                 if not beneficiary_id:
-                    raise UpdateFailError(f"fail to insert beneficiary {records[0].id}")
-
+                    raise UpdateFailError(
+                        f"failed to insert beneficiary {records[0].id}"
+                    )
                 notebook_id: UUID | None = await update_notebook(
-                    db, beneficiary_id, fieldsToUpdate
+                    db, beneficiary, beneficiary_id
                 )
                 if notebook_id:
                     await insert_or_update_need_orientation(

--- a/backend/api/v1/routers/csv2json.py
+++ b/backend/api/v1/routers/csv2json.py
@@ -36,8 +36,6 @@ async def parse_beneficiaries(
     upload_file: UploadFile,
 ):
     dataframe = await file_to_json(upload_file)
-    for line in dataframe.iterrows():
-        print(line)
     return [map_csv_row_beneficiary(row) for _, row in dataframe.iterrows()]
 
 
@@ -52,9 +50,7 @@ async def file_to_json(upload_file: UploadFile) -> DataFrame:
         contents = await upload_file.read()
         with BytesIO(contents) as data:
             df = pd.read_excel(
-                data,
-                header=0,
-                dtype=object,
+                data, header=0, dtype=object, na_values="", keep_default_na=False
             )
     elif file_info.mime_type in ["text/plain", "text/csv"]:
 
@@ -68,6 +64,8 @@ async def file_to_json(upload_file: UploadFile) -> DataFrame:
                 skip_blank_lines=True,
                 sep=";",
                 dtype=object,
+                na_values="",
+                keep_default_na=False,
             )
     else:
         raise HTTPException(

--- a/backend/api/v1/routers/csv2json.py
+++ b/backend/api/v1/routers/csv2json.py
@@ -40,9 +40,9 @@ async def parse_beneficiaries(
 
 
 async def file_to_json(upload_file: UploadFile) -> DataFrame:
-    file_info: magic.FileMagic = magic.detect_from_fobj(upload_file.file)
+    mime_type: str = magic.from_descriptor(upload_file.file.fileno(), mime=True)
 
-    if file_info.mime_type in [
+    if mime_type in [
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "application/vnd.ms-excel",
     ]:
@@ -52,7 +52,7 @@ async def file_to_json(upload_file: UploadFile) -> DataFrame:
             df = pd.read_excel(
                 data, header=0, dtype=object, na_values="", keep_default_na=False
             )
-    elif file_info.mime_type in ["text/plain", "text/csv"]:
+    elif mime_type in ["text/plain", "text/csv"]:
 
         contents = await upload_file.read()
         charset = chardet.detect(contents)
@@ -70,7 +70,7 @@ async def file_to_json(upload_file: UploadFile) -> DataFrame:
     else:
         raise HTTPException(
             status_code=400,
-            detail=f"File type '{file_info.mime_type}' not supported. Allowed types are csv or excel",
+            detail=f"File type '{mime_type}' not supported. Allowed types are csv or excel",
         )
 
     data_frame = df.replace({np.nan: None})

--- a/backend/api/v1/routers/uploads.py
+++ b/backend/api/v1/routers/uploads.py
@@ -52,9 +52,9 @@ async def create_upload_file(
 ):
     deployment_id = request.state.deployment_id
 
-    file_info: magic.FileMagic = magic.detect_from_fobj(upload_file.file)
+    mime_type: str = magic.from_descriptor(upload_file.file.fileno(), mime=True)
 
-    if file_info.mime_type in [
+    if mime_type in [
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "application/vnd.ms-excel",
     ]:
@@ -65,7 +65,7 @@ async def create_upload_file(
                 data,
                 header=0,
             )
-    elif file_info.mime_type in ["text/plain", "text/csv"]:
+    elif mime_type in ["text/plain", "text/csv"]:
 
         contents = await upload_file.read()
         charset = chardet.detect(contents)
@@ -80,7 +80,7 @@ async def create_upload_file(
     else:
         raise HTTPException(
             status_code=400,
-            detail=f"File type '{file_info.mime_type}' not supported. Allowed types are csv or excel",
+            detail=f"File type '{mime_type}' not supported. Allowed types are csv or excel",
         )
 
     df = df.replace({np.nan: None})

--- a/backend/tests/api/test_admin_structures.py
+++ b/backend/tests/api/test_admin_structures.py
@@ -9,9 +9,9 @@ sender_email = "test@toto.fr"
 
 @mock.patch("api.v1.routers.admin_structures.send_invitation_email")
 async def test_jwt_token_verification(
-    mock_send_invitation_mail: mock.Mock,
+    _: mock.Mock,
     test_client,
-    get_professionnal_jwt,
+    get_professional_jwt,
     deployment_id_cd93: UUID,
     structure_id_pe_livry: UUID,
 ):
@@ -29,7 +29,7 @@ async def test_jwt_token_verification(
             },
             "structure_id": str(structure_id_pe_livry),
         },
-        headers={"jwt-token": f"{get_professionnal_jwt}"},
+        headers={"jwt-token": f"{get_professional_jwt}"},
     )
 
     json = response.json()
@@ -96,7 +96,7 @@ async def test_insert_admin_structure_with_structure_in_db(
 
 @mock.patch("api.v1.routers.admin_structures.send_invitation_email")
 async def test_insert_existing_admin_structure_in_structure_in_db(
-    mock_send_invitation_mail: mock.Mock,
+    _: mock.Mock,
     test_client,
     db_connection: Connection,
     get_admin_structure_jwt,
@@ -143,7 +143,7 @@ async def test_insert_existing_admin_structure_in_structure_in_db(
 
 @mock.patch("api.v1.routers.admin_structures.send_invitation_email")
 async def test_insert_existing_admin_structure_in_existing_structure(
-    mock_send_invitation_mail: mock.Mock,
+    _: mock.Mock,
     test_client,
     get_admin_structure_jwt,
     deployment_id_cd93: UUID,
@@ -171,7 +171,7 @@ async def test_insert_existing_admin_structure_in_existing_structure(
 
 @mock.patch("api.v1.routers.admin_structures.send_invitation_email")
 async def test_insert_deleted_admin_structure_in_structure_in_db(
-    mock_send_invitation_mail: mock.Mock,
+    _: mock.Mock,
     test_client,
     db_connection: Connection,
     get_admin_structure_jwt,

--- a/backend/tests/api/test_import_beneficiaries.py
+++ b/backend/tests/api/test_import_beneficiaries.py
@@ -32,11 +32,11 @@ async def import_beneficiaries(
 
 async def test_import_beneficiaries_must_be_done_by_a_manager(
     test_client,
-    get_professionnal_jwt,
+    get_professional_jwt,
 ):
     response = test_client.post(
         "/v1/beneficiaries/bulk",
-        headers={"jwt-token": f"{get_professionnal_jwt}"},
+        headers={"jwt-token": f"{get_professional_jwt}"},
         data=json.dumps(
             {
                 "beneficiaries": [],

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,7 +12,7 @@ from api.core.init import create_app
 from api.core.settings import settings
 from api.db.crud.beneficiary import get_beneficiary_by_id
 from api.db.crud.professional import get_professional_by_email
-from api.db.models.beneficiary import Beneficiary
+from api.db.models.beneficiary import Beneficiary, BeneficiaryImport
 from api.db.models.professional import Professional
 
 test_dir = os.path.dirname(os.path.realpath(__file__))
@@ -264,7 +264,7 @@ def get_admin_cdb_jwt() -> str:
 
 
 @pytest.fixture
-def get_professionnal_jwt() -> str:
+def get_professional_jwt() -> str:
     return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2hhc3VyYS5pby9qd3QvY2xhaW1zIjp7IngtaGFzdXJhLWFsbG93ZWQtcm9sZXMiOlsicHJvZmVzc2lvbmFsIl0sIngtaGFzdXJhLWRlZmF1bHQtcm9sZSI6InByb2Zlc3Npb25hbCIsIngtaGFzdXJhLXVzZXItaWQiOiIxNzQzNDQ2NC01ZjY5LTQwY2MtODE3Mi00MDE2MDk1OGEzM2QiLCJ4LWhhc3VyYS1wcm9mZXNzaW9uYWwtaWQiOiIxYTViODE3Yi02YjgxLTRhNGQtOTk1My0yNjcwN2E1NGUwZTkiLCJ4LWhhc3VyYS1kZXBsb3ltZW50LWlkIjoiNGRhYjgwMzYtYTg2ZS00ZDVmLTliZDQtNmNlODhjMTk0MGQwIn0sImlkIjoiMTc0MzQ0NjQtNWY2OS00MGNjLTgxNzItNDAxNjA5NThhMzNkIiwicm9sZSI6InByb2Zlc3Npb25hbCIsInByb2Zlc3Npb25hbElkIjoiMWE1YjgxN2ItNmI4MS00YTRkLTk5NTMtMjY3MDdhNTRlMGU5IiwiZGVwbG95bWVudElkIjoiNGRhYjgwMzYtYTg2ZS00ZDVmLTliZDQtNmNlODhjMTk0MGQwIiwiaWF0IjoxNjYxODY2NzkzLCJleHAiOjE5Nzc0NDI3OTMsInN1YiI6IjE3NDM0NDY0LTVmNjktNDBjYy04MTcyLTQwMTYwOTU4YTMzZCJ9.sSj94JD2BvBjjUttMhfNQnVwvj6vOWnKW3Vkkbsskxs"
 
 
@@ -307,3 +307,24 @@ def deployment_id_cd93() -> UUID:
 @pytest.fixture
 def structure_id_pe_livry() -> UUID:
     return UUID("a81bc81b-dead-4e5d-abff-90865d1e13b2")
+
+
+@pytest.fixture
+@pytest.mark.asyncio
+async def beneficiary_import_alain_die() -> BeneficiaryImport:
+    return BeneficiaryImport(
+        internal_id="1234",
+        firstname="Alain",
+        lastname="Die",
+        date_of_birth="1980-01-01",
+        place_of_birth="Lyon",
+        mobile_number="0601020304",
+        email="alain.die@lycos.com",
+        address1="Rue",
+        postal_code="69900",
+        city="Lyon",
+        work_situation="iae",
+        right_rsa="rsa_droit_ouvert_versable",
+        right_ass=True,
+        geographical_area="between_20_30",
+    )

--- a/backend/tests/test_beneficiary.py
+++ b/backend/tests/test_beneficiary.py
@@ -2,7 +2,7 @@ from datetime import date
 
 from api.db.crud.beneficiary import get_beneficiary_from_personal_information
 from api.db.crud.wanted_job import find_wanted_job_for_beneficiary
-from api.db.models.beneficiary import Beneficiary
+from api.db.models.beneficiary import Beneficiary, BeneficiaryImport
 from cdb_csv import pe
 from cdb_csv.models.csv_row import PrincipalCsvRow
 
@@ -136,3 +136,58 @@ async def test_get_beneficiary_with_unknown_rome_code(
                 )
 
                 assert "Rome code not found" in caplog.text
+
+
+def test_beneficiary_model_beneficiary_filled_keys(
+    beneficiary_import_alain_die: BeneficiaryImport,
+):
+    editable_keys = beneficiary_import_alain_die.get_beneficiary_editable_keys()
+    editable_keys.sort()
+    assert editable_keys == [
+        "address1",
+        "address2",
+        "city",
+        "email",
+        "mobile_number",
+        "place_of_birth",
+        "postal_code",
+    ]
+
+
+def test_beneficiary_model_notebook_filled_keys(
+    beneficiary_import_alain_die: BeneficiaryImport,
+):
+    editable_keys = beneficiary_import_alain_die.get_notebook_editable_keys()
+    editable_keys.sort()
+    assert editable_keys == [
+        "geographical_area",
+        "right_ass",
+        "right_rsa",
+        "work_situation",
+    ]
+
+
+def test_beneficairy_get_values_for_keys(
+    beneficiary_import_alain_die: BeneficiaryImport,
+):
+    beneficiary_import_alain_die.right_are = True
+    beneficiary_import_alain_die.right_ass = True
+    beneficiary_import_alain_die.right_bonus = True
+    values = beneficiary_import_alain_die.get_values_for_keys(
+        [
+            "geographical_area",
+            "right_are",
+            "right_ass",
+            "right_bonus",
+            "right_rsa",
+            "work_situation",
+        ]
+    )
+    assert values == [
+        "between_20_30",
+        True,
+        True,
+        True,
+        "rsa_droit_ouvert_versable",
+        "iae",
+    ]

--- a/backend/tests/test_beneficiary_import.py
+++ b/backend/tests/test_beneficiary_import.py
@@ -5,11 +5,11 @@ from api.db.models.beneficiary import BeneficiaryImport
 
 async def test_strip_beneficiary_data_on_import():
     beneficiary = BeneficiaryImport(
-        si_id=" 123 ",
+        internal_id=" 123 ",
         firstname="Remi",
         lastname="Cado",
         date_of_birth=date(2001, 4, 30),
         nir=" 101047505612317  ",
     )
-    assert beneficiary.si_id == "123"
+    assert beneficiary.internal_id == "123"
     assert beneficiary.nir == "101047505612317"

--- a/e2e/features/manager/importBeneficiaires.feature
+++ b/e2e/features/manager/importBeneficiaires.feature
@@ -17,8 +17,8 @@ Fonctionnalité: Import de bénéficiaires
 		Alors je vois "4 bénéficiaires sélectionnés sur 4"
 		Quand je clique sur "Confirmer"
 		Alors je vois "2 bénéficiaires importés sur 4 demandés."
-		Alors je vois "Un bénéficiaire existant utilise cet internalId ou ce nom/prénom/date de naissance sur le territoire." sur la ligne "charlie"
-		Alors je vois "Un bénéficiaire existant utilise cet internalId ou ce nom/prénom/date de naissance sur le territoire." sur la ligne "Charlotte"
+		Alors je vois "Un bénéficiaire existe déjà avec cet identifiant SI sur le territoire." sur la ligne "Charlotte"
+		Alors je vois "Un bénéficiaire existe déjà avec ce nom/prénom/date de naissance sur le territoire." sur la ligne "charlie"
 
 	Scénario: Import de bénéficiaires avec différents formats de date
 		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
@@ -49,6 +49,7 @@ Fonctionnalité: Import de bénéficiaires
 		Quand je clique sur "Confirmer"
 		Alors je vois "1 bénéficiaire importé"
 		Alors je vois "1 bénéficiaire mis à jour"
+
 
 	Scénario: Import de nouveaux bénéficiaires
 		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"


### PR DESCRIPTION
## :wrench: Problème

Actuellement, la mise à jour via import peut entrainer une perte d'information du bénéficiaire ou dans son carnet.

## :cake: Solution

On met à jour seulement les champs dont la valeur n'est pas `None`
On a choisi cette solution car potentiellement moins soumise au risque perte de données. L'inconvénient est qu'on ne peut plus "vider" un champs via un ré-import. (Selon les retours, on aura la possibilité d'utiliser une valeur dédié à la remise à zéro d'un champ)
  

## :rotating_light:  Points d'attention / Remarques

Afin que tout cela fonctionne, on a du modifier l'insert pour supporter None dans les champs boolean `right_are`, `right_rtqh`, `right_ass`, `right_bonus` car un Pre traitement du model pydantic passait les champs à False ce qui faisait que meme lorsque la valeur n'etait pas fourni (None) celle la etait transformé en False et donc sujet à modification.

Autre point d'attention, nous avons tenu compte du cas particulier de l'adresse découpé en plusieur champs ou le changement d'addresse entraine un remive a zero du champ `address2` si ce dernier n'est pas fourni pour éviter d'avoir des données relative à l'ancienne adresse

## :desert_island: Comment tester

Des fichiers sont en cours de préparation

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1274.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


fix #1282
