### PR TITLE
fix: Accéder à l'annuaire directement depuis son URL entraine une erreur.

### DIFF
--- a/app/src/routes/(auth)/pro/annuaire/+page.svelte
+++ b/app/src/routes/(auth)/pro/annuaire/+page.svelte
@@ -10,6 +10,7 @@
 	import { operationStore, query } from '@urql/svelte';
 	import { browser } from '$app/environment';
 	import { addMonths } from 'date-fns';
+	import { accountData } from '$lib/stores';
 
 	import type { PageData } from './$types';
 	import { dt } from './+page';
@@ -17,7 +18,7 @@
 	export let data: PageData;
 
 	let searching = false;
-	const { accountId } = data;
+	const accountId = $accountData.id;
 	let { search, selected } = data;
 
 	const queryVariables = buildQueryVariables({
@@ -59,9 +60,9 @@
 	function updateResult() {
 		updateUrl(search, selected);
 		$result.variables = buildQueryVariables({
-			accountId: accountId,
-			search: search,
-			selected: selected,
+			accountId,
+			search,
+			selected,
 		});
 		$result.reexecute();
 	}

--- a/app/src/routes/(auth)/pro/annuaire/+page.ts
+++ b/app/src/routes/(auth)/pro/annuaire/+page.ts
@@ -1,6 +1,4 @@
 import type { PageLoad } from './$types';
-import { connectedUser } from '$lib/stores';
-import { get } from 'svelte/store';
 
 export const dt = {
 	none: 'none',
@@ -17,7 +15,6 @@ export const load: PageLoad = async ({ url }) => {
 	if (url.searchParams.get('dt') && dt[url.searchParams.get('dt')]) {
 		selected = dt[url.searchParams.get('dt')];
 	}
-	const { id: accountId } = get(connectedUser);
 
-	return { accountId, search, selected };
+	return { search, selected };
 };


### PR DESCRIPTION
## :wrench: Problème

Si un professionnel authentifié essaie d'accéder à la page de l'annuaire des bénéficiaires directement via son adresse (URL), la page échoue à se charger et une erreur est affichée.

Après investigation, on se rend compte que dans le cas d'un premier chargement, le `connectedUser` récupéré dans `pro/+page.ts` est `undefined`.
La tentative d'accès à l'id via une destructuration lève alors une exception `cannot destrcture id of undefined ...`.

## :cake: Solution

Il n'y a pas d'intérêt particulier à récupérer l'identifiant de l'utilisateur authentifié puis de le passer en contexte de la page.
On peut utiliser directement le store `accountData` depuis la page svelte et ainsi bénéficier du mécanisme de mise à jour lors de la mise à jour du store.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Se connecter sur https://cdb-app-review-pr1351.osc-fr1.scalingo.io en tant que pro.
Se rendre à l'adresse `https://cdb-app-review-pr1351.osc-fr1.scalingo.io/pro/annuaire`
Vérifier que l'annuaire des bénéficiaires est correctement affiché.

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
