### PR TITLE
fix: add missing fields in import preview

### DIFF
--- a/app/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/app/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -46,7 +46,11 @@
 			<Text class="mb-2" value={`RSA - ${rsaRightKeys.byKey[notebook.rightRsa]}`} />
 			{#if [notebook.rightAre, notebook.rightBonus, notebook.rightAss].filter( (field) => Boolean(field) ).length > 0}
 				<p>
-					{[notebook.rightAre && 'ARE', notebook.rightAss && 'ASS', notebook.rightBonus && 'Bonus']
+					{[
+						notebook.rightAre && 'ARE',
+						notebook.rightAss && 'ASS',
+						notebook.rightBonus && "Prime d'activité",
+					]
 						.filter((field) => Boolean(field))
 						.join(', ')}
 				</p>

--- a/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
+++ b/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
@@ -174,7 +174,7 @@
 		{ label: 'Ville', key: 'Ville', mandatory: false },
 		{ label: 'Situation de travail', key: 'Situation', mandatory: false },
 		{ label: 'N° CAF/MSA', key: 'Numéro allocataire CAF/MSA', mandatory: false },
-		{ label: 'N° Pôle emploi', key: 'Identifiant Pôle Emploi', mandatory: false },
+		{ label: 'N° Pôle emploi', key: 'Identifiant Pôle emploi', mandatory: false },
 		{ label: 'Droits RSA', key: 'Droits RSA', mandatory: false },
 		{ label: 'Droits ARE', key: 'Droits ARE', mandatory: false },
 		{ label: 'Droits ASS', key: 'Droits ASS', mandatory: false },
@@ -183,7 +183,7 @@
 		{ label: 'Zone de mobilité', key: 'Zone de mobilité', mandatory: false },
 		{
 			label: 'Emplois recherchés (texte + code ROME)',
-			key: 'Emploi recherché (code ROME)"',
+			key: 'Emploi recherché (code ROME)',
 			mandatory: false,
 		},
 		{ label: 'Niveau de formation', key: 'Niveau de formation', mandatory: false },
@@ -235,10 +235,13 @@
 					>consulter la notice de remplissage</a
 				>.
 			</div>
-			<Dropzone on:drop={handleFilesSelect} multiple={false} accept=".csv,.xls,.xlsx">
-				<span class="cursor-default">
-					Déposez votre fichier ou cliquez pour le rechercher sur votre ordinateur.
-				</span>
+			<Dropzone
+				on:drop={handleFilesSelect}
+				multiple={false}
+				accept=".csv,.xls,.xlsx"
+				containerClasses="cursor-pointer dropzone"
+			>
+				Déposez votre fichier ou cliquez pour le rechercher sur votre ordinateur.
 			</Dropzone>
 		{:else}
 			{#await parsePromise}
@@ -299,12 +302,16 @@
 											{#if beneficiary.valid}
 												{#if key === 'Date de naissance*'}
 													<Text value={formatDateLocale(beneficiary.data[key])} defaultValue="" />
+												{:else if ["Prime d'activité", 'Droits ARE', 'Droits ASS', 'Droits RQTH'].includes(key)}
+													<Text value={beneficiary.data[key] ? 'Oui' : 'Non'} defaultValue="" />
 												{:else}
 													<Text value={beneficiary.data[key]} defaultValue="" />
 												{/if}
 											{:else if lineErrors[key]}
-												<i class="ri-alert-line text-error " title={lineErrors[key]} />
-												<Text
+												<i
+													class="ri-alert-line text-error "
+													title={translateError(lineErrors[key])}
+												/><Text
 													class="text-error border-dashed border-b-1 "
 													title={translateError(lineErrors[key])}
 													value={beneficiary.row[key]}
@@ -469,3 +476,12 @@
 		{/await}
 	{/if}
 </div>
+
+<style>
+	:global(.dropzone):hover {
+		border-color: var(--blue-france-main-525);
+	}
+	:global(.dropzone):focus {
+		border-color: var(--blue-france-main-525);
+	}
+</style>

--- a/backend/api/db/models/beneficiary.py
+++ b/backend/api/db/models/beneficiary.py
@@ -73,7 +73,7 @@ class BeneficiaryImport(BaseModel):
     city: str | None = Field(None, alias="Ville")
     work_situation: str | None = Field(None, alias="Situation")
     caf_number: str | None = Field(None, alias="Numéro allocataire CAF/MSA")
-    pe_number: str | None = Field(None, alias="Identifiant Pôle Emploi")
+    pe_number: str | None = Field(None, alias="Identifiant Pôle emploi")
     right_rsa: str | None = Field(None, alias="Droits RSA")
     right_are: bool | None = Field(None, alias="Droits ARE")
     right_ass: bool | None = Field(None, alias="Droits ASS")

--- a/backend/api/v1/routers/csv2json.py
+++ b/backend/api/v1/routers/csv2json.py
@@ -36,6 +36,8 @@ async def parse_beneficiaries(
     upload_file: UploadFile,
 ):
     dataframe = await file_to_json(upload_file)
+    for line in dataframe.iterrows():
+        print(line)
     return [map_csv_row_beneficiary(row) for _, row in dataframe.iterrows()]
 
 


### PR DESCRIPTION
fix #1279

## :wrench: Problème

La prévisualisation d'un fichier d'import de bénéficiaire n'affiche pas la colonne `Identidfant Pôle emploi` ni `Emploi recherché`. On affiche aussi la valeur des champs boolean au lien de Oui / Non 

## :cake: Solution

Rajouter les colonnes manquantes et permettre d'afficher les valeur boolean en francais

## :rotating_light:  Points d'attention / Remarques
 
On profite de la PR pour fixer un oubli lors de la correction de l'affichage de la Prime d'activité qui s'affiche `Bonus`  

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Se rendre sur la [review app](https://cdb-app-review-pr1284.osc-fr1.scalingo.io).
<!-- END ## emplacement de l'URL de la review app ## -->

Se connecter en tant `manager.cd93` et importer le fichier de beneficiaire suivant [Fichier import intial.xlsx](https://github.com/gip-inclusion/carnet-de-bord/files/10071205/Fichier.import.intial.xlsx). 
On observe bien le que les champs `Identifiant Pôle emploi` et `Emploi recherché` ainsi que les champs booléens s'affichent bien en français



<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
