### PR TITLE
chore: Changer des textes pour améliorer la navigation / lecture

### DIFF
--- a/app/src/lib/ui/AdminCreate/AdminCreate.svelte
+++ b/app/src/lib/ui/AdminCreate/AdminCreate.svelte
@@ -43,7 +43,7 @@
 
 <div class="flex flex-col gap-6">
 	<div>
-		<h1>Ajouter un Admin PDI</h1>
+		<h1>Ajouter un Admin de territoire</h1>
 		<p class="mb-0">
 			Veuillez renseigner les informations ci-dessous pour ajouter un nouvel administrateur.
 		</p>

--- a/app/src/routes/(auth)/manager/bienvenue/+page.svelte
+++ b/app/src/routes/(auth)/manager/bienvenue/+page.svelte
@@ -55,7 +55,7 @@
 </svelte:head>
 <div class="pt-12">
 	{#if !$updateResult?.data && !$updateResult?.error}
-		<h1>Création de mon compte Admin PDI</h1>
+		<h1>Création de mon compte Admin de territoire</h1>
 		<p>
 			Bienvenue sur Carnet de bord ! Pour cette première connexion, nous vous invitons à vérifier et
 			mettre à jour les informations ci-dessous puis à cliquer sur le bouton "Créer mon compte".

--- a/app/src/routes/(auth)/orientation/beneficiaires/+page.svelte
+++ b/app/src/routes/(auth)/orientation/beneficiaires/+page.svelte
@@ -32,7 +32,7 @@
 	<title>Liste des bénéficiaires - Carnet de bord</title>
 </svelte:head>
 <Breadcrumbs segments={breadcrumbs} />
-<h1>Orientation des bénéficiaires</h1>
+<h1>Bénéficiaires</h1>
 <Container
 	listType="orientation"
 	search={data.search}

--- a/e2e/features/manager/onboardingManager.feature
+++ b/e2e/features/manager/onboardingManager.feature
@@ -7,7 +7,7 @@ Fonctionnalité: Onboarding manager
 
 	Scénario: Première connexion - Mise à jour profil
 		Soit un "administrateur pdi" authentifié pour la première fois avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
-		Quand je vois "Création de mon compte Admin PDI"
+		Quand je vois "Création de mon compte Admin de territoire"
 
 		Alors je vois "Agathe" dans le champ "Prénom"
 		Alors je vois "DeBlouze" dans le champ "Nom"

--- a/e2e/features/orientationManager/addOrientationManager.feature
+++ b/e2e/features/orientationManager/addOrientationManager.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Assignation d'un chargé d'orientation
 	Scénario: Modifier le rattachement d'un bénéficiaire
 		Soit un "chargé d'orientation" authentifié avec l'email "giulia.diaby@cd93.fr"
 		Quand je clique sur "Bénéficiaires"
-		Quand j'attends que le titre de page "Orientation des bénéficiaires" apparaisse
+		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Quand je selectionne l'option "Autres bénéficiaires du territoire" dans la liste "Bénéficiaires"
 		Quand je clique sur "Non assigné" dans la ligne de "Conley"
 		Alors je vois "Assigner un chargé d'orientation"

--- a/e2e/features/orientationManager/filterBeneficiary.feature
+++ b/e2e/features/orientationManager/filterBeneficiary.feature
@@ -10,7 +10,7 @@ Fonctionnalité: Fitrer la liste des bénéficiaires
 		Quand je clique sur "Bénéficiaires"
 		Quand je selectionne l'option "Autres bénéficiaires du territoire" dans la liste "Bénéficiaires"
 		Quand je selectionne l'option "Orienté" dans la liste "Statut"
-		Quand j'attends que le titre de page "Orientation des bénéficiaires" apparaisse
+		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Alors je recherche "ca"
 		Quand je clique sur "Rechercher"
 		Alors je vois "Non assigné" sur la ligne "Cash"
@@ -19,7 +19,7 @@ Fonctionnalité: Fitrer la liste des bénéficiaires
 	Scénario: Afficher la liste des bénéficiaires à orienter de mon portefeuille
 		Soit un "chargé d'orientation" authentifié avec l'email "samy.rouate@cd93.fr"
 		Quand je clique sur "Bénéficiaires"
-		Quand j'attends que le titre de page "Orientation des bénéficiaires" apparaisse
+		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Alors je vois "Samy Rouate" sur la ligne "Mcleod"
 		Alors je vois "Samy Rouate" sur la ligne "Terry"
 		Alors je vois "Samy Rouate" sur la ligne "Tran"

--- a/e2e/features/orientationManager/orientationRequestsList.feature
+++ b/e2e/features/orientationManager/orientationRequestsList.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Liste des demandes de réorientation
 	Scénario: Aucune demande de réorientation
 		Soit un "chargé d'orientation" authentifié avec l'email "laure.loge@cd51.fr"
 		Quand je clique sur "Bénéficiaires"
-		Quand j'attends que le titre de page "Orientation des bénéficiaires" apparaisse
+		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Alors je ne vois pas "Demandes de réorientation"
 		Quand je vais sur la page "/orientation/demandes"
 		Quand j'attends que le titre de page "Demandes de réorientation" apparaisse
@@ -17,7 +17,7 @@ Fonctionnalité: Liste des demandes de réorientation
   Scénario: Une demande de réorientation
 		Soit un "chargé d'orientation" authentifié avec l'email "giulia.diaby@cd93.fr"
 		Quand je clique sur "Bénéficiaires"
-		Quand j'attends que le titre de page "Orientation des bénéficiaires" apparaisse
+		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Alors je vois "Demandes de réorientation"
 		Quand je clique sur "Demandes de réorientation"
 		Quand j'attends que le titre de page "Demandes de réorientation" apparaisse

--- a/e2e/features/orientationManager/rattachement.feature
+++ b/e2e/features/orientationManager/rattachement.feature
@@ -9,7 +9,7 @@ Fonctionnalité: Rattachement d'un pro par un chargé d'orientation
 		Soit un "chargé d'orientation" authentifié avec l'email "giulia.diaby@cd93.fr"
 		Quand je clique sur "Bénéficiaires"
 		Quand je selectionne l'option "Orienté" dans la liste "Statut"
-		Quand j'attends que le titre de page "Orientation des bénéficiaires" apparaisse
+		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Alors je vois "Pierre Chevalier" sur la ligne "Tifour"
 		Quand je clique sur "Pierre Chevalier" dans la ligne de "Tifour"
 		Alors je vois "Rattacher des bénéficiaires"
@@ -24,7 +24,7 @@ Fonctionnalité: Rattachement d'un pro par un chargé d'orientation
 	Scénario: Ré-orienter des bénéficiaires
 		Soit un "chargé d'orientation" authentifié avec l'email "giulia.diaby@cd93.fr"
 		Quand je clique sur "Bénéficiaires"
-		Quand j'attends que le titre de page "Orientation des bénéficiaires" apparaisse
+		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
  		Alors je choisis "Sélectionner Myrna Henderson"
 		Alors je choisis "Sélectionner Della Lynch"
 		Alors je vois "2 sélectionnés"


### PR DESCRIPTION
## :wrench: Problème

Lors de la démo du sprint 22 (21/11/2022), nous avons relevé des messages, titre ou intitulés de champs peu clairs ou obsolètes.

Ca complique l'UX.

## :cake: Solution

Afin de faciliter l'ergonomie / navigation, il faudrait modifier les textes suivants :
- (titre h1 de page) dans la page qui liste les bénéficiaires, il faudrait renommer le titre "Orientation des bénéficiaires" en "Bénéficiaires"
- (libellé) renommer "Admin PDI" en "Admin territoire"


## :rotating_light:  Points d'attention / Remarques

Dans l'issue #1278, il est fait mention d'un message d'erreur à corriger.
Cela a été fait dans une autre PR, [déjà mergée](https://github.com/gip-inclusion/carnet-de-bord/blame/3c71e6c03550f086f0ee176ee31e2266159817ec/backend/api/v1/routers/beneficiaries.py)

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1307.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

closes #1278

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
