### PR TITLE
fix: améliorer les messages d'erreur de connexion

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -1462,6 +1462,7 @@ export type Beneficiary = {
 	/** An aggregate relationship */
 	orientationRequest_aggregate: OrientationRequestAggregate;
 	peNumber?: Maybe<Scalars['String']>;
+	peUniqueId?: Maybe<Scalars['String']>;
 	placeOfBirth?: Maybe<Scalars['String']>;
 	postalCode?: Maybe<Scalars['String']>;
 	/** An array relationship */
@@ -1566,6 +1567,7 @@ export type BeneficiaryBoolExp = {
 	notebook?: InputMaybe<NotebookBoolExp>;
 	orientationRequest?: InputMaybe<OrientationRequestBoolExp>;
 	peNumber?: InputMaybe<StringComparisonExp>;
+	peUniqueId?: InputMaybe<StringComparisonExp>;
 	placeOfBirth?: InputMaybe<StringComparisonExp>;
 	postalCode?: InputMaybe<StringComparisonExp>;
 	structures?: InputMaybe<BeneficiaryStructureBoolExp>;
@@ -1605,6 +1607,7 @@ export type BeneficiaryInsertInput = {
 	notebook?: InputMaybe<NotebookObjRelInsertInput>;
 	orientationRequest?: InputMaybe<OrientationRequestArrRelInsertInput>;
 	peNumber?: InputMaybe<Scalars['String']>;
+	peUniqueId?: InputMaybe<Scalars['String']>;
 	placeOfBirth?: InputMaybe<Scalars['String']>;
 	postalCode?: InputMaybe<Scalars['String']>;
 	structures?: InputMaybe<BeneficiaryStructureArrRelInsertInput>;
@@ -1629,6 +1632,7 @@ export type BeneficiaryMaxFields = {
 	mobileNumber?: Maybe<Scalars['String']>;
 	nir?: Maybe<Scalars['String']>;
 	peNumber?: Maybe<Scalars['String']>;
+	peUniqueId?: Maybe<Scalars['String']>;
 	placeOfBirth?: Maybe<Scalars['String']>;
 	postalCode?: Maybe<Scalars['String']>;
 	updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -1651,6 +1655,7 @@ export type BeneficiaryMaxOrderBy = {
 	mobileNumber?: InputMaybe<OrderBy>;
 	nir?: InputMaybe<OrderBy>;
 	peNumber?: InputMaybe<OrderBy>;
+	peUniqueId?: InputMaybe<OrderBy>;
 	placeOfBirth?: InputMaybe<OrderBy>;
 	postalCode?: InputMaybe<OrderBy>;
 	updatedAt?: InputMaybe<OrderBy>;
@@ -1674,6 +1679,7 @@ export type BeneficiaryMinFields = {
 	mobileNumber?: Maybe<Scalars['String']>;
 	nir?: Maybe<Scalars['String']>;
 	peNumber?: Maybe<Scalars['String']>;
+	peUniqueId?: Maybe<Scalars['String']>;
 	placeOfBirth?: Maybe<Scalars['String']>;
 	postalCode?: Maybe<Scalars['String']>;
 	updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -1696,6 +1702,7 @@ export type BeneficiaryMinOrderBy = {
 	mobileNumber?: InputMaybe<OrderBy>;
 	nir?: InputMaybe<OrderBy>;
 	peNumber?: InputMaybe<OrderBy>;
+	peUniqueId?: InputMaybe<OrderBy>;
 	placeOfBirth?: InputMaybe<OrderBy>;
 	postalCode?: InputMaybe<OrderBy>;
 	updatedAt?: InputMaybe<OrderBy>;
@@ -1745,6 +1752,7 @@ export type BeneficiaryOrderBy = {
 	notebook?: InputMaybe<NotebookOrderBy>;
 	orientationRequest_aggregate?: InputMaybe<OrientationRequestAggregateOrderBy>;
 	peNumber?: InputMaybe<OrderBy>;
+	peUniqueId?: InputMaybe<OrderBy>;
 	placeOfBirth?: InputMaybe<OrderBy>;
 	postalCode?: InputMaybe<OrderBy>;
 	structures_aggregate?: InputMaybe<BeneficiaryStructureAggregateOrderBy>;
@@ -1789,6 +1797,8 @@ export enum BeneficiarySelectColumn {
 	/** column name */
 	PeNumber = 'peNumber',
 	/** column name */
+	PeUniqueId = 'peUniqueId',
+	/** column name */
 	PlaceOfBirth = 'placeOfBirth',
 	/** column name */
 	PostalCode = 'postalCode',
@@ -1813,6 +1823,7 @@ export type BeneficiarySetInput = {
 	mobileNumber?: InputMaybe<Scalars['String']>;
 	nir?: InputMaybe<Scalars['String']>;
 	peNumber?: InputMaybe<Scalars['String']>;
+	peUniqueId?: InputMaybe<Scalars['String']>;
 	placeOfBirth?: InputMaybe<Scalars['String']>;
 	postalCode?: InputMaybe<Scalars['String']>;
 	updatedAt?: InputMaybe<Scalars['timestamptz']>;
@@ -1843,6 +1854,7 @@ export type BeneficiaryStreamCursorValueInput = {
 	mobileNumber?: InputMaybe<Scalars['String']>;
 	nir?: InputMaybe<Scalars['String']>;
 	peNumber?: InputMaybe<Scalars['String']>;
+	peUniqueId?: InputMaybe<Scalars['String']>;
 	placeOfBirth?: InputMaybe<Scalars['String']>;
 	postalCode?: InputMaybe<Scalars['String']>;
 	updatedAt?: InputMaybe<Scalars['timestamptz']>;
@@ -2154,6 +2166,8 @@ export enum BeneficiaryUpdateColumn {
 	Nir = 'nir',
 	/** column name */
 	PeNumber = 'peNumber',
+	/** column name */
+	PeUniqueId = 'peUniqueId',
 	/** column name */
 	PlaceOfBirth = 'placeOfBirth',
 	/** column name */
@@ -16456,7 +16470,7 @@ export const GetProfessionalsFromStructuresDocument = {
 											fields: [
 												{
 													kind: 'ObjectField',
-													name: { kind: 'Name', value: 'firstname' },
+													name: { kind: 'Name', value: 'lastname' },
 													value: { kind: 'EnumValue', value: 'asc' },
 												},
 											],
@@ -16466,7 +16480,7 @@ export const GetProfessionalsFromStructuresDocument = {
 											fields: [
 												{
 													kind: 'ObjectField',
-													name: { kind: 'Name', value: 'lastname' },
+													name: { kind: 'Name', value: 'firstname' },
 													value: { kind: 'EnumValue', value: 'asc' },
 												},
 											],
@@ -21656,7 +21670,7 @@ export const GetProfessionalsForStructureDocument = {
 											fields: [
 												{
 													kind: 'ObjectField',
-													name: { kind: 'Name', value: 'firstname' },
+													name: { kind: 'Name', value: 'lastname' },
 													value: { kind: 'EnumValue', value: 'asc' },
 												},
 											],
@@ -21666,7 +21680,7 @@ export const GetProfessionalsForStructureDocument = {
 											fields: [
 												{
 													kind: 'ObjectField',
-													name: { kind: 'Name', value: 'lastname' },
+													name: { kind: 'Name', value: 'firstname' },
 													value: { kind: 'EnumValue', value: 'asc' },
 												},
 											],
@@ -27592,6 +27606,20 @@ export const GetAccountByEmailDocument = {
 								kind: 'Argument',
 								name: { kind: 'Name', value: 'where' },
 								value: { kind: 'Variable', name: { kind: 'Name', value: 'criteria' } },
+							},
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'order_by' },
+								value: {
+									kind: 'ObjectValue',
+									fields: [
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: 'type' },
+											value: { kind: 'EnumValue', value: 'asc' },
+										},
+									],
+								},
 							},
 						],
 						selectionSet: {

--- a/app/src/lib/utils/post.ts
+++ b/app/src/lib/utils/post.ts
@@ -41,6 +41,23 @@ async function handleResponse<T>(response: Response): Promise<T> {
 	if (response.ok) {
 		return response.json();
 	}
+
+	if (response.headers.get('Content-type').includes('application/json')) {
+		const { message } = await response.json();
+		if (message) {
+			throw new HTTPError(message, response.status, response.statusText);
+		}
+	}
 	const errorMessage = await response.text();
-	return Promise.reject(new Error(`${response.status} - ${response.statusText}\n${errorMessage}`));
+	throw new HTTPError(errorMessage, response.status, response.statusText);
+}
+
+class HTTPError extends Error {
+	status: string;
+	statusText: string;
+	constructor(message, status, statusText) {
+		super(message);
+		this.status = status;
+		this.statusText = statusText;
+	}
 }

--- a/app/src/routes/auth/login/+page.svelte
+++ b/app/src/routes/auth/login/+page.svelte
@@ -6,7 +6,7 @@
 
 	let request: RequestStep = 'start';
 	let username = '';
-
+	let errorMessage = '';
 	let magicLink = '';
 
 	async function registration() {
@@ -22,6 +22,15 @@
 			request = 'success';
 		} catch (error) {
 			request = 'error';
+			console.error(error.statusText, error.status, error.message);
+			if (error.message === 'ACCOUNT_NOT_FOUND') {
+				errorMessage = "Ce courriel n'est pas rattaché à un compte existant";
+			} else if (error.message === 'ACCOUNT_NOT_CONFIRMED') {
+				errorMessage =
+					"Ce compte n'est pas confirmé. Contactez votre administrateur de territoire de Carnet de Bord.";
+			} else {
+				errorMessage = 'Une erreur est survenue, veuillez ré-essayer ultérieurement.';
+			}
 		}
 	}
 </script>
@@ -44,7 +53,7 @@
 					bind:value={username}
 					inputLabel="Courriel"
 					placeholder="nour@social.gouv.fr"
-					error={request === 'error' ? "Ce courriel n'est pas rattaché à un compte existant" : ''}
+					error={request === 'error' ? errorMessage : ''}
 					required={true}
 				/>
 				<div>

--- a/app/src/routes/auth/login/_getAccountByUsernameorEmail.gql
+++ b/app/src/routes/auth/login/_getAccountByUsernameorEmail.gql
@@ -36,7 +36,7 @@ query GetAccountByUsername($comp: String_comparison_exp!) {
   }
 }
 query GetAccountByEmail($criteria: account_bool_exp!) {
-  account(where: $criteria) {
+  account(where: $criteria, order_by: { type: asc }) {
     id
     username
     beneficiary {


### PR DESCRIPTION
close #1142

## :wrench: Problème

les messages d'erreurs au login sont peu informatifs si on a un compte inexistant ou un compte non confirmé

## :cake: Solution

On différencie les messages d'erreur


## :rotating_light:  Points d'attention / Remarques

On a crée une classe HTTPError pour récupérer le status / statusText

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

se connecter avec `bienvenu.lejeune` et voir le message d'erreur
se connecter avec `xyz.unknonw` et voir le message d'erreur

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1298.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->