### PR TITLE
fix: date shown on reorientation decision banner

### DIFF
--- a/app/src/lib/ui/OrientationRequest/ProOrientationRequestBanner.svelte
+++ b/app/src/lib/ui/OrientationRequest/ProOrientationRequestBanner.svelte
@@ -16,6 +16,11 @@
 			: reorientationRequest.status == 'accepted'
 			? 'acceptée'
 			: 'envoyée';
+
+	$: date =
+		reorientationRequest.status == 'denied' || reorientationRequest.status == 'accepted'
+			? formatDateLocale(reorientationRequest.decidedAt)
+			: formatDateLocale(reorientationRequest.createdAt);
 </script>
 
 <div class="bg-gray-100">
@@ -24,7 +29,7 @@
 			<div class="{color} fr-icon-info-fill" aria-hidden />
 			<div>
 				<p class="fr-text--bold {color} mb-0">
-					Demande de réorientation {decision} le {formatDateLocale(reorientationRequest.createdAt)}
+					Demande de réorientation {decision} le {date}
 				</p>
 				<p class="mb-0">
 					Orientation recommandée : {reorientationRequest.requestedOrientationType.label}


### PR DESCRIPTION
## :wrench: Problème

Dans le bandeau de réorientation pour les carnets consultés par des pros, la date affichée est toujours la date de demande, même quand une décision a été prise.

## :cake: Solution

Afficher la date de décision si une décision a été prise.

## :desert_island: Comment tester

En se connectant avec Paul Camara, vérifier que la date de demande d'acceptation de réorientation dans le profil de Janie Herring est le 3 septembre 2022.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Ne pas supprimer ce bloc, qui sera mis à jour [automatiquement](.github/workflows/review-scalingo.yml).
<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
