### PR TITLE
fix: Afficher la nouvelle structure de rattachement dans la liste des bénéficiaires.

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -5904,8 +5904,8 @@ export type NotebookEvent = {
 	__typename?: 'notebook_event';
 	creationDate: Scalars['timestamptz'];
 	/** An object relationship */
-	creator: Account;
-	creatorId: Scalars['uuid'];
+	creator?: Maybe<Account>;
+	creatorId?: Maybe<Scalars['uuid']>;
 	event: Scalars['jsonb'];
 	eventDate: Scalars['timestamptz'];
 	eventType: NotebookEventTypeEnum;
@@ -14226,15 +14226,15 @@ export type GetNotebookQuery = {
 			eventDate: string;
 			event: any;
 			eventType: NotebookEventTypeEnum;
-			creatorId: string;
-			creator: {
+			creatorId?: string | null;
+			creator?: {
 				__typename?: 'account';
 				professional?: {
 					__typename?: 'professional';
 					structureId: string;
 					structure: { __typename?: 'structure'; name: string };
 				} | null;
-			};
+			} | null;
 		}>;
 	} | null;
 };
@@ -14253,15 +14253,15 @@ export type GetNotebookEventsQuery = {
 		eventDate: string;
 		event: any;
 		eventType: NotebookEventTypeEnum;
-		creatorId: string;
-		creator: {
+		creatorId?: string | null;
+		creator?: {
 			__typename?: 'account';
 			professional?: {
 				__typename?: 'professional';
 				structureId: string;
 				structure: { __typename?: 'structure'; name: string };
 			} | null;
-		};
+		} | null;
 	}>;
 };
 
@@ -14271,15 +14271,15 @@ export type EventFieldsFragment = {
 	eventDate: string;
 	event: any;
 	eventType: NotebookEventTypeEnum;
-	creatorId: string;
-	creator: {
+	creatorId?: string | null;
+	creator?: {
 		__typename?: 'account';
 		professional?: {
 			__typename?: 'professional';
 			structureId: string;
 			structure: { __typename?: 'structure'; name: string };
 		} | null;
-	};
+	} | null;
 };
 
 export type GetNotebookMemberByIdQueryVariables = Exact<{
@@ -16229,6 +16229,31 @@ export const GetBeneficiariesDocument = {
 								{
 									kind: 'Field',
 									name: { kind: 'Name', value: 'structures' },
+									arguments: [
+										{
+											kind: 'Argument',
+											name: { kind: 'Name', value: 'where' },
+											value: {
+												kind: 'ObjectValue',
+												fields: [
+													{
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: 'status' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: '_neq' },
+																	value: { kind: 'StringValue', value: 'outdated', block: false },
+																},
+															],
+														},
+													},
+												],
+											},
+										},
+									],
 									selectionSet: {
 										kind: 'SelectionSet',
 										selections: [
@@ -23079,6 +23104,31 @@ export const BeneficiariesWithOrientationRequestDocument = {
 								{
 									kind: 'Field',
 									name: { kind: 'Name', value: 'structures' },
+									arguments: [
+										{
+											kind: 'Argument',
+											name: { kind: 'Name', value: 'where' },
+											value: {
+												kind: 'ObjectValue',
+												fields: [
+													{
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: 'status' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: '_neq' },
+																	value: { kind: 'StringValue', value: 'outdated', block: false },
+																},
+															],
+														},
+													},
+												],
+											},
+										},
+									],
 									selectionSet: {
 										kind: 'SelectionSet',
 										selections: [

--- a/app/src/lib/ui/BeneficiaryList/_getBeneficiaries.gql
+++ b/app/src/lib/ui/BeneficiaryList/_getBeneficiaries.gql
@@ -29,7 +29,7 @@ query GetBeneficiaries(
         needOrientation
       }
     }
-    structures {
+    structures(where: { status: { _neq: "outdated" } }) {
       structure {
         id
         name

--- a/app/src/routes/(auth)/orientation/demandes/_getBeneficiariesWithOrientationRequest.gql
+++ b/app/src/routes/(auth)/orientation/demandes/_getBeneficiariesWithOrientationRequest.gql
@@ -5,7 +5,7 @@ query BeneficiariesWithOrientationRequest {
     id
     firstname
     lastname
-    structures {
+    structures(where: { status: { _neq: "outdated" } }) {
       structure {
         id
         name


### PR DESCRIPTION
## :wrench: Problème

Lors d'un rattachement après une orientation / réorientation (avec ou sans demande), la structure de rattachement affichée dans la liste des bénéficiaires n'est pas la nouvelle structure mais toujours l'ancienne.

## :cake: Solution

Lors d'un changement d'orientation, on ne supprime pas la ligne `beneficiary_structure` mais on la modifie avec le statut `outdated` puis on en crée une nouvelle pour modéliser le rattachement à la nouvelle structure.
Lors de l'affichage de la liste des bénéficiaires, on ne filtre pas les structures mais le code assume que la première structure est la bonne et donc affiche toujours la toute première structure de rattachement du bénéficiaire.

Pour corriger ce comportement, on ajoute un filtre sur le statut pour exclure les `beneficiary_structure` dont le statut est `outdated`.
On choisit cette solution plutôt que d'agir sur les permissions afin d'être plus souple si par la suite on souhaite affiche l'ensemble des structures à laquelle à été rattaché un bénéficiaire.

## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester
<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1336.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

Se connecter en tant que `giulia.diaby`.
Se rendre sur la liste des bénéficiaires.
Ouvrir un carnet de bord.
Changer la structure de rattachement du bénéficiaire via le bouton `Orienter/Réorienter`.
Retourner sur la liste des bénéficiaires.
Constater que la structure affichée pour le bénéficiaire orienté est bien la nouvelle structure de rattachement.

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
