### PR TITLE
fix: display Pôle Emploi structure for PE events

### DIFF
--- a/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
@@ -38,14 +38,17 @@
 	}
 
 	function eventCategory(event): string {
-		if (event.eventType == EventType.Action || event.eventType == EventType.Target) {
+		if (
+			(event.eventType == EventType.Action || event.eventType == EventType.Target) &&
+			focusThemeKeys.byKey[event.event.category]
+		) {
 			return (
 				constantToString(event.eventType, eventTypes) +
 				' ' +
 				focusThemeKeys.byKey[event.event.category]
 			);
 		} else {
-			return 'Inconnue';
+			return 'Action inconnue';
 		}
 	}
 

--- a/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
@@ -259,7 +259,13 @@
 									<td>{formatDateLocale(event.eventDate)} </td>
 									<td>{eventCategory(event)}</td>
 									<td>{event.event.event_label}</td>
-									<td>{event.creator?.professional?.structure.name ?? '-'} </td>
+									<td
+										>{#if !event.creator && event.event.from == 'pole_emploi'}
+											Pôle Emploi
+										{:else}
+											{event.creator?.professional?.structure.name ?? '-'}
+										{/if}</td
+									>
 									<td>{constantToString(event.event.status, statusValues)}</td>
 								</tr>
 							{:else}


### PR DESCRIPTION
## :wrench: Problème

Lors de l'import des actions PE, aucune structure n'est affichée.

## :cake: Solution

Afficher « Pôle Emploi » comme structure pour chaque évènement importé de Pôle Emploi.


## :desert_island: Comment tester

Dans l'historique de parcours, les actions PE importées par le script devraient afficher comme structure « Pôle Emploi »

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1330.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


#755 
