### PR TITLE
feat: stockage de l'identifiant unique Pôle Emploi lors de l'import

### DIFF
--- a/backend/api/db/crud/beneficiary.py
+++ b/backend/api/db/crud/beneficiary.py
@@ -72,12 +72,32 @@ OR (internal_id = $4 AND deployment_id = $5)
     ]
 
 
+async def update_beneficiary_field(
+    connection: Connection,
+    field_name: str,
+    field_value: str,
+    beneficiary_id: UUID,
+) -> UUID | None:
+
+    result: Record | None = await connection.fetchrow(
+        f"""
+UPDATE beneficiary SET {field_name} = $2
+where id = $1
+returning id
+        """,
+        beneficiary_id,
+        field_value,
+    )
+    if result:
+        return result["id"]
+
+
 async def update_beneficiary(
     connection: Connection,
     beneficiary: BeneficiaryImport,
     beneficiary_id: UUID,
 ) -> UUID | None:
-    result = await connection.fetchrow(
+    result: Record | None = await connection.fetchrow(
         f"""
 UPDATE beneficiary SET mobile_number = $2,
     address1 = $3,

--- a/backend/api/db/models/beneficiary.py
+++ b/backend/api/db/models/beneficiary.py
@@ -44,7 +44,7 @@ class Beneficiary(BaseModel):
     # (account is created on the first login attempt)
     account_id: UUID | None
     nir: str | None
-    pe_unique_id: str | None
+    pe_unique_import_id: str | None
 
 
 def snake_to_camel(field):

--- a/backend/api/db/models/beneficiary.py
+++ b/backend/api/db/models/beneficiary.py
@@ -44,6 +44,7 @@ class Beneficiary(BaseModel):
     # (account is created on the first login attempt)
     account_id: UUID | None
     nir: str | None
+    pe_unique_id: str | None
 
 
 def snake_to_camel(field):

--- a/backend/cdb_csv/pe.py
+++ b/backend/cdb_csv/pe.py
@@ -378,14 +378,14 @@ async def import_beneficiary(
 
     if beneficiary and beneficiary.notebook is not None:
 
-        if beneficiary.pe_unique_id != pe_unique_id:
+        if beneficiary.pe_unique_import_id != pe_unique_id:
             beneficiary_uuid: UUID | None = await update_beneficiary_field(
-                connection, "pe_unique_id", pe_unique_id, beneficiary.id
+                connection, "pe_unique_import_id", pe_unique_id, beneficiary.id
             )
 
             if beneficiary_uuid:
                 logging.info(
-                    f"{pe_unique_id} - Updated beneficiary pe_unique_id to value {pe_unique_id}"
+                    f"{pe_unique_id} - Updated beneficiary pe_unique_import_id to value {pe_unique_id}"
                 )
 
         # Do we already have some external data for this beneficiary?

--- a/backend/cdb_csv/pe.py
+++ b/backend/cdb_csv/pe.py
@@ -15,7 +15,10 @@ from api.db.crud.account import (
     get_account_by_professional_email,
     insert_professional_account,
 )
-from api.db.crud.beneficiary import get_beneficiary_from_personal_information
+from api.db.crud.beneficiary import (
+    get_beneficiary_from_personal_information,
+    update_beneficiary_field,
+)
 from api.db.crud.external_data import (
     get_last_external_data_by_beneficiary_id_and_source,
     insert_external_data_for_beneficiary_and_professional,
@@ -93,7 +96,7 @@ async def match_beneficiaries_and_pros(connection: Connection, principal_csv: st
             if beneficiary and beneficiary.notebook is not None:
 
                 logging.info(
-                    f"{pe_unique_id} - Found matching beneficiary {beneficiary.id}"
+                    f"{pe_unique_id} - Found matching beneficiary for pro {beneficiary.id}"
                 )
 
                 account: AccountDB | None = await get_account_by_professional_email(
@@ -374,6 +377,16 @@ async def import_beneficiary(
     )
 
     if beneficiary and beneficiary.notebook is not None:
+
+        if beneficiary.pe_unique_id != pe_unique_id:
+            beneficiary_uuid: UUID | None = await update_beneficiary_field(
+                connection, "pe_unique_id", pe_unique_id, beneficiary.id
+            )
+
+            if beneficiary_uuid:
+                logging.info(
+                    f"{pe_unique_id} - Updated beneficiary pe_unique_id to value {pe_unique_id}"
+                )
 
         # Do we already have some external data for this beneficiary?
         external_data: ExternalData | None = (

--- a/backend/tests/test_pe_csv_import.py
+++ b/backend/tests/test_pe_csv_import.py
@@ -124,7 +124,7 @@ async def test_parse_principal_csv(
 
     assert sophie_tifour is not None and sophie_tifour.notebook is not None
     assert len(sophie_tifour.notebook.wanted_jobs) == 3
-    assert sophie_tifour.pe_unique_id == "71288a46-3c4d-4372-9298-c32936d7e76d"
+    assert sophie_tifour.pe_unique_import_id == "71288a46-3c4d-4372-9298-c32936d7e76d"
 
     professional = await get_professional_by_email(
         db_connection, "referent_prenom4.referent_nom4@pole-emploi.fr"

--- a/backend/tests/test_pe_csv_import.py
+++ b/backend/tests/test_pe_csv_import.py
@@ -124,6 +124,7 @@ async def test_parse_principal_csv(
 
     assert sophie_tifour is not None and sophie_tifour.notebook is not None
     assert len(sophie_tifour.notebook.wanted_jobs) == 3
+    assert sophie_tifour.pe_unique_id == "71288a46-3c4d-4372-9298-c32936d7e76d"
 
     professional = await get_professional_by_email(
         db_connection, "referent_prenom4.referent_nom4@pole-emploi.fr"

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_beneficiary.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_beneficiary.yaml
@@ -17,7 +17,7 @@ configuration:
       custom_name: mobileNumber
     pe_number:
       custom_name: peNumber
-    pe_unique_id:
+    pe_unique_import_id:
       custom_name: peUniqueId
     place_of_birth:
       custom_name: placeOfBirth
@@ -33,7 +33,7 @@ configuration:
     internal_id: internalId
     mobile_number: mobileNumber
     pe_number: peNumber
-    pe_unique_id: peUniqueId
+    pe_unique_import_id: peUniqueId
     place_of_birth: placeOfBirth
     postal_code: postalCode
     updated_at: updatedAt

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_beneficiary.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_beneficiary.yaml
@@ -17,6 +17,8 @@ configuration:
       custom_name: mobileNumber
     pe_number:
       custom_name: peNumber
+    pe_unique_id:
+      custom_name: peUniqueId
     place_of_birth:
       custom_name: placeOfBirth
     postal_code:
@@ -31,6 +33,7 @@ configuration:
     internal_id: internalId
     mobile_number: mobileNumber
     pe_number: peNumber
+    pe_unique_id: peUniqueId
     place_of_birth: placeOfBirth
     postal_code: postalCode
     updated_at: updatedAt

--- a/hasura/migrations/carnet_de_bord/1669048458209_alter_table_public_beneficiary_add_column_pe_unique_id/down.sql
+++ b/hasura/migrations/carnet_de_bord/1669048458209_alter_table_public_beneficiary_add_column_pe_unique_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."beneficiary" drop column "pe_unique_id";

--- a/hasura/migrations/carnet_de_bord/1669048458209_alter_table_public_beneficiary_add_column_pe_unique_id/down.sql
+++ b/hasura/migrations/carnet_de_bord/1669048458209_alter_table_public_beneficiary_add_column_pe_unique_id/down.sql
@@ -1,1 +1,1 @@
-alter table "public"."beneficiary" drop column "pe_unique_id";
+alter table "public"."beneficiary" drop column "pe_unique_import_id";

--- a/hasura/migrations/carnet_de_bord/1669048458209_alter_table_public_beneficiary_add_column_pe_unique_id/up.sql
+++ b/hasura/migrations/carnet_de_bord/1669048458209_alter_table_public_beneficiary_add_column_pe_unique_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."beneficiary" add column "pe_unique_id" text null;

--- a/hasura/migrations/carnet_de_bord/1669048458209_alter_table_public_beneficiary_add_column_pe_unique_id/up.sql
+++ b/hasura/migrations/carnet_de_bord/1669048458209_alter_table_public_beneficiary_add_column_pe_unique_id/up.sql
@@ -1,1 +1,1 @@
-alter table "public"."beneficiary" add column "pe_unique_id" text null;
+alter table "public"."beneficiary" add column "pe_unique_import_id" text null;


### PR DESCRIPTION
## :wrench: Problème

Lors de l'import du fichier PE principal, nous ne gardons pas le champ nommé `identifiant_unique_de` qui représente un identifiant unique par bénéficiaire généré par PE. Cet identifiant permettant de trouver l'action correspondante dans le fichier des actions, nous ne sommes pour l'instant pas capable de faire le lien entre une action PE et le bénéficiaire lors de l'import.

## :cake: Solution

Sauvegarder l'information `identifiant_unique_de` dans CdB lors de l'import du fichier principal de PE. Pour ce faire, on rajoute un champ `pe_unique_id` dans la table `Beneficiary`.

## :desert_island: Comment tester

Les tests fonctionnels couvrent les cas de test

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1277.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

fix #1268 
