### PR TITLE
feat: accès au carnet en lecture seule

### DIFF
--- a/app/elm/ReadOnlyNotebook/Main.elm
+++ b/app/elm/ReadOnlyNotebook/Main.elm
@@ -1,0 +1,261 @@
+module ReadOnlyNotebook.Main exposing (..)
+
+import Browser
+import Html exposing (Html, a, div, h2, h3, p, text)
+import Html.Attributes exposing (class, href, title)
+import Http
+import Json.Decode
+import Json.Encode
+
+
+type alias Token =
+    String
+
+
+type alias Flags =
+    { token : Token
+    , serverUrl : String
+    , notebookId : String
+    }
+
+
+type alias Model =
+    { token : Token
+    , serverUrl : String
+    , notebookId : String
+    , notebook : NotebookLoadingState
+    }
+
+
+type NotebookLoadingState
+    = Loaded Notebook
+    | Loading
+    | LoadingError
+
+
+type Msg
+    = NotebookResult (Result Http.Error Notebook)
+
+
+type alias Notebook =
+    { beneficiary : Beneficiary
+    , members : List NotebookMember
+    }
+
+
+type alias Beneficiary =
+    { id : String
+    , firstname : String
+    , lastname : String
+    , mobileNumber : String
+    , email : String
+    , dateOfBirth : String
+    , address1 : String
+    , address2 : String
+    , city : String
+    , postalCode : String
+    , cafNumber : String
+    , peNumber : String
+    }
+
+
+type alias Structure =
+    { name : String
+    }
+
+
+type Account
+    = Pro
+        { firstname : String
+        , lastname : String
+        , position : String
+        , structure : Structure
+        }
+    | OrientationManager
+        { firstname : String
+        , lastname : String
+        }
+
+
+type alias NotebookMember =
+    { memberType : String
+    , account : Maybe Account
+    }
+
+
+type alias NotebookVariables =
+    { id : String
+    }
+
+
+type alias GqlQuery =
+    { query : String
+    , variables : NotebookVariables
+    }
+
+
+notebookDecoder : Json.Decode.Decoder Notebook
+notebookDecoder =
+    let
+        unOrientedBeneficiaryParser =
+            Json.Decode.field "data"
+                (Json.Decode.field "unorientedBeneficiaryCount"
+                    (Json.Decode.field "aggregate"
+                        (Json.Decode.field "count" Json.Decode.int)
+                    )
+                )
+
+        orientedBeneficiaryParser =
+            Json.Decode.field "data"
+                (Json.Decode.field "orientedBeneficiaryCount"
+                    (Json.Decode.field "aggregate"
+                        (Json.Decode.field "count" Json.Decode.int)
+                    )
+                )
+    in
+    Json.Decode.map2 Notebook
+        orientedBeneficiaryParser
+        unOrientedBeneficiaryParser
+
+
+encodeGqlQuery : GqlQuery -> Json.Encode.Value
+encodeGqlQuery record =
+    Json.Encode.object
+        [ ( "query", Json.Encode.string <| record.query )
+        , ( "variables", encodeGqlQueryVariables <| record.variables )
+        ]
+
+
+encodeGqlQueryVariables : NotebookVariables -> Json.Encode.Value
+encodeGqlQueryVariables record =
+    Json.Encode.object
+        [ ( "id", Json.Encode.string <| record.id )
+        ]
+
+
+getNotebook : Token -> String -> String -> (Result Http.Error Notebook -> msg) -> Cmd msg
+getNotebook token serverUrl notebookId toMsg =
+    let
+        gqlQuery =
+            { query = """
+query GetBeneficiaryDashboard($id: uuid!) {
+  unorientedBeneficiaryCount: beneficiary_aggregate(where: {
+    notebook: {
+      members: {accountId: {_eq: $id}},
+      notebookInfo: {needOrientation: {_eq: true}}
+    }}) {
+    aggregate {
+      count
+    }
+  }
+  orientedBeneficiaryCount: beneficiary_aggregate(where: {
+    notebook: {
+      members: {accountId: {_eq: $id}},
+      _not: {notebookInfo: {needOrientation: {_eq: true}}}
+    }}) {
+    aggregate {
+      count
+    }
+  }
+  orientationRequestCount: beneficiary_aggregate( where: {
+    notebook: { members: {accountId: {_eq: $id}} },
+    orientationRequest: { decidedAt: { _is_null: true } }
+    }) {
+    aggregate {
+      count
+    }
+  }
+  otherUnorientedBeneficiaryCount: beneficiary_aggregate(where: {
+    notebook: {
+      _and: [
+        {notebookInfo: {needOrientation: {_eq: true}}},
+        {_not: {members: {accountId: {_eq: $id}}}}
+      ]
+    }}) {
+    aggregate {
+      count
+    }
+  }
+  otherOrientedBeneficiaryCount: beneficiary_aggregate(where: {
+    notebook: {
+      _and: [
+        {_not: {notebookInfo: {needOrientation: {_eq: true}}}},
+        {_not: {members: {accountId: {_eq: $id}}}}
+      ]
+    }}) {
+    aggregate {
+      count
+    }
+  }
+  otherOrientationRequestCount: beneficiary_aggregate( where: {
+      notebook: { _not: { members: { accountId: { _eq: $id } } } }
+      orientationRequest: { decidedAt: { _is_null: true } }
+    }) {
+    aggregate {
+      count
+    }
+  }
+}
+      """
+            , variables = { id = notebookId }
+            }
+    in
+    Http.request
+        { method = "POST"
+        , headers = [ Http.header "authorization" ("Bearer " ++ token) ]
+        , url = serverUrl
+        , body = Http.jsonBody (encodeGqlQuery gqlQuery)
+        , expect = Http.expectJson toMsg notebookDecoder
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+main : Program Flags Model Msg
+main =
+    Browser.element
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
+
+
+init : Flags -> ( Model, Cmd Msg )
+init flags =
+    let
+        model =
+            { token = flags.token
+            , serverUrl = flags.serverUrl
+            , notebookId = flags.notebookId
+            , notebook = Loading
+            }
+    in
+    ( model
+    , getNotebook model.token
+        model.serverUrl
+        model.notebookId
+        NotebookResult
+    )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    Sub.none
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        NotebookResult result ->
+            case result of
+                Ok notebook ->
+                    ( { model | notebook = Loaded notebook }, Cmd.none )
+
+                Err _ ->
+                    ( { model | notebook = LoadingError }, Cmd.none )
+
+
+view : Model -> Html Msg
+view model =
+    text "coucou"

--- a/app/elm/ReadOnlyNotebook/Main.elm.d.ts
+++ b/app/elm/ReadOnlyNotebook/Main.elm.d.ts
@@ -9,6 +9,6 @@ export interface ElmApp {
 
 export type Flags = { [key: string]: any };
 
-export as namespace Elm;
+export as namespace ElmRo;
 
-export { Elm };
+export { ElmRo };

--- a/app/elm/ReadOnlyNotebook/Main.elm.d.ts
+++ b/app/elm/ReadOnlyNotebook/Main.elm.d.ts
@@ -1,0 +1,14 @@
+export namespace ReadOnlyNotebook.Main {
+	function init(options: { node?: HTMLElement | null; flags: Flags }): ElmApp;
+}
+export interface ElmApp {
+	ports: {
+		[key: string]: any;
+	};
+}
+
+export type Flags = { [key: string]: any };
+
+export as namespace Elm;
+
+export { Elm };

--- a/app/src/routes/(auth)/pro/carnet/[uuid]/infos/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/infos/+page.svelte
@@ -4,7 +4,7 @@
 
 	export let data: PageData;
 
-	import { Elm as ElmRO } from '../../../../../../../elm/ReadOnlyNotebook/Main.elm';
+	import { ElmRo as Elm } from '../../../../../../../elm/ReadOnlyNotebook/Main.elm';
 	import { onMount } from 'svelte';
 
 	let elmNode: HTMLElement;

--- a/app/src/routes/(auth)/pro/carnet/[uuid]/infos/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/infos/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { graphqlAPI, token } from '$lib/stores';
+
+	export let data: PageData;
+
+	import { Elm as ElmRO } from '../../../../../../../elm/ReadOnlyNotebook/Main.elm';
+	import { onMount } from 'svelte';
+
+	let elmNode: HTMLElement;
+	onMount(() => {
+		if (!elmNode) return;
+		Elm.ReadOnlyNotebook.Main.init({
+			node: elmNode,
+			flags: {
+				token: $token,
+				serverUrl: $graphqlAPI,
+				notebookId: data.notebookId,
+			},
+		});
+	});
+</script>
+
+<svelte:head>
+	<title>Informations du bénéficiaire - Carnet de bord</title>
+</svelte:head>
+
+<div>
+	<!-- Elm app needs to be wrapped by a div to avoid navigation exceptions when unmounting -->
+	<div bind:this={elmNode} />
+</div>

--- a/app/src/routes/(auth)/pro/carnet/[uuid]/infos/+page.ts
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/infos/+page.ts
@@ -1,0 +1,9 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = ({ params }) => {
+	const notebookId = params.uuid;
+
+	return {
+		notebookId,
+	};
+};

--- a/e2e/features/pro/carnet/read_only_other_notebook.feature
+++ b/e2e/features/pro/carnet/read_only_other_notebook.feature
@@ -1,0 +1,9 @@
+#language: fr
+
+Fonctionnalité: Accès en lecture seule à un carnet dont je ne suis pas membre
+	En tant que pro
+	Je veux uniquement voir les informations personnelles et le groupe de suivi du bénificiaire
+
+	Scénario: Accès au carnet
+		Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Henderson"
+		Alors j'attends que le texte "Myrna Henderson" apparaisse

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_beneficiary.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_beneficiary.yaml
@@ -282,11 +282,7 @@ select_permissions:
         - pe_number
         - postal_code
         - updated_at
-      filter:
-        notebook:
-          members:
-            account_id:
-              _eq: X-Hasura-User-Id
+      filter: {}
       allow_aggregations: true
 update_permissions:
   - role: admin_cdb

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook.yaml
@@ -347,13 +347,7 @@ select_permissions:
         - work_situation
         - work_situation_date
         - work_situation_end_date
-      filter:
-        members:
-          _and:
-            - account_id:
-                _eq: X-Hasura-User-Id
-            - active:
-                _eq: true
+      filter: {}
       allow_aggregations: true
 update_permissions:
   - role: admin_cdb

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_member.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_member.yaml
@@ -215,10 +215,6 @@ select_permissions:
         - notebook_id
       filter:
         _and:
-          - notebook:
-              members:
-                account_id:
-                  _eq: X-Hasura-User-Id
           - active:
               _eq: true
           - notebook:


### PR DESCRIPTION
## :wrench: Problème

Les professionnels ne peuvent pas accéder aux informations d'un bénéficiaire afin de les renseigner si ils ne sont pas dans le groupe de suivi

## :cake: Solution

Permettre aux profils pro de pouvoir accéder en lecture aux informations du carnet de la personne


## :rotating_light:  Points d'attention / Remarques

Afin de ne pas mélanger les carnets actuels très complets avec le peu d'informations à afficher sur cette page, nous avons choisi de partir sur une nouvelle route Svelte.
Puisque nous avions une nouvelle route Svelte, nous sommes naturellement partis sur une implémentation en Elm.

## :desert_island: Comment tester

@TODO

<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Ne pas supprimer ce bloc, qui sera mis à jour [automatiquement](.github/workflows/review-scalingo.yml).
<!-- END ## emplacement de l'URL de la review app ## -->

Fix #1324 
