### PR TITLE
chore: Suppression des avertissements Svelte.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
 		"dev": "vite dev --host",
 		"build": "vite build",
 		"preview": "vite preview",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --fail-on-warnings",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "npm run lint:prettier && npm run lint:eslint && npm run svelte-check",
 		"lint:pre-commit": "pre-commit run --all-files",

--- a/app/src/lib/ui/LayerCDB.svelte
+++ b/app/src/lib/ui/LayerCDB.svelte
@@ -17,8 +17,8 @@
 
 <svelte:window on:keydown={handleKeyDown} />
 {#if currentLayer}
-	<div transition:fade on:click={close} class="!m-0 fixed inset-0 layer">
-		<div class="absolute inset-0 bg-black opacity-50" tabindex="0" />
+	<div transition:fade on:click={close} on:keydown={handleKeyDown} class="!m-0 fixed inset-0 layer">
+		<div class="absolute inset-0 bg-black opacity-50" />
 	</div>
 {/if}
 

--- a/app/src/lib/ui/base/Autocomplete.svelte
+++ b/app/src/lib/ui/base/Autocomplete.svelte
@@ -109,6 +109,11 @@
 		toggleSelection(suggestionIndex, shouldClose);
 	}
 
+	function suggestionKeyDownHandler(event: KeyboardEvent, suggestionIndex: number) {
+		const shouldClose = !multiple;
+		toggleSelection(suggestionIndex, shouldClose);
+	}
+
 	function toggleSelection(suggestionIndex: number, close = true) {
 		if (multiple) {
 			selectedItems = internalOptions.flatMap((o) => {
@@ -241,7 +246,6 @@
 						on:focus={positionCursor}
 						bind:this={input}
 						class="fr-input"
-						role="search"
 						autocomplete="off"
 						autocapitalize="off"
 						spellcheck="false"
@@ -260,6 +264,7 @@
 							{#each suggestions as suggestion}
 								<div
 									on:click={(e) => suggestionClickHandler(e, suggestion.index)}
+									on:keydown={(e) => suggestionKeyDownHandler(e, suggestion.index)}
 									role="option"
 									tabindex="0"
 									class="option"

--- a/app/src/lib/ui/base/Card.svelte
+++ b/app/src/lib/ui/base/Card.svelte
@@ -17,13 +17,11 @@
 
 <div
 	on:click={onClick}
-	class={`
-fr-card
-${horizontal ? 'fr-card--horizontal' : ''}
-${largeLink ? 'fr-enlarge-link' : ''}
-${hideArrow ? 'fr-card--no-arrow' : ''}
-${$$props.class}
-`}
+	on:keydown={onClick}
+	class={`fr-card ${$$props.class}`}
+	class:fr-card--horizontal={horizontal}
+	class:fr-enlarge-link={largeLink}
+	class:fr-card--no-arrow={hideArrow}
 	class:force-disable-hover={disabledHover}
 >
 	<div class="fr-card__body">

--- a/app/src/lib/ui/base/Footer.svelte
+++ b/app/src/lib/ui/base/Footer.svelte
@@ -42,6 +42,7 @@
 						class="fr-footer__bottom-link"
 						href="https://github.com/gip-inclusion/carnet-de-bord/blob/master/CHANGELOG.md"
 						target="_blank"
+						rel="noreferrer"
 					>
 						Version {appVersion}
 					</a>
@@ -71,6 +72,7 @@
 				<p>
 					Sauf mention contraire, tous les textes de ce site sont sous <a
 						href="https://github.com/etalab/licence-ouverte/blob/master/LO.md"
+						rel="noreferrer"
 						target="_blank">licence etalab-2.0</a
 					>
 				</p>

--- a/app/src/lib/ui/base/GroupCheckbox.svelte
+++ b/app/src/lib/ui/base/GroupCheckbox.svelte
@@ -24,7 +24,7 @@
 	}
 </script>
 
-<div class={`fr-checkbox-group ${classNames}`} on:click={input.click}>
+<div class={`fr-checkbox-group ${classNames}`} on:click={input.click} on:keydown={input.click}>
 	<input
 		bind:this={input}
 		type="checkbox"

--- a/app/src/lib/ui/base/NavBarItem.svelte
+++ b/app/src/lib/ui/base/NavBarItem.svelte
@@ -12,14 +12,13 @@
 	export let currentRoute: string;
 
 	$: isCurrent = currentRoute && menuItem.path && isCurrentRoute(currentRoute, menuItem.path);
+
+	function hideMenu() {
+		$isMenuOpened = false;
+	}
 </script>
 
-<li
-	class="fr-nav__item"
-	on:click={() => {
-		$isMenuOpened = false;
-	}}
->
+<li class="fr-nav__item" on:click={hideMenu} on:keydown={hideMenu}>
 	<Link
 		href={menuItem.path}
 		classNames={`fr-nav__link ${isCurrent ? 'text-france-blue' : 'notActive'}`}


### PR DESCRIPTION
## :wrench: Problème

Lors des builds svelte, on est pollué par un nombre important d'avertissements.
De plus, leur grand nombre ne permet pas de se rendre de l'introduction d'éventuels bogues qui seraient détectés par `svelte-check`.

## :cake: Solution

On corrige les différents avertissements en suivant les conseils donnés par svelte.
Il s'agit essentiellement d'avertissement liés à l'accessibilité, comme par exemple rendre possible la sélection au clavier d'un élément si cet élément réagit au clique de la souris.

Une fois l'ensemble des avertissements supprimés, on active le traitement des avertissements comme des erreurs, afin d'échouer le build si de nouveaux avertissement sont détectés.

## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Récupérer la branche en locale.
Lancer un build de l'application front et/ou la commande `svelte-check`.
Vérifier qu'aucun warning n'est affiché.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1327.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
