### PR TITLE
chore: Ajout d'un logger JSON dans l'application backend.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,5 @@
+LOG_LEVEL=debug
+
 # frontend
 GRAPHQL_API_URL=http://localhost:5000/v1/graphql
 SANDBOX_LOGIN=true
@@ -5,13 +7,13 @@ PUBLIC_MATOMO_URL=https://matomo.fabrique.social.gouv.fr/
 PUBLIC_MATOMO_SITE_ID=53
 PUBLIC_CRISP_WEBSITE_ID=2f9fd96d-44a0-4588-8f7e-a06a5a531c6f
 BACKEND_API_URL=http://localhost:8000
-LOG_LEVEL=debug
 PUBLIC_SENTRY_DSN=
 PUBLIC_SENTRY_ENVIRONMENT=
 
 # backend
 APP_URL=http://localhost:3000
 DATABASE_URL=postgres://cdb:test@localhost:5432/carnet_de_bord
+LOG_AS_JSON=false
 
 SMTP_HOST=smtp.mailtrap.io
 SMTP_PORT=2525

--- a/backend/api/core/logging.py
+++ b/backend/api/core/logging.py
@@ -1,0 +1,117 @@
+import logging
+import sys
+
+import structlog
+from structlog.types import EventDict, Processor
+
+# inspired by https://gist.github.com/nymous/f138c7f06062b7c43c060bf03759c29e
+
+# https://github.com/hynek/structlog/issues/35#issuecomment-591321744
+def rename_event_key(_, __, event_dict: EventDict) -> EventDict:
+    """
+    Log entries keep the text message in the `event` field, but Datadog
+    uses the `message` field. This processor moves the value from one field to
+    the other.
+    See https://github.com/hynek/structlog/issues/35#issuecomment-591321744
+    Even if we do not use Datadog, other apps logs the message in `message` field
+    so we keep the consistency with this swap.
+    """
+    event_dict["message"] = event_dict.pop("event")
+    return event_dict
+
+
+def drop_color_message_key(_, __, event_dict: EventDict) -> EventDict:
+    """
+    Uvicorn logs the message a second time in the extra `color_message`, but we don't
+    need it. This processor drops the key from the event dict if it exists.
+    """
+    event_dict.pop("color_message", None)
+    return event_dict
+
+
+def setup_logging(json_logs: bool, log_level: str):
+    timestamper = structlog.processors.TimeStamper(fmt="iso")
+
+    shared_processors: list[Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.stdlib.ExtraAdder(),
+        drop_color_message_key,
+        timestamper,
+        structlog.processors.StackInfoRenderer(),
+    ]
+
+    if json_logs:
+        # We rename the `event` key to `message` only in JSON logs, as Datadog looks for the
+        # `message` key but the pretty ConsoleRenderer looks for `event`
+        shared_processors.append(rename_event_key)
+        # Format the exception only for JSON logs, as we want to pretty-print them when
+        # using the ConsoleRenderer
+        shared_processors.append(structlog.processors.format_exc_info)
+
+    structlog.configure(
+        processors=shared_processors
+        + [
+            # Prepare event dict for `ProcessorFormatter`.
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+    log_renderer: structlog.types.Processor
+    if json_logs:
+        log_renderer = structlog.processors.JSONRenderer()
+    else:
+        log_renderer = structlog.dev.ConsoleRenderer()
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        # These run ONLY on `logging` entries that do NOT originate within
+        # structlog.
+        foreign_pre_chain=shared_processors,
+        # These run on ALL entries after the pre_chain is done.
+        processors=[
+            # Remove _record & _from_structlog.
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            log_renderer,
+        ],
+    )
+
+    handler = logging.StreamHandler()
+    # Use OUR `ProcessorFormatter` to format all `logging` entries.
+    handler.setFormatter(formatter)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(log_level.upper())
+
+    for _log in ["uvicorn", "uvicorn.error"]:
+        # Clear the log handlers for uvicorn loggers, and enable propagation
+        # so the messages are caught by our root logger and formatted correctly
+        # by structlog
+        logging.getLogger(_log).handlers.clear()
+        logging.getLogger(_log).propagate = True
+
+    # Since we re-create the access logs ourselves, to add all information
+    # in the structured log (see the `logging_middleware` in main.py), we clear
+    # the handlers and prevent the logs to propagate to a logger higher up in the
+    # hierarchy (effectively rendering them silent).
+    logging.getLogger("uvicorn.access").handlers.clear()
+    logging.getLogger("uvicorn.access").propagate = False
+
+    def handle_exception(exc_type, exc_value, exc_traceback):
+        """
+        Log any uncaught exception instead of letting it be printed by Python
+        (but leave KeyboardInterrupt untouched to allow users to Ctrl+C to stop)
+        See https://stackoverflow.com/a/16993115/3641865
+        """
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_traceback)
+            return
+
+        root_logger.error(
+            "Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback)
+        )
+
+    sys.excepthook = handle_exception

--- a/backend/api/core/logging.py
+++ b/backend/api/core/logging.py
@@ -3,6 +3,7 @@ import sys
 
 import structlog
 from structlog.types import EventDict, Processor
+from structlog_sentry import SentryProcessor
 
 # inspired by https://gist.github.com/nymous/f138c7f06062b7c43c060bf03759c29e
 
@@ -41,6 +42,7 @@ def setup_logging(json_logs: bool, log_level: str):
         drop_color_message_key,
         timestamper,
         structlog.processors.StackInfoRenderer(),
+        SentryProcessor(event_level=logging.ERROR),
     ]
 
     if json_logs:

--- a/backend/api/core/sendmail.py
+++ b/backend/api/core/sendmail.py
@@ -23,8 +23,6 @@ def send_mail(to: str, subject: str, message: str) -> None:
     msg.attach(part1)
     s = smtplib.SMTP(settings.smtp_host, int(settings.smtp_port))
 
-    s.set_debuglevel(True)
-
     if "maildev" not in settings.smtp_host:
         s.starttls()
 
@@ -41,6 +39,6 @@ def send_mail(to: str, subject: str, message: str) -> None:
     except smtplib.SMTPDataError as err:
         logging.error("sendmail error: %s", err)
     except smtplib.SMTPNotSupportedError as err:
-        logging.error("send mail error %s", err)
+        logging.error("sendmail error %s", err)
     finally:
         s.quit()

--- a/backend/api/core/sendmail.py
+++ b/backend/api/core/sendmail.py
@@ -5,8 +5,6 @@ from email.mime.text import MIMEText
 
 from api.core.settings import settings
 
-logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
-
 
 def send_mail(to: str, subject: str, message: str) -> None:
     if not settings.smtp_host or not settings.smtp_port:

--- a/backend/api/core/settings.py
+++ b/backend/api/core/settings.py
@@ -28,7 +28,8 @@ class Settings(BaseSettings):
     V1_PREFIX: str = "/v1"
     MAIL_FROM: str = "support.carnet-de-bord@fabrique.social.gouv.fr"
     LOG_FORMAT = "[%(asctime)s:%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
-    LOG_LEVEL: str
+    LOG_LEVEL: str = "INFO"
+    LOG_AS_JSON: bool = True
 
     @validator("LOG_LEVEL")
     def uppercase(raw: str) -> str:

--- a/backend/api/core/settings.py
+++ b/backend/api/core/settings.py
@@ -1,6 +1,6 @@
 import os
 
-from pydantic import BaseSettings
+from pydantic import BaseSettings, validator
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -28,6 +28,11 @@ class Settings(BaseSettings):
     V1_PREFIX: str = "/v1"
     MAIL_FROM: str = "support.carnet-de-bord@fabrique.social.gouv.fr"
     LOG_FORMAT = "[%(asctime)s:%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
+    LOG_LEVEL: str
+
+    @validator("LOG_LEVEL")
+    def uppercase(raw: str) -> str:
+        return raw.upper()
 
     class Config:
         env_file = ".env"

--- a/backend/api/core/settings.py
+++ b/backend/api/core/settings.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     LOG_AS_JSON: bool = True
 
+    SENTRY_DSN: str | None
+    SENTRY_ENVIRONMENT: str | None
+
     @validator("LOG_LEVEL")
     def uppercase(raw: str) -> str:
         return raw.upper()

--- a/backend/api/db/crud/orientation_manager.py
+++ b/backend/api/db/crud/orientation_manager.py
@@ -5,7 +5,6 @@ from uuid import UUID
 from asyncpg import Record
 from asyncpg.connection import Connection
 
-from api.core.settings import settings
 from api.db.crud.account import (
     create_username,
     get_accounts_with_query,
@@ -16,8 +15,6 @@ from api.db.models.orientation_manager import (
     OrientationManagerCsvRow,
     OrientationManagerDB,
 )
-
-logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
 
 def parse_orientation_manager_from_record(record: Record) -> OrientationManagerDB:

--- a/backend/api/db/models/structure.py
+++ b/backend/api/db/models/structure.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 from uuid import UUID
 
@@ -6,11 +5,8 @@ from luhn_validator import validate as validate_luhn
 from pandas.core.series import Series
 from pydantic import BaseModel, EmailStr, Field, HttpUrl, ValidationError, validator
 
-from api.core.settings import settings
 from api.db.models.csv import CsvFieldError
 from api.db.models.validator import phone_validator, postal_code_validator
-
-logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
 
 class StructureInsert(BaseModel):

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -9,7 +9,11 @@ from api.core.init import create_app
 from api.core.logging import setup_logging
 from api.core.settings import settings
 
-sentry_sdk.init(attach_stacktrace=True)
+sentry_sdk.init(
+    attach_stacktrace=True,
+    dsn=settings.SENTRY_DSN,
+    environment=settings.SENTRY_ENVIRONMENT,
+)
 
 setup_logging(json_logs=settings.LOG_AS_JSON, log_level=settings.LOG_LEVEL)
 access_logger = structlog.stdlib.get_logger("api.access")
@@ -28,7 +32,6 @@ async def logging_middleware(request: Request, call_next) -> Response:
     try:
         response = await call_next(request)
     except Exception:
-        # Est-ce qu'on devrait envoyer l'exception à Sentry ?
         structlog.stdlib.get_logger("api.error").exception("Uncaught exception")
         raise
     finally:

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,21 +1,58 @@
-import logging
+import time
 
 import sentry_sdk
-from pythonjsonlogger import jsonlogger
+import structlog
+from fastapi import Request, Response
+from uvicorn.protocols.utils import get_path_with_query_string
 
 from api.core.init import create_app
+from api.core.logging import setup_logging
 from api.core.settings import settings
-
-uvicorn_logger = logging.getLogger("uvicorn")
-uvicorn_logger.removeHandler(uvicorn_logger.handlers[0])
-
-logger = logging.getLogger()
-logHandler = logging.StreamHandler()
-logger.setLevel(settings.LOG_LEVEL)
-formatter = jsonlogger.JsonFormatter()
-logHandler.setFormatter(formatter)
-logger.addHandler(logHandler)
 
 sentry_sdk.init(attach_stacktrace=True)
 
+setup_logging(json_logs=settings.LOG_AS_JSON, log_level=settings.LOG_LEVEL)
+access_logger = structlog.stdlib.get_logger("api.access")
+
 app = create_app()
+
+
+@app.middleware("http")
+async def logging_middleware(request: Request, call_next) -> Response:
+    structlog.contextvars.clear_contextvars()
+
+    start_time = time.perf_counter_ns()
+    # If the call_next raises an error, we still want to return our own 500 response,
+    # so we can add headers to it (process time, request ID...)
+    response = Response(status_code=500)
+    try:
+        response = await call_next(request)
+    except Exception:
+        # Est-ce qu'on devrait envoyer l'exception à Sentry ?
+        structlog.stdlib.get_logger("api.error").exception("Uncaught exception")
+        raise
+    finally:
+        process_time = time.perf_counter_ns() - start_time
+        status_code = response.status_code
+        url = get_path_with_query_string(request.scope)
+        client_host = request.client.host
+        client_port = request.client.port
+        http_method = request.method
+        http_version = request.scope["http_version"]
+        # Recreate the Uvicorn access log format, but add all parameters as structured information
+        access_logger.info(
+            f"""{client_host}:{client_port} - "{http_method} {url} HTTP/{http_version}" {status_code}""",
+            http={
+                "url": str(request.url),
+                "status_code": status_code,
+                "method": http_method,
+                "version": http_version,
+            },
+            network={"client": {"ip": client_host, "port": client_port}},
+            duration=process_time,
+            response={
+                "body": response,
+            },
+        )
+        response.headers["X-Process-Time"] = str(process_time / 10**9)
+        return response

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -6,9 +6,12 @@ from pythonjsonlogger import jsonlogger
 from api.core.init import create_app
 from api.core.settings import settings
 
-logging.basicConfig(level=settings.LOG_LEVEL, format=settings.LOG_FORMAT)
+uvicorn_logger = logging.getLogger("uvicorn")
+uvicorn_logger.removeHandler(uvicorn_logger.handlers[0])
+
 logger = logging.getLogger()
 logHandler = logging.StreamHandler()
+logger.setLevel(settings.LOG_LEVEL)
 formatter = jsonlogger.JsonFormatter()
 logHandler.setFormatter(formatter)
 logger.addHandler(logHandler)

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,6 +1,17 @@
+import logging
+
 import sentry_sdk
+from pythonjsonlogger import jsonlogger
 
 from api.core.init import create_app
+from api.core.settings import settings
+
+logging.basicConfig(level=settings.LOG_LEVEL, format=settings.LOG_FORMAT)
+logger = logging.getLogger()
+logHandler = logging.StreamHandler()
+formatter = jsonlogger.JsonFormatter()
+logHandler.setFormatter(formatter)
+logger.addHandler(logHandler)
 
 sentry_sdk.init(attach_stacktrace=True)
 

--- a/backend/api/v1/routers/admin_structures.py
+++ b/backend/api/v1/routers/admin_structures.py
@@ -6,7 +6,6 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
 from api.core.emails import send_invitation_email
 from api.core.init import connection
-from api.core.settings import settings
 from api.db.crud.admin_structure import (
     create_admin_structure_with_account,
     get_admin_structure_by_email,
@@ -16,8 +15,6 @@ from api.db.models.account import AccountDB
 from api.db.models.admin_structure import AdminStructure, AdminStructureStructureInput
 from api.db.models.role import RoleEnum
 from api.v1.dependencies import allowed_jwt_roles
-
-logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
 admin_only = allowed_jwt_roles([RoleEnum.ADMIN_CDB, RoleEnum.ADMIN_STRUCTURE])
 

--- a/backend/api/v1/routers/csv2json.py
+++ b/backend/api/v1/routers/csv2json.py
@@ -1,4 +1,3 @@
-import logging
 from io import BytesIO
 
 import chardet
@@ -8,15 +7,12 @@ import pandas as pd
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from pandas import DataFrame
 
-from api.core.settings import settings
 from api.db.models.beneficiary import BeneficiaryCsvRowResponse
 from api.db.models.beneficiary import map_csv_row as map_csv_row_beneficiary
 from api.db.models.role import RoleEnum
 from api.db.models.structure import StructureCsvRowResponse
 from api.db.models.structure import map_csv_row as map_csv_row_structure
 from api.v1.dependencies import allowed_jwt_roles, extract_deployment_id
-
-logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
 manager_only = allowed_jwt_roles([RoleEnum.MANAGER])
 

--- a/backend/api/v1/routers/managers.py
+++ b/backend/api/v1/routers/managers.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
 from api.core.emails import send_invitation_email
 from api.core.init import connection
-from api.core.settings import settings
 from api.db.crud.account import (
     create_username,
     get_accounts_with_query,
@@ -15,8 +14,6 @@ from api.db.models.account import AccountDBWithAccessKey
 from api.db.models.manager import Manager, ManagerInput
 from api.db.models.role import RoleEnum
 from api.v1.dependencies import allowed_jwt_roles
-
-logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
 admin_cdb_only = allowed_jwt_roles([RoleEnum.ADMIN_CDB])
 

--- a/backend/api/v1/routers/structures.py
+++ b/backend/api/v1/routers/structures.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 
 from api.core.exceptions import InsertFailError
 from api.core.init import connection
-from api.core.settings import settings
 from api.db.crud.admin_structure import (
     create_admin_structure_with_account,
     get_admin_structure_by_email,
@@ -29,8 +28,6 @@ from api.db.models.structure import (
 )
 from api.v1.dependencies import allowed_jwt_roles, extract_deployment_id
 from api.v1.routers.admin_structures import send_invitation_email
-
-logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
 admin_only = allowed_jwt_roles([RoleEnum.MANAGER])
 

--- a/backend/api/v1/routers/uploads.py
+++ b/backend/api/v1/routers/uploads.py
@@ -22,7 +22,6 @@ from pydantic import ValidationError
 from api.core.emails import send_invitation_email
 from api.core.exceptions import InsertFailError
 from api.core.init import connection
-from api.core.settings import settings
 from api.db.crud.orientation_manager import create_orientation_manager_with_account
 from api.db.models.account import AccountDBWithAccessKey
 from api.db.models.orientation_manager import (
@@ -34,8 +33,6 @@ from api.db.models.orientation_manager import (
 )
 from api.db.models.role import RoleEnum
 from api.v1.dependencies import allowed_jwt_roles, extract_deployment_id
-
-logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
 manager_only = allowed_jwt_roles([RoleEnum.MANAGER])
 

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -864,6 +864,18 @@ tests = ["coverage[toml]", "freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "
 typing = ["mypy", "rich", "twisted"]
 
 [[package]]
+name = "structlog-sentry"
+version = "2.0.0"
+description = "Sentry integration for structlog"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+sentry-sdk = "*"
+structlog = "*"
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -971,7 +983,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "560fb34d81ead6c1d0d1ebafe84a0767476b7c5c4860ab038aa70c425429d746"
+content-hash = "7def1eeff7b901ec64fd9f99fdbae7e38e19e98b2df4970a698f6edacdf09ae4"
 
 [metadata.files]
 aiohttp = [
@@ -1690,6 +1702,10 @@ StrEnum = [
 structlog = [
     {file = "structlog-22.3.0-py3-none-any.whl", hash = "sha256:b403f344f902b220648fa9f286a23c0cc5439a5844d271fec40562dbadbc70ad"},
     {file = "structlog-22.3.0.tar.gz", hash = "sha256:e7509391f215e4afb88b1b80fa3ea074be57a5a17d794bd436a5c949da023333"},
+]
+structlog-sentry = [
+    {file = "structlog-sentry-2.0.0.tar.gz", hash = "sha256:0149f42a51b32deb036fa4fdb8a77d106b08cf227c963f28faf1abcbb3b38b2d"},
+    {file = "structlog_sentry-2.0.0-py3-none-any.whl", hash = "sha256:67e9d56a73b9a09b3122f0beb5da3706423d890ae440961c8f8e9b0b7bd1e1fa"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -79,7 +79,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "backoff"
@@ -114,7 +114,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -318,7 +318,7 @@ botocore = ["botocore (>=1.21,<2)"]
 dev = ["aiofiles", "aiohttp (>=3.7.1,<3.9.0)", "black (==22.3.0)", "botocore (>=1.21,<2)", "check-manifest (>=0.42,<1)", "flake8 (==3.8.1)", "isort (==4.3.21)", "mock (==4.0.2)", "mypy (==0.910)", "parse (==1.15.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "requests (>=2.26,<3)", "requests-toolbelt (>=0.9.1,<1)", "sphinx (>=3.0.0,<4)", "sphinx-argparse (==0.2.5)", "sphinx-rtd-theme (>=0.4,<1)", "types-aiofiles", "types-mock", "types-requests", "urllib3 (>=1.26)", "vcrpy (==4.0.2)", "websockets (>=10,<11)", "websockets (>=9,<10)"]
 requests = ["requests (>=2.26,<3)", "requests-toolbelt (>=0.9.1,<1)", "urllib3 (>=1.26)"]
 test = ["aiofiles", "aiohttp (>=3.7.1,<3.9.0)", "botocore (>=1.21,<2)", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "requests (>=2.26,<3)", "requests-toolbelt (>=0.9.1,<1)", "urllib3 (>=1.26)", "vcrpy (==4.0.2)", "websockets (>=10,<11)", "websockets (>=9,<10)"]
-test_no_transport = ["aiofiles", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "vcrpy (==4.0.2)"]
+test-no-transport = ["aiofiles", "mock (==4.0.2)", "parse (==1.15.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-console-scripts (==1.3.1)", "pytest-cov (==3.0.0)", "vcrpy (==4.0.2)"]
 websockets = ["websockets (>=10,<11)", "websockets (>=9,<10)"]
 
 [[package]]
@@ -676,6 +676,14 @@ python-versions = ">=3.7"
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-json-logger"
+version = "2.0.4"
+description = "A python library adding a json log formatter"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "python-magic"
 version = "0.4.27"
 description = "File type identification using libmagic"
@@ -726,7 +734,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "respx"
@@ -776,7 +784,7 @@ falcon = ["falcon (>=1.4)"]
 fastapi = ["fastapi (>=0.79.0)"]
 flask = ["blinker (>=1.1)", "flask (>=0.11)"]
 httpx = ["httpx (>=0.16.0)"]
-pure_eval = ["asttokens", "executing", "pure-eval"]
+pure-eval = ["asttokens", "executing", "pure-eval"]
 pyspark = ["pyspark (>=2.4.4)"]
 quart = ["blinker (>=1.1)", "quart (>=0.16.1)"]
 rq = ["rq (>=0.6)"]
@@ -957,7 +965,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "b35279541d1e81767d5c0c76cb7e8de91170625724b59846e80e7a46bc855c30"
+content-hash = "7b32e77c2841f8012fc31da59b148dbc212cbd8c7af3ba064011d71f6fe6cd6e"
 
 [metadata.files]
 aiohttp = [
@@ -1579,6 +1587,10 @@ python-dateutil = [
 python-dotenv = [
     {file = "python-dotenv-0.21.0.tar.gz", hash = "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"},
     {file = "python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
+]
+python-json-logger = [
+    {file = "python-json-logger-2.0.4.tar.gz", hash = "sha256:764d762175f99fcc4630bd4853b09632acb60a6224acb27ce08cd70f0b1b81bd"},
+    {file = "python_json_logger-2.0.4-py3-none-any.whl", hash = "sha256:3b03487b14eb9e4f77e4fc2a023358b5394b82fd89cecf5586259baed57d8c6f"},
 ]
 python-magic = [
     {file = "python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b"},

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -676,14 +676,6 @@ python-versions = ">=3.7"
 cli = ["click (>=5.0)"]
 
 [[package]]
-name = "python-json-logger"
-version = "2.0.4"
-description = "A python library adding a json log formatter"
-category = "main"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
 name = "python-magic"
 version = "0.4.27"
 description = "File type identification using libmagic"
@@ -858,6 +850,20 @@ release = ["twine"]
 test = ["pylint", "pytest", "pytest-black", "pytest-cov", "pytest-pylint"]
 
 [[package]]
+name = "structlog"
+version = "22.3.0"
+description = "Structured Logging for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+dev = ["structlog[docs,tests,typing]"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "twisted"]
+tests = ["coverage[toml]", "freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "simplejson"]
+typing = ["mypy", "rich", "twisted"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -965,7 +971,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "7b32e77c2841f8012fc31da59b148dbc212cbd8c7af3ba064011d71f6fe6cd6e"
+content-hash = "560fb34d81ead6c1d0d1ebafe84a0767476b7c5c4860ab038aa70c425429d746"
 
 [metadata.files]
 aiohttp = [
@@ -1588,10 +1594,6 @@ python-dotenv = [
     {file = "python-dotenv-0.21.0.tar.gz", hash = "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"},
     {file = "python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
 ]
-python-json-logger = [
-    {file = "python-json-logger-2.0.4.tar.gz", hash = "sha256:764d762175f99fcc4630bd4853b09632acb60a6224acb27ce08cd70f0b1b81bd"},
-    {file = "python_json_logger-2.0.4-py3-none-any.whl", hash = "sha256:3b03487b14eb9e4f77e4fc2a023358b5394b82fd89cecf5586259baed57d8c6f"},
-]
 python-magic = [
     {file = "python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b"},
     {file = "python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"},
@@ -1684,6 +1686,10 @@ starlette = [
 StrEnum = [
     {file = "StrEnum-0.4.8-py3-none-any.whl", hash = "sha256:36de425703f97511326b358dfd25939c9dabb4bee1ca15663570ba7cb8b5fa9c"},
     {file = "StrEnum-0.4.8.tar.gz", hash = "sha256:08a7647f4fac2977470e5618cccd5e8b939768f02e5f5dd7864adaa329559949"},
+]
+structlog = [
+    {file = "structlog-22.3.0-py3-none-any.whl", hash = "sha256:b403f344f902b220648fa9f286a23c0cc5439a5844d271fec40562dbadbc70ad"},
+    {file = "structlog-22.3.0.tar.gz", hash = "sha256:e7509391f215e4afb88b1b80fa3ea074be57a5a17d794bd436a5c949da023333"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,6 +35,7 @@ respx = "^0.20.0"
 luhn-validator = "^1.1.4"
 phonenumbers = "^8.12.56"
 gql = {extras = ["aiohttp"], version = "^3.4.0"}
+python-json-logger = "^2.0.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,6 +36,7 @@ luhn-validator = "^1.1.4"
 phonenumbers = "^8.12.56"
 gql = {extras = ["aiohttp"], version = "^3.4.0"}
 structlog = "^22.3.0"
+structlog-sentry = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,7 +35,7 @@ respx = "^0.20.0"
 luhn-validator = "^1.1.4"
 phonenumbers = "^8.12.56"
 gql = {extras = ["aiohttp"], version = "^3.4.0"}
-python-json-logger = "^2.0.4"
+structlog = "^22.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"


### PR DESCRIPTION
## :wrench: Problème

Les logs de l'application backend ne sont pas au format JSON.
Cela n'est pas pratique à manipuler avec des scripts ou outils de gestion des logs.

## :cake: Solution

On utilise `structlog` comme indiqué dans ce [gist](https://gist.github.com/nymous/f138c7f06062b7c43c060bf03759c29e).
Avec la variable d'environnement `LOG_AS_JSON` on peut choisir si on veut des logs au format JSON ou non.
Par défaut, on considère que oui (pratique pour tous les environements de déploiement actuels).
En local, on peut décider que non via le fichier `.env` (le fichier `.env.sample` a été mis à jour).

Chaque requête http fait désormais l'objet d'un log.

## :rotating_light:  Points d'attention / Remarques

Pour conserver le comportement actuel des `logging.error` qui envoie l'erreur à Sentry, nous avons ajouté `structlog_sentry`.

## :desert_island: Comment tester

Faire un appel http à l'API.
Vérifier dans les logs scalingo que ceux-ci sont en JSON.

Exemple de log :
```
{"http": {"url": "http://localhost:8000/healthz", "status_code": 200, "method": "GET", "version": "1.1"}, "network": {"client": {"ip": "127.0.0.1", "port": 55501}}, "duration": 776017, "response": {"body": "<starlette.responses.StreamingResponse object at 0x11a6dc7f0>"}, "logger": "api.access", "level": "info", "timestamp": "2022-12-05T21:15:14.585232Z", "message": "127.0.0.1:55501 - \"GET /healthz HTTP/1.1\" 200"}
```

<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Ne pas supprimer ce bloc, qui sera mis à jour [automatiquement](.github/workflows/review-scalingo.yml).
<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
