### PR TITLE
fix(errors): meilleur traitement des réponses d'erreur JSON

### DIFF
--- a/app/src/hooks.server.ts
+++ b/app/src/hooks.server.ts
@@ -1,7 +1,7 @@
 import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { logger } from '$lib/utils/logger';
 import * as Sentry from '@sentry/node';
-import { initSentry } from '$lib/utils/sentry';
+import { initSentry, captureException } from '$lib/utils/sentry';
 
 initSentry(Sentry);
 
@@ -37,5 +37,5 @@ export const handleError: HandleServerError = ({ error, event }) => {
 		method: event.request.method,
 		url: event.url,
 	});
-	Sentry.captureException(err);
+	captureException(err);
 };

--- a/app/src/lib/ui/OrientationRequest/ChangeOrientationForm.svelte
+++ b/app/src/lib/ui/OrientationRequest/ChangeOrientationForm.svelte
@@ -9,6 +9,7 @@
 	import OrientationForm, {
 		type OrientationValidationSchema,
 	} from '../OrientationManager/OrientationForm.svelte';
+	import { captureException } from '$lib/utils/sentry';
 
 	export let notebook:
 		| GetNotebookByBeneficiaryIdQuery['notebook'][0]
@@ -35,6 +36,7 @@
 			);
 		} catch (err) {
 			console.error(err);
+			captureException(err);
 			displayError = true;
 			return;
 		}

--- a/app/src/lib/ui/OrientationRequest/DenyOrientationRequestConfirmation.svelte
+++ b/app/src/lib/ui/OrientationRequest/DenyOrientationRequestConfirmation.svelte
@@ -5,7 +5,7 @@
 	import { postApiJson } from '$lib/utils/post';
 	import Alert from '../base/Alert.svelte';
 	import { token } from '$lib/stores';
-	import * as Sentry from '@sentry/svelte';
+	import { captureException } from '$lib/utils/sentry';
 	export let orientationRequest: GetNotebookByBeneficiaryIdQuery['notebook'][0]['beneficiary']['orientationRequest'][0];
 	export let onBeneficiaryOrientationChanged: () => void;
 
@@ -21,7 +21,7 @@
 				{ 'jwt-token': $token }
 			);
 		} catch (err) {
-			Sentry.captureException(err);
+			captureException(err);
 			displayError = true;
 			return;
 		}

--- a/app/src/lib/utils/post.ts
+++ b/app/src/lib/utils/post.ts
@@ -42,13 +42,14 @@ async function handleResponse<T>(response: Response): Promise<T> {
 		return response.json();
 	}
 
+	let errorMessage;
 	if (response.headers.get('Content-type').includes('application/json')) {
-		const { message } = await response.json();
-		if (message) {
-			throw new HTTPError(message, response.status, response.statusText);
-		}
+		const errorBody = await response.json();
+		errorMessage = errorBody.errorMessage ?? errorBody.detail ?? JSON.stringify(errorBody);
+	} else {
+		errorMessage = await response.text();
 	}
-	const errorMessage = await response.text();
+
 	throw new HTTPError(errorMessage, response.status, response.statusText);
 }
 

--- a/app/src/lib/utils/post.ts
+++ b/app/src/lib/utils/post.ts
@@ -45,7 +45,7 @@ async function handleResponse<T>(response: Response): Promise<T> {
 	let errorMessage;
 	if (response.headers.get('Content-type').includes('application/json')) {
 		const errorBody = await response.json();
-		errorMessage = errorBody.errorMessage ?? errorBody.detail ?? JSON.stringify(errorBody);
+		errorMessage = errorBody.message ?? errorBody.detail ?? JSON.stringify(errorBody);
 	} else {
 		errorMessage = await response.text();
 	}

--- a/app/src/lib/utils/sentry.ts
+++ b/app/src/lib/utils/sentry.ts
@@ -5,6 +5,8 @@ type SentryInterface = {
 	init: (options: Options) => void;
 };
 
+let sentry;
+
 export function initSentry(Sentry: SentryInterface) {
 	if (!env.PUBLIC_SENTRY_DSN) {
 		return;
@@ -17,4 +19,11 @@ export function initSentry(Sentry: SentryInterface) {
 		release: `carnet-de-bord-app@${appVersion}`,
 		autoSessionTracking: false,
 	});
+
+	sentry = Sentry;
+}
+
+export function captureException(err: Error) {
+	console.error(err);
+	if (sentry) sentry.captureException(err);
 }


### PR DESCRIPTION
## :wrench: Problème

Quand un serveur appelé par l'application Svelte renvoyait une erreur au format JSON, si le JSON ne contenait pas de propriété `message` on tentait de récupérer le texte de la réponse comme message d'erreur. Mais il est interdit dans l'API `fetch` d'appeler `response.text()` après avoir appelé `response.json()`.

## :cake: Solution

Si la réponse est de type `application/json` on récupère son contenu avec `json()` puis si on ne trouve pas de propriété `message` (ni `detail`, qui est utilisé par défaut par FastAPI) on re-convertit tout le JSON en chaîne.

## :rotating_light:  Points d'attention / Remarques

On ajoute aussi une capture d'exception via Sentry.

## :desert_island: Comment tester

Faire une opération qui déclenche une réponse d'erreur. Par exemple (actuellement et jusqu'à ce que ce bug soit corrigé), tenter une réorientation quand on est connecté en tant qu'administrateur de structure ou de territoire.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1349.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
