### PR TITLE
ci: désactiver la création de review apps sur les PR étrangères

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -12,6 +12,8 @@ jobs:
   scalingo-link:
     name: Create and link Scalingo review apps
     runs-on: ubuntu-latest
+    # run only for local PRs, since we need secrets access anyway
+    if: github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## :wrench: Problème

Les PR ouvertes depuis d'autres repos que celui-ci déclenchent le _workflow_ de création de _review app_, mais celui-ci ne peut pas réussir car il s'exécute sans accès aux secrets nécessaires. En particulier, les PR ouvertes par Dependabot sont concernées, ex. #1275.

## :cake: Solution

Pour des raisons de sécurité, on ne veut pas donner aux PR étrangères l'accès aux secrets. On se contente ici de désactiver la création de _review app_ dans le cas d'une PR venant d'un autre repo, ce qui nous évite d'avoir un échec qui apparaît dans la liste des exécutions.

## :rotating_light:  Points d'attention / Remarques

Dans l'absolu des _review apps_ pourraient être intéressantes pour les PR de Dependabot, et on pourrait configurer le _workflow_ pour leur donner accès aux secrets, mais il y a une bonne raison pour laquelle GitHub a fait ce choix de ne pas donner accès aux secrets y compris pour les PR de Dependabot : en effet, une dépendance qui aurait été compromise pourrait exécuter du code arbitraire dans le contexte d'une PR de mise à jour. Voir https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/ pour plus de détails.

## :desert_island: Comment tester

J'ai vérifié que le comportement était correct en utilisant des _forks_ de ce repo. Voir notamment ce qui se passe quand une PR étrangère est ouverte : https://github.com/ut7/carnet-de-bord/actions/runs/3534232522

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1287.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->