### PR TITLE
feat: autoriser la recherche de tous les notebooks

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -9475,6 +9475,10 @@ export type QueryRoot = {
 	search_notebook_members: Array<NotebookMember>;
 	/** execute function "search_notebook_members" and query aggregates on result of table type "notebook_member" */
 	search_notebook_members_aggregate: NotebookMemberAggregate;
+	/** execute function "search_public_notebooks" which returns "notebook_public_view" */
+	search_public_notebooks: Array<NotebookPublicView>;
+	/** execute function "search_public_notebooks" and query aggregates on result of table type "notebook_public_view" */
+	search_public_notebooks_aggregate: NotebookPublicViewAggregate;
 	/** execute function "search_rome_codes" which returns "rome_code" */
 	search_rome_codes: Array<RomeCode>;
 	/** execute function "search_rome_codes" and query aggregates on result of table type "rome_code" */
@@ -10139,6 +10143,24 @@ export type QueryRootSearchNotebookMembersAggregateArgs = {
 	offset?: InputMaybe<Scalars['Int']>;
 	order_by?: InputMaybe<Array<NotebookMemberOrderBy>>;
 	where?: InputMaybe<NotebookMemberBoolExp>;
+};
+
+export type QueryRootSearchPublicNotebooksArgs = {
+	args: SearchPublicNotebooksArgs;
+	distinct_on?: InputMaybe<Array<NotebookPublicViewSelectColumn>>;
+	limit?: InputMaybe<Scalars['Int']>;
+	offset?: InputMaybe<Scalars['Int']>;
+	order_by?: InputMaybe<Array<NotebookPublicViewOrderBy>>;
+	where?: InputMaybe<NotebookPublicViewBoolExp>;
+};
+
+export type QueryRootSearchPublicNotebooksAggregateArgs = {
+	args: SearchPublicNotebooksArgs;
+	distinct_on?: InputMaybe<Array<NotebookPublicViewSelectColumn>>;
+	limit?: InputMaybe<Scalars['Int']>;
+	offset?: InputMaybe<Scalars['Int']>;
+	order_by?: InputMaybe<Array<NotebookPublicViewOrderBy>>;
+	where?: InputMaybe<NotebookPublicViewBoolExp>;
 };
 
 export type QueryRootSearchRomeCodesArgs = {
@@ -11001,6 +11023,10 @@ export type SearchNotebookMembersArgs = {
 	search?: InputMaybe<Scalars['String']>;
 };
 
+export type SearchPublicNotebooksArgs = {
+	search?: InputMaybe<Scalars['String']>;
+};
+
 export type SearchRomeCodesArgs = {
 	search?: InputMaybe<Scalars['String']>;
 };
@@ -11688,6 +11714,10 @@ export type SubscriptionRoot = {
 	search_notebook_members: Array<NotebookMember>;
 	/** execute function "search_notebook_members" and query aggregates on result of table type "notebook_member" */
 	search_notebook_members_aggregate: NotebookMemberAggregate;
+	/** execute function "search_public_notebooks" which returns "notebook_public_view" */
+	search_public_notebooks: Array<NotebookPublicView>;
+	/** execute function "search_public_notebooks" and query aggregates on result of table type "notebook_public_view" */
+	search_public_notebooks_aggregate: NotebookPublicViewAggregate;
 	/** execute function "search_rome_codes" which returns "rome_code" */
 	search_rome_codes: Array<RomeCode>;
 	/** execute function "search_rome_codes" and query aggregates on result of table type "rome_code" */
@@ -12542,6 +12572,24 @@ export type SubscriptionRootSearchNotebookMembersAggregateArgs = {
 	offset?: InputMaybe<Scalars['Int']>;
 	order_by?: InputMaybe<Array<NotebookMemberOrderBy>>;
 	where?: InputMaybe<NotebookMemberBoolExp>;
+};
+
+export type SubscriptionRootSearchPublicNotebooksArgs = {
+	args: SearchPublicNotebooksArgs;
+	distinct_on?: InputMaybe<Array<NotebookPublicViewSelectColumn>>;
+	limit?: InputMaybe<Scalars['Int']>;
+	offset?: InputMaybe<Scalars['Int']>;
+	order_by?: InputMaybe<Array<NotebookPublicViewOrderBy>>;
+	where?: InputMaybe<NotebookPublicViewBoolExp>;
+};
+
+export type SubscriptionRootSearchPublicNotebooksAggregateArgs = {
+	args: SearchPublicNotebooksArgs;
+	distinct_on?: InputMaybe<Array<NotebookPublicViewSelectColumn>>;
+	limit?: InputMaybe<Scalars['Int']>;
+	offset?: InputMaybe<Scalars['Int']>;
+	order_by?: InputMaybe<Array<NotebookPublicViewOrderBy>>;
+	where?: InputMaybe<NotebookPublicViewBoolExp>;
 };
 
 export type SubscriptionRootSearchRomeCodesArgs = {
@@ -14517,6 +14565,34 @@ export type SearchNotebookMemberQuery = {
 				}>;
 			};
 		};
+	}>;
+};
+
+export type SearchPublicNotebooksQueryVariables = Exact<{
+	filter?: InputMaybe<Scalars['String']>;
+}>;
+
+export type SearchPublicNotebooksQuery = {
+	__typename?: 'query_root';
+	search_public_notebooks: Array<{
+		__typename?: 'notebook_public_view';
+		id?: string | null;
+		beneficiary?: {
+			__typename?: 'beneficiary';
+			dateOfBirth: string;
+			firstname: string;
+			id: string;
+			lastname: string;
+			mobileNumber?: string | null;
+			orientationRequest: Array<{
+				__typename?: 'orientation_request';
+				id: string;
+				status?: string | null;
+				createdAt: string;
+				decidedAt?: string | null;
+				requestedOrientationType?: { __typename?: 'orientation_type'; label: string } | null;
+			}>;
+		} | null;
 	}>;
 };
 
@@ -22747,6 +22823,126 @@ export const SearchNotebookMemberDocument = {
 		},
 	],
 } as unknown as DocumentNode<SearchNotebookMemberQuery, SearchNotebookMemberQueryVariables>;
+export const SearchPublicNotebooksDocument = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'OperationDefinition',
+			operation: 'query',
+			name: { kind: 'Name', value: 'SearchPublicNotebooks' },
+			variableDefinitions: [
+				{
+					kind: 'VariableDefinition',
+					variable: { kind: 'Variable', name: { kind: 'Name', value: 'filter' } },
+					type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+				},
+			],
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'search_public_notebooks' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'args' },
+								value: {
+									kind: 'ObjectValue',
+									fields: [
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: 'search' },
+											value: { kind: 'Variable', name: { kind: 'Name', value: 'filter' } },
+										},
+									],
+								},
+							},
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'order_by' },
+								value: {
+									kind: 'ObjectValue',
+									fields: [
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: 'updated_at' },
+											value: { kind: 'EnumValue', value: 'desc_nulls_first' },
+										},
+									],
+								},
+							},
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'beneficiary' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'dateOfBirth' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'firstname' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'lastname' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'mobileNumber' } },
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'orientationRequest' },
+												arguments: [
+													{
+														kind: 'Argument',
+														name: { kind: 'Name', value: 'order_by' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'createdAt' },
+																	value: { kind: 'EnumValue', value: 'desc' },
+																},
+															],
+														},
+													},
+													{
+														kind: 'Argument',
+														name: { kind: 'Name', value: 'limit' },
+														value: { kind: 'IntValue', value: '1' },
+													},
+												],
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'status' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'decidedAt' } },
+														{
+															kind: 'Field',
+															name: { kind: 'Name', value: 'requestedOrientationType' },
+															selectionSet: {
+																kind: 'SelectionSet',
+																selections: [
+																	{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
+																],
+															},
+														},
+													],
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					},
+				],
+			},
+		},
+	],
+} as unknown as DocumentNode<SearchPublicNotebooksQuery, SearchPublicNotebooksQueryVariables>;
 export const GetNotebookDocument = {
 	kind: 'Document',
 	definitions: [
@@ -26671,6 +26867,10 @@ export type GetLastVisitedOrUpdatedQueryStore = OperationStore<
 export type SearchNotebookMemberQueryStore = OperationStore<
 	SearchNotebookMemberQuery,
 	SearchNotebookMemberQueryVariables
+>;
+export type SearchPublicNotebooksQueryStore = OperationStore<
+	SearchPublicNotebooksQuery,
+	SearchPublicNotebooksQueryVariables
 >;
 export type GetNotebookQueryStore = OperationStore<GetNotebookQuery, GetNotebookQueryVariables>;
 export type GetNotebookEventsQueryStore = OperationStore<

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -40,19 +40,6 @@ export type CreateDeploymentOutput = {
 	label: Scalars['String'];
 };
 
-/** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
-export type IntComparisonExp = {
-	_eq?: InputMaybe<Scalars['Int']>;
-	_gt?: InputMaybe<Scalars['Int']>;
-	_gte?: InputMaybe<Scalars['Int']>;
-	_in?: InputMaybe<Array<Scalars['Int']>>;
-	_is_null?: InputMaybe<Scalars['Boolean']>;
-	_lt?: InputMaybe<Scalars['Int']>;
-	_lte?: InputMaybe<Scalars['Int']>;
-	_neq?: InputMaybe<Scalars['Int']>;
-	_nin?: InputMaybe<Array<Scalars['Int']>>;
-};
-
 /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
 export type StringComparisonExp = {
 	_eq?: InputMaybe<Scalars['String']>;
@@ -261,33 +248,6 @@ export type AccountAggregate = {
 	nodes: Array<Account>;
 };
 
-export type AccountAggregateBoolExp = {
-	bool_and?: InputMaybe<AccountAggregateBoolExpBoolAnd>;
-	bool_or?: InputMaybe<AccountAggregateBoolExpBoolOr>;
-	count?: InputMaybe<AccountAggregateBoolExpCount>;
-};
-
-export type AccountAggregateBoolExpBoolAnd = {
-	arguments: AccountSelectColumnAccountAggregateBoolExpBoolAndArgumentsColumns;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<AccountBoolExp>;
-	predicate: BooleanComparisonExp;
-};
-
-export type AccountAggregateBoolExpBoolOr = {
-	arguments: AccountSelectColumnAccountAggregateBoolExpBoolOrArgumentsColumns;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<AccountBoolExp>;
-	predicate: BooleanComparisonExp;
-};
-
-export type AccountAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<AccountSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<AccountBoolExp>;
-	predicate: IntComparisonExp;
-};
-
 /** aggregate fields of "account" */
 export type AccountAggregateFields = {
 	__typename?: 'account_aggregate_fields';
@@ -337,17 +297,11 @@ export type AccountBoolExp = {
 	manager?: InputMaybe<ManagerBoolExp>;
 	managerId?: InputMaybe<UuidComparisonExp>;
 	notebookActionsCreated?: InputMaybe<NotebookActionBoolExp>;
-	notebookActionsCreated_aggregate?: InputMaybe<NotebookActionAggregateBoolExp>;
 	notebookEventsCreated?: InputMaybe<NotebookEventBoolExp>;
-	notebookEventsCreated_aggregate?: InputMaybe<NotebookEventAggregateBoolExp>;
 	notebookFocusesCreated?: InputMaybe<NotebookFocusBoolExp>;
-	notebookFocusesCreated_aggregate?: InputMaybe<NotebookFocusAggregateBoolExp>;
 	notebookTargetsCreated?: InputMaybe<NotebookTargetBoolExp>;
-	notebookTargetsCreated_aggregate?: InputMaybe<NotebookTargetAggregateBoolExp>;
 	notebooksCreated?: InputMaybe<NotebookMemberBoolExp>;
-	notebooksCreated_aggregate?: InputMaybe<NotebookMemberAggregateBoolExp>;
 	notebooksWhereMember?: InputMaybe<NotebookMemberBoolExp>;
-	notebooksWhereMember_aggregate?: InputMaybe<NotebookMemberAggregateBoolExp>;
 	onboardingDone?: InputMaybe<BooleanComparisonExp>;
 	orientationManagerId?: InputMaybe<UuidComparisonExp>;
 	orientation_manager?: InputMaybe<OrientationManagerBoolExp>;
@@ -678,22 +632,6 @@ export enum AccountSelectColumn {
 	UpdatedAt = 'updatedAt',
 	/** column name */
 	Username = 'username',
-}
-
-/** select "account_aggregate_bool_exp_bool_and_arguments_columns" columns of table "account" */
-export enum AccountSelectColumnAccountAggregateBoolExpBoolAndArgumentsColumns {
-	/** column name */
-	Confirmed = 'confirmed',
-	/** column name */
-	OnboardingDone = 'onboardingDone',
-}
-
-/** select "account_aggregate_bool_exp_bool_or_arguments_columns" columns of table "account" */
-export enum AccountSelectColumnAccountAggregateBoolExpBoolOrArgumentsColumns {
-	/** column name */
-	Confirmed = 'confirmed',
-	/** column name */
-	OnboardingDone = 'onboardingDone',
 }
 
 /** input type for updating data in table "account" */
@@ -1031,17 +969,6 @@ export type AdminStructureAggregate = {
 	nodes: Array<AdminStructure>;
 };
 
-export type AdminStructureAggregateBoolExp = {
-	count?: InputMaybe<AdminStructureAggregateBoolExpCount>;
-};
-
-export type AdminStructureAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<AdminStructureSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<AdminStructureBoolExp>;
-	predicate: IntComparisonExp;
-};
-
 /** aggregate fields of "admin_structure" */
 export type AdminStructureAggregateFields = {
 	__typename?: 'admin_structure_aggregate_fields';
@@ -1086,7 +1013,6 @@ export type AdminStructureBoolExp = {
 	phoneNumbers?: InputMaybe<StringComparisonExp>;
 	position?: InputMaybe<StringComparisonExp>;
 	structures?: InputMaybe<AdminStructureStructureBoolExp>;
-	structures_aggregate?: InputMaybe<AdminStructureStructureAggregateBoolExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 };
 
@@ -1287,17 +1213,6 @@ export type AdminStructureStructureAggregate = {
 	__typename?: 'admin_structure_structure_aggregate';
 	aggregate?: Maybe<AdminStructureStructureAggregateFields>;
 	nodes: Array<AdminStructureStructure>;
-};
-
-export type AdminStructureStructureAggregateBoolExp = {
-	count?: InputMaybe<AdminStructureStructureAggregateBoolExpCount>;
-};
-
-export type AdminStructureStructureAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<AdminStructureStructureSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<AdminStructureStructureBoolExp>;
-	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "admin_structure_structure" */
@@ -1602,17 +1517,6 @@ export type BeneficiaryAggregate = {
 	nodes: Array<Beneficiary>;
 };
 
-export type BeneficiaryAggregateBoolExp = {
-	count?: InputMaybe<BeneficiaryAggregateBoolExpCount>;
-};
-
-export type BeneficiaryAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<BeneficiarySelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<BeneficiaryBoolExp>;
-	predicate: IntComparisonExp;
-};
-
 /** aggregate fields of "beneficiary" */
 export type BeneficiaryAggregateFields = {
 	__typename?: 'beneficiary_aggregate_fields';
@@ -1665,13 +1569,11 @@ export type BeneficiaryBoolExp = {
 	notebook?: InputMaybe<NotebookBoolExp>;
 	notebook_public_view?: InputMaybe<NotebookPublicViewBoolExp>;
 	orientationRequest?: InputMaybe<OrientationRequestBoolExp>;
-	orientationRequest_aggregate?: InputMaybe<OrientationRequestAggregateBoolExp>;
 	peNumber?: InputMaybe<StringComparisonExp>;
 	peUniqueId?: InputMaybe<StringComparisonExp>;
 	placeOfBirth?: InputMaybe<StringComparisonExp>;
 	postalCode?: InputMaybe<StringComparisonExp>;
 	structures?: InputMaybe<BeneficiaryStructureBoolExp>;
-	structures_aggregate?: InputMaybe<BeneficiaryStructureAggregateBoolExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 };
 
@@ -1989,17 +1891,6 @@ export type BeneficiaryStructureAggregate = {
 	__typename?: 'beneficiary_structure_aggregate';
 	aggregate?: Maybe<BeneficiaryStructureAggregateFields>;
 	nodes: Array<BeneficiaryStructure>;
-};
-
-export type BeneficiaryStructureAggregateBoolExp = {
-	count?: InputMaybe<BeneficiaryStructureAggregateBoolExpCount>;
-};
-
-export type BeneficiaryStructureAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<BeneficiaryStructureSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<BeneficiaryStructureBoolExp>;
-	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "beneficiary_structure" */
@@ -2520,19 +2411,14 @@ export type DeploymentBoolExp = {
 	_not?: InputMaybe<DeploymentBoolExp>;
 	_or?: InputMaybe<Array<DeploymentBoolExp>>;
 	admin_structures?: InputMaybe<AdminStructureBoolExp>;
-	admin_structures_aggregate?: InputMaybe<AdminStructureAggregateBoolExp>;
 	beneficiaries?: InputMaybe<BeneficiaryBoolExp>;
-	beneficiaries_aggregate?: InputMaybe<BeneficiaryAggregateBoolExp>;
 	config?: InputMaybe<JsonbComparisonExp>;
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	id?: InputMaybe<UuidComparisonExp>;
 	label?: InputMaybe<StringComparisonExp>;
 	managers?: InputMaybe<ManagerBoolExp>;
-	managers_aggregate?: InputMaybe<ManagerAggregateBoolExp>;
 	orientation_managers?: InputMaybe<OrientationManagerBoolExp>;
-	orientation_managers_aggregate?: InputMaybe<OrientationManagerAggregateBoolExp>;
 	structures?: InputMaybe<StructureBoolExp>;
-	structures_aggregate?: InputMaybe<StructureAggregateBoolExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 };
 
@@ -2729,17 +2615,6 @@ export type ExternalDataAggregate = {
 	__typename?: 'external_data_aggregate';
 	aggregate?: Maybe<ExternalDataAggregateFields>;
 	nodes: Array<ExternalData>;
-};
-
-export type ExternalDataAggregateBoolExp = {
-	count?: InputMaybe<ExternalDataAggregateBoolExpCount>;
-};
-
-export type ExternalDataAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<ExternalDataSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<ExternalDataBoolExp>;
-	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "external_data" */
@@ -3198,7 +3073,6 @@ export type ExternalSourceBoolExp = {
 	_or?: InputMaybe<Array<ExternalSourceBoolExp>>;
 	comment?: InputMaybe<StringComparisonExp>;
 	external_data?: InputMaybe<ExternalDataBoolExp>;
-	external_data_aggregate?: InputMaybe<ExternalDataAggregateBoolExp>;
 	value?: InputMaybe<StringComparisonExp>;
 };
 
@@ -3369,17 +3243,6 @@ export type ManagerAggregate = {
 	__typename?: 'manager_aggregate';
 	aggregate?: Maybe<ManagerAggregateFields>;
 	nodes: Array<Manager>;
-};
-
-export type ManagerAggregateBoolExp = {
-	count?: InputMaybe<ManagerAggregateBoolExpCount>;
-};
-
-export type ManagerAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<ManagerSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<ManagerBoolExp>;
-	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "manager" */
@@ -5512,17 +5375,6 @@ export type NotebookActionAggregate = {
 	nodes: Array<NotebookAction>;
 };
 
-export type NotebookActionAggregateBoolExp = {
-	count?: InputMaybe<NotebookActionAggregateBoolExpCount>;
-};
-
-export type NotebookActionAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<NotebookActionSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookActionBoolExp>;
-	predicate: IntComparisonExp;
-};
-
 /** aggregate fields of "notebook_action" */
 export type NotebookActionAggregateFields = {
 	__typename?: 'notebook_action_aggregate_fields';
@@ -5803,17 +5655,6 @@ export type NotebookAppointmentAggregate = {
 	nodes: Array<NotebookAppointment>;
 };
 
-export type NotebookAppointmentAggregateBoolExp = {
-	count?: InputMaybe<NotebookAppointmentAggregateBoolExpCount>;
-};
-
-export type NotebookAppointmentAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<NotebookAppointmentSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookAppointmentBoolExp>;
-	predicate: IntComparisonExp;
-};
-
 /** aggregate fields of "notebook_appointment" */
 export type NotebookAppointmentAggregateFields = {
 	__typename?: 'notebook_appointment_aggregate_fields';
@@ -6064,7 +5905,6 @@ export type NotebookBoolExp = {
 	_not?: InputMaybe<NotebookBoolExp>;
 	_or?: InputMaybe<Array<NotebookBoolExp>>;
 	appointments?: InputMaybe<NotebookAppointmentBoolExp>;
-	appointments_aggregate?: InputMaybe<NotebookAppointmentAggregateBoolExp>;
 	beneficiary?: InputMaybe<BeneficiaryBoolExp>;
 	beneficiaryId?: InputMaybe<UuidComparisonExp>;
 	contractEndDate?: InputMaybe<DateComparisonExp>;
@@ -6074,13 +5914,10 @@ export type NotebookBoolExp = {
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	educationLevel?: InputMaybe<StringComparisonExp>;
 	events?: InputMaybe<NotebookEventBoolExp>;
-	events_aggregate?: InputMaybe<NotebookEventAggregateBoolExp>;
 	focuses?: InputMaybe<NotebookFocusBoolExp>;
-	focuses_aggregate?: InputMaybe<NotebookFocusAggregateBoolExp>;
 	geographicalArea?: InputMaybe<StringComparisonExp>;
 	id?: InputMaybe<UuidComparisonExp>;
 	members?: InputMaybe<NotebookMemberBoolExp>;
-	members_aggregate?: InputMaybe<NotebookMemberAggregateBoolExp>;
 	nbMembers?: InputMaybe<BigintComparisonExp>;
 	notebookInfo?: InputMaybe<NotebookInfoBoolExp>;
 	rightAre?: InputMaybe<BooleanComparisonExp>;
@@ -6090,7 +5927,6 @@ export type NotebookBoolExp = {
 	rightRsa?: InputMaybe<StringComparisonExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 	wantedJobs?: InputMaybe<WantedJobBoolExp>;
-	wantedJobs_aggregate?: InputMaybe<WantedJobAggregateBoolExp>;
 	workSituation?: InputMaybe<StringComparisonExp>;
 	workSituationDate?: InputMaybe<DateComparisonExp>;
 	workSituationEndDate?: InputMaybe<DateComparisonExp>;
@@ -6132,17 +5968,6 @@ export type NotebookEventAggregate = {
 	__typename?: 'notebook_event_aggregate';
 	aggregate?: Maybe<NotebookEventAggregateFields>;
 	nodes: Array<NotebookEvent>;
-};
-
-export type NotebookEventAggregateBoolExp = {
-	count?: InputMaybe<NotebookEventAggregateBoolExpCount>;
-};
-
-export type NotebookEventAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<NotebookEventSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookEventBoolExp>;
-	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "notebook_event" */
@@ -6413,7 +6238,6 @@ export type NotebookEventTypeBoolExp = {
 	_or?: InputMaybe<Array<NotebookEventTypeBoolExp>>;
 	comment?: InputMaybe<StringComparisonExp>;
 	notebook_events?: InputMaybe<NotebookEventBoolExp>;
-	notebook_events_aggregate?: InputMaybe<NotebookEventAggregateBoolExp>;
 	value?: InputMaybe<StringComparisonExp>;
 };
 
@@ -6622,17 +6446,6 @@ export type NotebookFocusAggregate = {
 	nodes: Array<NotebookFocus>;
 };
 
-export type NotebookFocusAggregateBoolExp = {
-	count?: InputMaybe<NotebookFocusAggregateBoolExpCount>;
-};
-
-export type NotebookFocusAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<NotebookFocusSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookFocusBoolExp>;
-	predicate: IntComparisonExp;
-};
-
 /** aggregate fields of "notebook_focus" */
 export type NotebookFocusAggregateFields = {
 	__typename?: 'notebook_focus_aggregate_fields';
@@ -6680,7 +6493,6 @@ export type NotebookFocusBoolExp = {
 	notebookId?: InputMaybe<UuidComparisonExp>;
 	situations?: InputMaybe<JsonbComparisonExp>;
 	targets?: InputMaybe<NotebookTargetBoolExp>;
-	targets_aggregate?: InputMaybe<NotebookTargetAggregateBoolExp>;
 	theme?: InputMaybe<StringComparisonExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 };
@@ -6924,33 +6736,6 @@ export type NotebookInfoAggregate = {
 	nodes: Array<NotebookInfo>;
 };
 
-export type NotebookInfoAggregateBoolExp = {
-	bool_and?: InputMaybe<NotebookInfoAggregateBoolExpBoolAnd>;
-	bool_or?: InputMaybe<NotebookInfoAggregateBoolExpBoolOr>;
-	count?: InputMaybe<NotebookInfoAggregateBoolExpCount>;
-};
-
-export type NotebookInfoAggregateBoolExpBoolAnd = {
-	arguments: NotebookInfoSelectColumnNotebookInfoAggregateBoolExpBoolAndArgumentsColumns;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookInfoBoolExp>;
-	predicate: BooleanComparisonExp;
-};
-
-export type NotebookInfoAggregateBoolExpBoolOr = {
-	arguments: NotebookInfoSelectColumnNotebookInfoAggregateBoolExpBoolOrArgumentsColumns;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookInfoBoolExp>;
-	predicate: BooleanComparisonExp;
-};
-
-export type NotebookInfoAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<NotebookInfoSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookInfoBoolExp>;
-	predicate: IntComparisonExp;
-};
-
 /** aggregate fields of "notebook_info" */
 export type NotebookInfoAggregateFields = {
 	__typename?: 'notebook_info_aggregate_fields';
@@ -7093,18 +6878,6 @@ export enum NotebookInfoSelectColumn {
 	UpdatedAt = 'updatedAt',
 }
 
-/** select "notebook_info_aggregate_bool_exp_bool_and_arguments_columns" columns of table "notebook_info" */
-export enum NotebookInfoSelectColumnNotebookInfoAggregateBoolExpBoolAndArgumentsColumns {
-	/** column name */
-	NeedOrientation = 'needOrientation',
-}
-
-/** select "notebook_info_aggregate_bool_exp_bool_or_arguments_columns" columns of table "notebook_info" */
-export enum NotebookInfoSelectColumnNotebookInfoAggregateBoolExpBoolOrArgumentsColumns {
-	/** column name */
-	NeedOrientation = 'needOrientation',
-}
-
 /** input type for updating data in table "notebook_info" */
 export type NotebookInfoSetInput = {
 	createdAt?: InputMaybe<Scalars['timestamptz']>;
@@ -7225,33 +6998,6 @@ export type NotebookMemberAggregate = {
 	__typename?: 'notebook_member_aggregate';
 	aggregate?: Maybe<NotebookMemberAggregateFields>;
 	nodes: Array<NotebookMember>;
-};
-
-export type NotebookMemberAggregateBoolExp = {
-	bool_and?: InputMaybe<NotebookMemberAggregateBoolExpBoolAnd>;
-	bool_or?: InputMaybe<NotebookMemberAggregateBoolExpBoolOr>;
-	count?: InputMaybe<NotebookMemberAggregateBoolExpCount>;
-};
-
-export type NotebookMemberAggregateBoolExpBoolAnd = {
-	arguments: NotebookMemberSelectColumnNotebookMemberAggregateBoolExpBoolAndArgumentsColumns;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookMemberBoolExp>;
-	predicate: BooleanComparisonExp;
-};
-
-export type NotebookMemberAggregateBoolExpBoolOr = {
-	arguments: NotebookMemberSelectColumnNotebookMemberAggregateBoolExpBoolOrArgumentsColumns;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookMemberBoolExp>;
-	predicate: BooleanComparisonExp;
-};
-
-export type NotebookMemberAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<NotebookMemberSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookMemberBoolExp>;
-	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "notebook_member" */
@@ -7443,18 +7189,6 @@ export enum NotebookMemberSelectColumn {
 	MemberType = 'memberType',
 	/** column name */
 	NotebookId = 'notebookId',
-}
-
-/** select "notebook_member_aggregate_bool_exp_bool_and_arguments_columns" columns of table "notebook_member" */
-export enum NotebookMemberSelectColumnNotebookMemberAggregateBoolExpBoolAndArgumentsColumns {
-	/** column name */
-	Active = 'active',
-}
-
-/** select "notebook_member_aggregate_bool_exp_bool_or_arguments_columns" columns of table "notebook_member" */
-export enum NotebookMemberSelectColumnNotebookMemberAggregateBoolExpBoolOrArgumentsColumns {
-	/** column name */
-	Active = 'active',
 }
 
 /** input type for updating data in table "notebook_member" */
@@ -7666,7 +7400,6 @@ export type NotebookPublicViewBoolExp = {
 	created_at?: InputMaybe<TimestamptzComparisonExp>;
 	id?: InputMaybe<UuidComparisonExp>;
 	members?: InputMaybe<NotebookMemberBoolExp>;
-	members_aggregate?: InputMaybe<NotebookMemberAggregateBoolExp>;
 	notebook?: InputMaybe<NotebookBoolExp>;
 	updated_at?: InputMaybe<TimestamptzComparisonExp>;
 };
@@ -7904,17 +7637,6 @@ export type NotebookTargetAggregate = {
 	nodes: Array<NotebookTarget>;
 };
 
-export type NotebookTargetAggregateBoolExp = {
-	count?: InputMaybe<NotebookTargetAggregateBoolExpCount>;
-};
-
-export type NotebookTargetAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<NotebookTargetSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<NotebookTargetBoolExp>;
-	predicate: IntComparisonExp;
-};
-
 /** aggregate fields of "notebook_target" */
 export type NotebookTargetAggregateFields = {
 	__typename?: 'notebook_target_aggregate_fields';
@@ -7949,7 +7671,6 @@ export type NotebookTargetBoolExp = {
 	_not?: InputMaybe<NotebookTargetBoolExp>;
 	_or?: InputMaybe<Array<NotebookTargetBoolExp>>;
 	actions?: InputMaybe<NotebookActionBoolExp>;
-	actions_aggregate?: InputMaybe<NotebookActionAggregateBoolExp>;
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	creator?: InputMaybe<AccountBoolExp>;
 	creatorId?: InputMaybe<UuidComparisonExp>;
@@ -8252,17 +7973,6 @@ export type OrientationManagerAggregate = {
 	nodes: Array<OrientationManager>;
 };
 
-export type OrientationManagerAggregateBoolExp = {
-	count?: InputMaybe<OrientationManagerAggregateBoolExpCount>;
-};
-
-export type OrientationManagerAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<OrientationManagerSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<OrientationManagerBoolExp>;
-	predicate: IntComparisonExp;
-};
-
 /** aggregate fields of "orientation_manager" */
 export type OrientationManagerAggregateFields = {
 	__typename?: 'orientation_manager_aggregate_fields';
@@ -8298,7 +8008,6 @@ export type OrientationManagerBoolExp = {
 	_or?: InputMaybe<Array<OrientationManagerBoolExp>>;
 	account?: InputMaybe<AccountBoolExp>;
 	accounts?: InputMaybe<AccountBoolExp>;
-	accounts_aggregate?: InputMaybe<AccountAggregateBoolExp>;
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	deployment?: InputMaybe<DeploymentBoolExp>;
 	deploymentId?: InputMaybe<UuidComparisonExp>;
@@ -8543,17 +8252,6 @@ export type OrientationRequestAggregate = {
 	__typename?: 'orientation_request_aggregate';
 	aggregate?: Maybe<OrientationRequestAggregateFields>;
 	nodes: Array<OrientationRequest>;
-};
-
-export type OrientationRequestAggregateBoolExp = {
-	count?: InputMaybe<OrientationRequestAggregateBoolExpCount>;
-};
-
-export type OrientationRequestAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<OrientationRequestSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<OrientationRequestBoolExp>;
-	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "orientation_request" */
@@ -8872,7 +8570,6 @@ export type OrientationTypeBoolExp = {
 	id?: InputMaybe<StringComparisonExp>;
 	label?: InputMaybe<StringComparisonExp>;
 	notebook_infos?: InputMaybe<NotebookInfoBoolExp>;
-	notebook_infos_aggregate?: InputMaybe<NotebookInfoAggregateBoolExp>;
 };
 
 /** unique or primary key constraints on table "orientation_type" */
@@ -9020,17 +8717,6 @@ export type ProfessionalAggregate = {
 	__typename?: 'professional_aggregate';
 	aggregate?: Maybe<ProfessionalAggregateFields>;
 	nodes: Array<Professional>;
-};
-
-export type ProfessionalAggregateBoolExp = {
-	count?: InputMaybe<ProfessionalAggregateBoolExpCount>;
-};
-
-export type ProfessionalAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<ProfessionalSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<ProfessionalBoolExp>;
-	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "professional" */
@@ -10708,7 +10394,6 @@ export type RoleBoolExp = {
 	_not?: InputMaybe<RoleBoolExp>;
 	_or?: InputMaybe<Array<RoleBoolExp>>;
 	accounts?: InputMaybe<AccountBoolExp>;
-	accounts_aggregate?: InputMaybe<AccountAggregateBoolExp>;
 	label?: InputMaybe<StringComparisonExp>;
 };
 
@@ -10886,7 +10571,6 @@ export type RomeCodeBoolExp = {
 	id?: InputMaybe<UuidComparisonExp>;
 	label?: InputMaybe<StringComparisonExp>;
 	wanted_by?: InputMaybe<WantedJobBoolExp>;
-	wanted_by_aggregate?: InputMaybe<WantedJobAggregateBoolExp>;
 };
 
 /** unique or primary key constraints on table "rome_code" */
@@ -11125,17 +10809,6 @@ export type StructureAggregate = {
 	nodes: Array<Structure>;
 };
 
-export type StructureAggregateBoolExp = {
-	count?: InputMaybe<StructureAggregateBoolExpCount>;
-};
-
-export type StructureAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<StructureSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<StructureBoolExp>;
-	predicate: IntComparisonExp;
-};
-
 /** aggregate fields of "structure" */
 export type StructureAggregateFields = {
 	__typename?: 'structure_aggregate_fields';
@@ -11172,9 +10845,7 @@ export type StructureBoolExp = {
 	address1?: InputMaybe<StringComparisonExp>;
 	address2?: InputMaybe<StringComparisonExp>;
 	admins?: InputMaybe<AdminStructureStructureBoolExp>;
-	admins_aggregate?: InputMaybe<AdminStructureStructureAggregateBoolExp>;
 	beneficiaries?: InputMaybe<BeneficiaryStructureBoolExp>;
-	beneficiaries_aggregate?: InputMaybe<BeneficiaryStructureAggregateBoolExp>;
 	city?: InputMaybe<StringComparisonExp>;
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	deployment?: InputMaybe<DeploymentBoolExp>;
@@ -11185,7 +10856,6 @@ export type StructureBoolExp = {
 	phone?: InputMaybe<StringComparisonExp>;
 	postalCode?: InputMaybe<StringComparisonExp>;
 	professionals?: InputMaybe<ProfessionalBoolExp>;
-	professionals_aggregate?: InputMaybe<ProfessionalAggregateBoolExp>;
 	shortDesc?: InputMaybe<StringComparisonExp>;
 	siret?: InputMaybe<StringComparisonExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
@@ -11472,9 +11142,9 @@ export type SubscriptionRoot = {
 	account_info: Array<AccountInfo>;
 	/** fetch aggregated fields from the table: "account_info" */
 	account_info_aggregate: AccountInfoAggregate;
-	/** fetch data from the table in a streaming manner: "account_info" */
+	/** fetch data from the table in a streaming manner : "account_info" */
 	account_info_stream: Array<AccountInfo>;
-	/** fetch data from the table in a streaming manner: "account" */
+	/** fetch data from the table in a streaming manner : "account" */
 	account_stream: Array<Account>;
 	/** fetch data from the table: "admin_cdb" */
 	admin_cdb: Array<AdminCdb>;
@@ -11482,7 +11152,7 @@ export type SubscriptionRoot = {
 	admin_cdb_aggregate: AdminCdbAggregate;
 	/** fetch data from the table: "admin_cdb" using primary key columns */
 	admin_cdb_by_pk?: Maybe<AdminCdb>;
-	/** fetch data from the table in a streaming manner: "admin_cdb" */
+	/** fetch data from the table in a streaming manner : "admin_cdb" */
 	admin_cdb_stream: Array<AdminCdb>;
 	/** fetch data from the table: "admin_structure" */
 	admin_structure: Array<AdminStructure>;
@@ -11490,7 +11160,7 @@ export type SubscriptionRoot = {
 	admin_structure_aggregate: AdminStructureAggregate;
 	/** fetch data from the table: "admin_structure" using primary key columns */
 	admin_structure_by_pk?: Maybe<AdminStructure>;
-	/** fetch data from the table in a streaming manner: "admin_structure" */
+	/** fetch data from the table in a streaming manner : "admin_structure" */
 	admin_structure_stream: Array<AdminStructure>;
 	/** fetch data from the table: "admin_structure_structure" */
 	admin_structure_structure: Array<AdminStructureStructure>;
@@ -11498,7 +11168,7 @@ export type SubscriptionRoot = {
 	admin_structure_structure_aggregate: AdminStructureStructureAggregate;
 	/** fetch data from the table: "admin_structure_structure" using primary key columns */
 	admin_structure_structure_by_pk?: Maybe<AdminStructureStructure>;
-	/** fetch data from the table in a streaming manner: "admin_structure_structure" */
+	/** fetch data from the table in a streaming manner : "admin_structure_structure" */
 	admin_structure_structure_stream: Array<AdminStructureStructure>;
 	/** fetch data from the table: "beneficiary" */
 	beneficiary: Array<Beneficiary>;
@@ -11506,7 +11176,7 @@ export type SubscriptionRoot = {
 	beneficiary_aggregate: BeneficiaryAggregate;
 	/** fetch data from the table: "beneficiary" using primary key columns */
 	beneficiary_by_pk?: Maybe<Beneficiary>;
-	/** fetch data from the table in a streaming manner: "beneficiary" */
+	/** fetch data from the table in a streaming manner : "beneficiary" */
 	beneficiary_stream: Array<Beneficiary>;
 	/** fetch data from the table: "beneficiary_structure" */
 	beneficiary_structure: Array<BeneficiaryStructure>;
@@ -11514,7 +11184,7 @@ export type SubscriptionRoot = {
 	beneficiary_structure_aggregate: BeneficiaryStructureAggregate;
 	/** fetch data from the table: "beneficiary_structure" using primary key columns */
 	beneficiary_structure_by_pk?: Maybe<BeneficiaryStructure>;
-	/** fetch data from the table in a streaming manner: "beneficiary_structure" */
+	/** fetch data from the table in a streaming manner : "beneficiary_structure" */
 	beneficiary_structure_stream: Array<BeneficiaryStructure>;
 	/** fetch data from the table: "deployment" */
 	deployment: Array<Deployment>;
@@ -11522,7 +11192,7 @@ export type SubscriptionRoot = {
 	deployment_aggregate: DeploymentAggregate;
 	/** fetch data from the table: "deployment" using primary key columns */
 	deployment_by_pk?: Maybe<Deployment>;
-	/** fetch data from the table in a streaming manner: "deployment" */
+	/** fetch data from the table in a streaming manner : "deployment" */
 	deployment_stream: Array<Deployment>;
 	/** An array relationship */
 	external_data: Array<ExternalData>;
@@ -11536,9 +11206,9 @@ export type SubscriptionRoot = {
 	external_data_info_aggregate: ExternalDataInfoAggregate;
 	/** fetch data from the table: "external_data_info" using primary key columns */
 	external_data_info_by_pk?: Maybe<ExternalDataInfo>;
-	/** fetch data from the table in a streaming manner: "external_data_info" */
+	/** fetch data from the table in a streaming manner : "external_data_info" */
 	external_data_info_stream: Array<ExternalDataInfo>;
-	/** fetch data from the table in a streaming manner: "external_data" */
+	/** fetch data from the table in a streaming manner : "external_data" */
 	external_data_stream: Array<ExternalData>;
 	/** fetch data from the table: "external_source" */
 	external_source: Array<ExternalSource>;
@@ -11546,7 +11216,7 @@ export type SubscriptionRoot = {
 	external_source_aggregate: ExternalSourceAggregate;
 	/** fetch data from the table: "external_source" using primary key columns */
 	external_source_by_pk?: Maybe<ExternalSource>;
-	/** fetch data from the table in a streaming manner: "external_source" */
+	/** fetch data from the table in a streaming manner : "external_source" */
 	external_source_stream: Array<ExternalSource>;
 	/** fetch data from the table: "manager" */
 	manager: Array<Manager>;
@@ -11554,7 +11224,7 @@ export type SubscriptionRoot = {
 	manager_aggregate: ManagerAggregate;
 	/** fetch data from the table: "manager" using primary key columns */
 	manager_by_pk?: Maybe<Manager>;
-	/** fetch data from the table in a streaming manner: "manager" */
+	/** fetch data from the table in a streaming manner : "manager" */
 	manager_stream: Array<Manager>;
 	/** fetch data from the table: "notebook" */
 	notebook: Array<Notebook>;
@@ -11564,7 +11234,7 @@ export type SubscriptionRoot = {
 	notebook_action_aggregate: NotebookActionAggregate;
 	/** fetch data from the table: "notebook_action" using primary key columns */
 	notebook_action_by_pk?: Maybe<NotebookAction>;
-	/** fetch data from the table in a streaming manner: "notebook_action" */
+	/** fetch data from the table in a streaming manner : "notebook_action" */
 	notebook_action_stream: Array<NotebookAction>;
 	/** fetch aggregated fields from the table: "notebook" */
 	notebook_aggregate: NotebookAggregate;
@@ -11574,7 +11244,7 @@ export type SubscriptionRoot = {
 	notebook_appointment_aggregate: NotebookAppointmentAggregate;
 	/** fetch data from the table: "notebook_appointment" using primary key columns */
 	notebook_appointment_by_pk?: Maybe<NotebookAppointment>;
-	/** fetch data from the table in a streaming manner: "notebook_appointment" */
+	/** fetch data from the table in a streaming manner : "notebook_appointment" */
 	notebook_appointment_stream: Array<NotebookAppointment>;
 	/** fetch data from the table: "notebook" using primary key columns */
 	notebook_by_pk?: Maybe<Notebook>;
@@ -11584,7 +11254,7 @@ export type SubscriptionRoot = {
 	notebook_event_aggregate: NotebookEventAggregate;
 	/** fetch data from the table: "notebook_event" using primary key columns */
 	notebook_event_by_pk?: Maybe<NotebookEvent>;
-	/** fetch data from the table in a streaming manner: "notebook_event" */
+	/** fetch data from the table in a streaming manner : "notebook_event" */
 	notebook_event_stream: Array<NotebookEvent>;
 	/** fetch data from the table: "notebook_event_type" */
 	notebook_event_type: Array<NotebookEventType>;
@@ -11592,7 +11262,7 @@ export type SubscriptionRoot = {
 	notebook_event_type_aggregate: NotebookEventTypeAggregate;
 	/** fetch data from the table: "notebook_event_type" using primary key columns */
 	notebook_event_type_by_pk?: Maybe<NotebookEventType>;
-	/** fetch data from the table in a streaming manner: "notebook_event_type" */
+	/** fetch data from the table in a streaming manner : "notebook_event_type" */
 	notebook_event_type_stream: Array<NotebookEventType>;
 	/** fetch data from the table: "notebook_focus" */
 	notebook_focus: Array<NotebookFocus>;
@@ -11600,7 +11270,7 @@ export type SubscriptionRoot = {
 	notebook_focus_aggregate: NotebookFocusAggregate;
 	/** fetch data from the table: "notebook_focus" using primary key columns */
 	notebook_focus_by_pk?: Maybe<NotebookFocus>;
-	/** fetch data from the table in a streaming manner: "notebook_focus" */
+	/** fetch data from the table in a streaming manner : "notebook_focus" */
 	notebook_focus_stream: Array<NotebookFocus>;
 	/** fetch data from the table: "notebook_info" */
 	notebook_info: Array<NotebookInfo>;
@@ -11608,7 +11278,7 @@ export type SubscriptionRoot = {
 	notebook_info_aggregate: NotebookInfoAggregate;
 	/** fetch data from the table: "notebook_info" using primary key columns */
 	notebook_info_by_pk?: Maybe<NotebookInfo>;
-	/** fetch data from the table in a streaming manner: "notebook_info" */
+	/** fetch data from the table in a streaming manner : "notebook_info" */
 	notebook_info_stream: Array<NotebookInfo>;
 	/** fetch data from the table: "notebook_member" */
 	notebook_member: Array<NotebookMember>;
@@ -11616,15 +11286,15 @@ export type SubscriptionRoot = {
 	notebook_member_aggregate: NotebookMemberAggregate;
 	/** fetch data from the table: "notebook_member" using primary key columns */
 	notebook_member_by_pk?: Maybe<NotebookMember>;
-	/** fetch data from the table in a streaming manner: "notebook_member" */
+	/** fetch data from the table in a streaming manner : "notebook_member" */
 	notebook_member_stream: Array<NotebookMember>;
 	/** fetch data from the table: "notebook_public_view" */
 	notebook_public_view: Array<NotebookPublicView>;
 	/** fetch aggregated fields from the table: "notebook_public_view" */
 	notebook_public_view_aggregate: NotebookPublicViewAggregate;
-	/** fetch data from the table in a streaming manner: "notebook_public_view" */
+	/** fetch data from the table in a streaming manner : "notebook_public_view" */
 	notebook_public_view_stream: Array<NotebookPublicView>;
-	/** fetch data from the table in a streaming manner: "notebook" */
+	/** fetch data from the table in a streaming manner : "notebook" */
 	notebook_stream: Array<Notebook>;
 	/** fetch data from the table: "notebook_target" */
 	notebook_target: Array<NotebookTarget>;
@@ -11632,7 +11302,7 @@ export type SubscriptionRoot = {
 	notebook_target_aggregate: NotebookTargetAggregate;
 	/** fetch data from the table: "notebook_target" using primary key columns */
 	notebook_target_by_pk?: Maybe<NotebookTarget>;
-	/** fetch data from the table in a streaming manner: "notebook_target" */
+	/** fetch data from the table in a streaming manner : "notebook_target" */
 	notebook_target_stream: Array<NotebookTarget>;
 	/** fetch data from the table: "orientation_manager" */
 	orientation_manager: Array<OrientationManager>;
@@ -11640,7 +11310,7 @@ export type SubscriptionRoot = {
 	orientation_manager_aggregate: OrientationManagerAggregate;
 	/** fetch data from the table: "orientation_manager" using primary key columns */
 	orientation_manager_by_pk?: Maybe<OrientationManager>;
-	/** fetch data from the table in a streaming manner: "orientation_manager" */
+	/** fetch data from the table in a streaming manner : "orientation_manager" */
 	orientation_manager_stream: Array<OrientationManager>;
 	/** fetch data from the table: "orientation_request" */
 	orientation_request: Array<OrientationRequest>;
@@ -11648,7 +11318,7 @@ export type SubscriptionRoot = {
 	orientation_request_aggregate: OrientationRequestAggregate;
 	/** fetch data from the table: "orientation_request" using primary key columns */
 	orientation_request_by_pk?: Maybe<OrientationRequest>;
-	/** fetch data from the table in a streaming manner: "orientation_request" */
+	/** fetch data from the table in a streaming manner : "orientation_request" */
 	orientation_request_stream: Array<OrientationRequest>;
 	/** fetch data from the table: "orientation_type" */
 	orientation_type: Array<OrientationType>;
@@ -11656,7 +11326,7 @@ export type SubscriptionRoot = {
 	orientation_type_aggregate: OrientationTypeAggregate;
 	/** fetch data from the table: "orientation_type" using primary key columns */
 	orientation_type_by_pk?: Maybe<OrientationType>;
-	/** fetch data from the table in a streaming manner: "orientation_type" */
+	/** fetch data from the table in a streaming manner : "orientation_type" */
 	orientation_type_stream: Array<OrientationType>;
 	/** fetch data from the table: "professional" */
 	professional: Array<Professional>;
@@ -11664,7 +11334,7 @@ export type SubscriptionRoot = {
 	professional_aggregate: ProfessionalAggregate;
 	/** fetch data from the table: "professional" using primary key columns */
 	professional_by_pk?: Maybe<Professional>;
-	/** fetch data from the table in a streaming manner: "professional" */
+	/** fetch data from the table in a streaming manner : "professional" */
 	professional_stream: Array<Professional>;
 	/** fetch data from the table: "ref_action" */
 	ref_action: Array<RefAction>;
@@ -11672,7 +11342,7 @@ export type SubscriptionRoot = {
 	ref_action_aggregate: RefActionAggregate;
 	/** fetch data from the table: "ref_action" using primary key columns */
 	ref_action_by_pk?: Maybe<RefAction>;
-	/** fetch data from the table in a streaming manner: "ref_action" */
+	/** fetch data from the table in a streaming manner : "ref_action" */
 	ref_action_stream: Array<RefAction>;
 	/** fetch data from the table: "ref_situation" */
 	ref_situation: Array<RefSituation>;
@@ -11680,7 +11350,7 @@ export type SubscriptionRoot = {
 	ref_situation_aggregate: RefSituationAggregate;
 	/** fetch data from the table: "ref_situation" using primary key columns */
 	ref_situation_by_pk?: Maybe<RefSituation>;
-	/** fetch data from the table in a streaming manner: "ref_situation" */
+	/** fetch data from the table in a streaming manner : "ref_situation" */
 	ref_situation_stream: Array<RefSituation>;
 	/** fetch data from the table: "ref_target" */
 	ref_target: Array<RefTarget>;
@@ -11688,7 +11358,7 @@ export type SubscriptionRoot = {
 	ref_target_aggregate: RefTargetAggregate;
 	/** fetch data from the table: "ref_target" using primary key columns */
 	ref_target_by_pk?: Maybe<RefTarget>;
-	/** fetch data from the table in a streaming manner: "ref_target" */
+	/** fetch data from the table in a streaming manner : "ref_target" */
 	ref_target_stream: Array<RefTarget>;
 	/** fetch data from the table: "role" */
 	role: Array<Role>;
@@ -11696,7 +11366,7 @@ export type SubscriptionRoot = {
 	role_aggregate: RoleAggregate;
 	/** fetch data from the table: "role" using primary key columns */
 	role_by_pk?: Maybe<Role>;
-	/** fetch data from the table in a streaming manner: "role" */
+	/** fetch data from the table in a streaming manner : "role" */
 	role_stream: Array<Role>;
 	/** fetch data from the table: "rome_code" */
 	rome_code: Array<RomeCode>;
@@ -11704,7 +11374,7 @@ export type SubscriptionRoot = {
 	rome_code_aggregate: RomeCodeAggregate;
 	/** fetch data from the table: "rome_code" using primary key columns */
 	rome_code_by_pk?: Maybe<RomeCode>;
-	/** fetch data from the table in a streaming manner: "rome_code" */
+	/** fetch data from the table in a streaming manner : "rome_code" */
 	rome_code_stream: Array<RomeCode>;
 	/** execute function "search_beneficiaries" which returns "beneficiary" */
 	search_beneficiaries: Array<Beneficiary>;
@@ -11728,7 +11398,7 @@ export type SubscriptionRoot = {
 	structure_aggregate: StructureAggregate;
 	/** fetch data from the table: "structure" using primary key columns */
 	structure_by_pk?: Maybe<Structure>;
-	/** fetch data from the table in a streaming manner: "structure" */
+	/** fetch data from the table in a streaming manner : "structure" */
 	structure_stream: Array<Structure>;
 	/** fetch data from the table: "wanted_job" */
 	wanted_job: Array<WantedJob>;
@@ -11736,7 +11406,7 @@ export type SubscriptionRoot = {
 	wanted_job_aggregate: WantedJobAggregate;
 	/** fetch data from the table: "wanted_job" using primary key columns */
 	wanted_job_by_pk?: Maybe<WantedJob>;
-	/** fetch data from the table in a streaming manner: "wanted_job" */
+	/** fetch data from the table in a streaming manner : "wanted_job" */
 	wanted_job_stream: Array<WantedJob>;
 };
 
@@ -12720,17 +12390,6 @@ export type WantedJobAggregate = {
 	__typename?: 'wanted_job_aggregate';
 	aggregate?: Maybe<WantedJobAggregateFields>;
 	nodes: Array<WantedJob>;
-};
-
-export type WantedJobAggregateBoolExp = {
-	count?: InputMaybe<WantedJobAggregateBoolExpCount>;
-};
-
-export type WantedJobAggregateBoolExpCount = {
-	arguments?: InputMaybe<Array<WantedJobSelectColumn>>;
-	distinct?: InputMaybe<Scalars['Boolean']>;
-	filter?: InputMaybe<WantedJobBoolExp>;
-	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "wanted_job" */
@@ -14570,11 +14229,32 @@ export type SearchNotebookMemberQuery = {
 
 export type SearchPublicNotebooksQueryVariables = Exact<{
 	filter?: InputMaybe<Scalars['String']>;
+	accountId: Scalars['uuid'];
 }>;
 
 export type SearchPublicNotebooksQuery = {
 	__typename?: 'query_root';
 	search_public_notebooks: Array<{
+		__typename?: 'notebook_public_view';
+		id?: string | null;
+		beneficiary?: {
+			__typename?: 'beneficiary';
+			dateOfBirth: string;
+			firstname: string;
+			id: string;
+			lastname: string;
+			mobileNumber?: string | null;
+			orientationRequest: Array<{
+				__typename?: 'orientation_request';
+				id: string;
+				status?: string | null;
+				createdAt: string;
+				decidedAt?: string | null;
+				requestedOrientationType?: { __typename?: 'orientation_type'; label: string } | null;
+			}>;
+		} | null;
+	}>;
+	notebooks_member_of: Array<{
 		__typename?: 'notebook_public_view';
 		id?: string | null;
 		beneficiary?: {
@@ -22836,6 +22516,14 @@ export const SearchPublicNotebooksDocument = {
 					variable: { kind: 'Variable', name: { kind: 'Name', value: 'filter' } },
 					type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
 				},
+				{
+					kind: 'VariableDefinition',
+					variable: { kind: 'Variable', name: { kind: 'Name', value: 'accountId' } },
+					type: {
+						kind: 'NonNullType',
+						type: { kind: 'NamedType', name: { kind: 'Name', value: 'uuid' } },
+					},
+				},
 			],
 			selectionSet: {
 				kind: 'SelectionSet',
@@ -22868,6 +22556,230 @@ export const SearchPublicNotebooksDocument = {
 											kind: 'ObjectField',
 											name: { kind: 'Name', value: 'updated_at' },
 											value: { kind: 'EnumValue', value: 'desc_nulls_first' },
+										},
+									],
+								},
+							},
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'where' },
+								value: {
+									kind: 'ObjectValue',
+									fields: [
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: '_not' },
+											value: {
+												kind: 'ObjectValue',
+												fields: [
+													{
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: 'notebook' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'members' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: 'active' },
+																				value: {
+																					kind: 'ObjectValue',
+																					fields: [
+																						{
+																							kind: 'ObjectField',
+																							name: { kind: 'Name', value: '_eq' },
+																							value: { kind: 'BooleanValue', value: true },
+																						},
+																					],
+																				},
+																			},
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: 'accountId' },
+																				value: {
+																					kind: 'ObjectValue',
+																					fields: [
+																						{
+																							kind: 'ObjectField',
+																							name: { kind: 'Name', value: '_eq' },
+																							value: {
+																								kind: 'Variable',
+																								name: { kind: 'Name', value: 'accountId' },
+																							},
+																						},
+																					],
+																				},
+																			},
+																		],
+																	},
+																},
+															],
+														},
+													},
+												],
+											},
+										},
+									],
+								},
+							},
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'beneficiary' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'dateOfBirth' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'firstname' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'lastname' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'mobileNumber' } },
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'orientationRequest' },
+												arguments: [
+													{
+														kind: 'Argument',
+														name: { kind: 'Name', value: 'order_by' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'createdAt' },
+																	value: { kind: 'EnumValue', value: 'desc' },
+																},
+															],
+														},
+													},
+													{
+														kind: 'Argument',
+														name: { kind: 'Name', value: 'limit' },
+														value: { kind: 'IntValue', value: '1' },
+													},
+												],
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'status' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'decidedAt' } },
+														{
+															kind: 'Field',
+															name: { kind: 'Name', value: 'requestedOrientationType' },
+															selectionSet: {
+																kind: 'SelectionSet',
+																selections: [
+																	{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
+																],
+															},
+														},
+													],
+												},
+											},
+										],
+									},
+								},
+							],
+						},
+					},
+					{
+						kind: 'Field',
+						alias: { kind: 'Name', value: 'notebooks_member_of' },
+						name: { kind: 'Name', value: 'search_public_notebooks' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'args' },
+								value: {
+									kind: 'ObjectValue',
+									fields: [
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: 'search' },
+											value: { kind: 'Variable', name: { kind: 'Name', value: 'filter' } },
+										},
+									],
+								},
+							},
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'order_by' },
+								value: {
+									kind: 'ObjectValue',
+									fields: [
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: 'updated_at' },
+											value: { kind: 'EnumValue', value: 'desc_nulls_first' },
+										},
+									],
+								},
+							},
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'where' },
+								value: {
+									kind: 'ObjectValue',
+									fields: [
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: 'notebook' },
+											value: {
+												kind: 'ObjectValue',
+												fields: [
+													{
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: 'members' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'active' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: '_eq' },
+																				value: { kind: 'BooleanValue', value: true },
+																			},
+																		],
+																	},
+																},
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'accountId' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: '_eq' },
+																				value: {
+																					kind: 'Variable',
+																					name: { kind: 'Name', value: 'accountId' },
+																				},
+																			},
+																		],
+																	},
+																},
+															],
+														},
+													},
+												],
+											},
 										},
 									],
 								},

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -40,6 +40,19 @@ export type CreateDeploymentOutput = {
 	label: Scalars['String'];
 };
 
+/** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
+export type IntComparisonExp = {
+	_eq?: InputMaybe<Scalars['Int']>;
+	_gt?: InputMaybe<Scalars['Int']>;
+	_gte?: InputMaybe<Scalars['Int']>;
+	_in?: InputMaybe<Array<Scalars['Int']>>;
+	_is_null?: InputMaybe<Scalars['Boolean']>;
+	_lt?: InputMaybe<Scalars['Int']>;
+	_lte?: InputMaybe<Scalars['Int']>;
+	_neq?: InputMaybe<Scalars['Int']>;
+	_nin?: InputMaybe<Array<Scalars['Int']>>;
+};
+
 /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
 export type StringComparisonExp = {
 	_eq?: InputMaybe<Scalars['String']>;
@@ -248,6 +261,33 @@ export type AccountAggregate = {
 	nodes: Array<Account>;
 };
 
+export type AccountAggregateBoolExp = {
+	bool_and?: InputMaybe<AccountAggregateBoolExpBoolAnd>;
+	bool_or?: InputMaybe<AccountAggregateBoolExpBoolOr>;
+	count?: InputMaybe<AccountAggregateBoolExpCount>;
+};
+
+export type AccountAggregateBoolExpBoolAnd = {
+	arguments: AccountSelectColumnAccountAggregateBoolExpBoolAndArgumentsColumns;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<AccountBoolExp>;
+	predicate: BooleanComparisonExp;
+};
+
+export type AccountAggregateBoolExpBoolOr = {
+	arguments: AccountSelectColumnAccountAggregateBoolExpBoolOrArgumentsColumns;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<AccountBoolExp>;
+	predicate: BooleanComparisonExp;
+};
+
+export type AccountAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<AccountSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<AccountBoolExp>;
+	predicate: IntComparisonExp;
+};
+
 /** aggregate fields of "account" */
 export type AccountAggregateFields = {
 	__typename?: 'account_aggregate_fields';
@@ -297,11 +337,17 @@ export type AccountBoolExp = {
 	manager?: InputMaybe<ManagerBoolExp>;
 	managerId?: InputMaybe<UuidComparisonExp>;
 	notebookActionsCreated?: InputMaybe<NotebookActionBoolExp>;
+	notebookActionsCreated_aggregate?: InputMaybe<NotebookActionAggregateBoolExp>;
 	notebookEventsCreated?: InputMaybe<NotebookEventBoolExp>;
+	notebookEventsCreated_aggregate?: InputMaybe<NotebookEventAggregateBoolExp>;
 	notebookFocusesCreated?: InputMaybe<NotebookFocusBoolExp>;
+	notebookFocusesCreated_aggregate?: InputMaybe<NotebookFocusAggregateBoolExp>;
 	notebookTargetsCreated?: InputMaybe<NotebookTargetBoolExp>;
+	notebookTargetsCreated_aggregate?: InputMaybe<NotebookTargetAggregateBoolExp>;
 	notebooksCreated?: InputMaybe<NotebookMemberBoolExp>;
+	notebooksCreated_aggregate?: InputMaybe<NotebookMemberAggregateBoolExp>;
 	notebooksWhereMember?: InputMaybe<NotebookMemberBoolExp>;
+	notebooksWhereMember_aggregate?: InputMaybe<NotebookMemberAggregateBoolExp>;
 	onboardingDone?: InputMaybe<BooleanComparisonExp>;
 	orientationManagerId?: InputMaybe<UuidComparisonExp>;
 	orientation_manager?: InputMaybe<OrientationManagerBoolExp>;
@@ -632,6 +678,22 @@ export enum AccountSelectColumn {
 	UpdatedAt = 'updatedAt',
 	/** column name */
 	Username = 'username',
+}
+
+/** select "account_aggregate_bool_exp_bool_and_arguments_columns" columns of table "account" */
+export enum AccountSelectColumnAccountAggregateBoolExpBoolAndArgumentsColumns {
+	/** column name */
+	Confirmed = 'confirmed',
+	/** column name */
+	OnboardingDone = 'onboardingDone',
+}
+
+/** select "account_aggregate_bool_exp_bool_or_arguments_columns" columns of table "account" */
+export enum AccountSelectColumnAccountAggregateBoolExpBoolOrArgumentsColumns {
+	/** column name */
+	Confirmed = 'confirmed',
+	/** column name */
+	OnboardingDone = 'onboardingDone',
 }
 
 /** input type for updating data in table "account" */
@@ -969,6 +1031,17 @@ export type AdminStructureAggregate = {
 	nodes: Array<AdminStructure>;
 };
 
+export type AdminStructureAggregateBoolExp = {
+	count?: InputMaybe<AdminStructureAggregateBoolExpCount>;
+};
+
+export type AdminStructureAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<AdminStructureSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<AdminStructureBoolExp>;
+	predicate: IntComparisonExp;
+};
+
 /** aggregate fields of "admin_structure" */
 export type AdminStructureAggregateFields = {
 	__typename?: 'admin_structure_aggregate_fields';
@@ -1013,6 +1086,7 @@ export type AdminStructureBoolExp = {
 	phoneNumbers?: InputMaybe<StringComparisonExp>;
 	position?: InputMaybe<StringComparisonExp>;
 	structures?: InputMaybe<AdminStructureStructureBoolExp>;
+	structures_aggregate?: InputMaybe<AdminStructureStructureAggregateBoolExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 };
 
@@ -1213,6 +1287,17 @@ export type AdminStructureStructureAggregate = {
 	__typename?: 'admin_structure_structure_aggregate';
 	aggregate?: Maybe<AdminStructureStructureAggregateFields>;
 	nodes: Array<AdminStructureStructure>;
+};
+
+export type AdminStructureStructureAggregateBoolExp = {
+	count?: InputMaybe<AdminStructureStructureAggregateBoolExpCount>;
+};
+
+export type AdminStructureStructureAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<AdminStructureStructureSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<AdminStructureStructureBoolExp>;
+	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "admin_structure_structure" */
@@ -1517,6 +1602,17 @@ export type BeneficiaryAggregate = {
 	nodes: Array<Beneficiary>;
 };
 
+export type BeneficiaryAggregateBoolExp = {
+	count?: InputMaybe<BeneficiaryAggregateBoolExpCount>;
+};
+
+export type BeneficiaryAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<BeneficiarySelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<BeneficiaryBoolExp>;
+	predicate: IntComparisonExp;
+};
+
 /** aggregate fields of "beneficiary" */
 export type BeneficiaryAggregateFields = {
 	__typename?: 'beneficiary_aggregate_fields';
@@ -1569,11 +1665,13 @@ export type BeneficiaryBoolExp = {
 	notebook?: InputMaybe<NotebookBoolExp>;
 	notebook_public_view?: InputMaybe<NotebookPublicViewBoolExp>;
 	orientationRequest?: InputMaybe<OrientationRequestBoolExp>;
+	orientationRequest_aggregate?: InputMaybe<OrientationRequestAggregateBoolExp>;
 	peNumber?: InputMaybe<StringComparisonExp>;
 	peUniqueId?: InputMaybe<StringComparisonExp>;
 	placeOfBirth?: InputMaybe<StringComparisonExp>;
 	postalCode?: InputMaybe<StringComparisonExp>;
 	structures?: InputMaybe<BeneficiaryStructureBoolExp>;
+	structures_aggregate?: InputMaybe<BeneficiaryStructureAggregateBoolExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 };
 
@@ -1891,6 +1989,17 @@ export type BeneficiaryStructureAggregate = {
 	__typename?: 'beneficiary_structure_aggregate';
 	aggregate?: Maybe<BeneficiaryStructureAggregateFields>;
 	nodes: Array<BeneficiaryStructure>;
+};
+
+export type BeneficiaryStructureAggregateBoolExp = {
+	count?: InputMaybe<BeneficiaryStructureAggregateBoolExpCount>;
+};
+
+export type BeneficiaryStructureAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<BeneficiaryStructureSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<BeneficiaryStructureBoolExp>;
+	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "beneficiary_structure" */
@@ -2411,14 +2520,19 @@ export type DeploymentBoolExp = {
 	_not?: InputMaybe<DeploymentBoolExp>;
 	_or?: InputMaybe<Array<DeploymentBoolExp>>;
 	admin_structures?: InputMaybe<AdminStructureBoolExp>;
+	admin_structures_aggregate?: InputMaybe<AdminStructureAggregateBoolExp>;
 	beneficiaries?: InputMaybe<BeneficiaryBoolExp>;
+	beneficiaries_aggregate?: InputMaybe<BeneficiaryAggregateBoolExp>;
 	config?: InputMaybe<JsonbComparisonExp>;
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	id?: InputMaybe<UuidComparisonExp>;
 	label?: InputMaybe<StringComparisonExp>;
 	managers?: InputMaybe<ManagerBoolExp>;
+	managers_aggregate?: InputMaybe<ManagerAggregateBoolExp>;
 	orientation_managers?: InputMaybe<OrientationManagerBoolExp>;
+	orientation_managers_aggregate?: InputMaybe<OrientationManagerAggregateBoolExp>;
 	structures?: InputMaybe<StructureBoolExp>;
+	structures_aggregate?: InputMaybe<StructureAggregateBoolExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 };
 
@@ -2615,6 +2729,17 @@ export type ExternalDataAggregate = {
 	__typename?: 'external_data_aggregate';
 	aggregate?: Maybe<ExternalDataAggregateFields>;
 	nodes: Array<ExternalData>;
+};
+
+export type ExternalDataAggregateBoolExp = {
+	count?: InputMaybe<ExternalDataAggregateBoolExpCount>;
+};
+
+export type ExternalDataAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<ExternalDataSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<ExternalDataBoolExp>;
+	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "external_data" */
@@ -3073,6 +3198,7 @@ export type ExternalSourceBoolExp = {
 	_or?: InputMaybe<Array<ExternalSourceBoolExp>>;
 	comment?: InputMaybe<StringComparisonExp>;
 	external_data?: InputMaybe<ExternalDataBoolExp>;
+	external_data_aggregate?: InputMaybe<ExternalDataAggregateBoolExp>;
 	value?: InputMaybe<StringComparisonExp>;
 };
 
@@ -3243,6 +3369,17 @@ export type ManagerAggregate = {
 	__typename?: 'manager_aggregate';
 	aggregate?: Maybe<ManagerAggregateFields>;
 	nodes: Array<Manager>;
+};
+
+export type ManagerAggregateBoolExp = {
+	count?: InputMaybe<ManagerAggregateBoolExpCount>;
+};
+
+export type ManagerAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<ManagerSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<ManagerBoolExp>;
+	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "manager" */
@@ -5375,6 +5512,17 @@ export type NotebookActionAggregate = {
 	nodes: Array<NotebookAction>;
 };
 
+export type NotebookActionAggregateBoolExp = {
+	count?: InputMaybe<NotebookActionAggregateBoolExpCount>;
+};
+
+export type NotebookActionAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<NotebookActionSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookActionBoolExp>;
+	predicate: IntComparisonExp;
+};
+
 /** aggregate fields of "notebook_action" */
 export type NotebookActionAggregateFields = {
 	__typename?: 'notebook_action_aggregate_fields';
@@ -5655,6 +5803,17 @@ export type NotebookAppointmentAggregate = {
 	nodes: Array<NotebookAppointment>;
 };
 
+export type NotebookAppointmentAggregateBoolExp = {
+	count?: InputMaybe<NotebookAppointmentAggregateBoolExpCount>;
+};
+
+export type NotebookAppointmentAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<NotebookAppointmentSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookAppointmentBoolExp>;
+	predicate: IntComparisonExp;
+};
+
 /** aggregate fields of "notebook_appointment" */
 export type NotebookAppointmentAggregateFields = {
 	__typename?: 'notebook_appointment_aggregate_fields';
@@ -5905,6 +6064,7 @@ export type NotebookBoolExp = {
 	_not?: InputMaybe<NotebookBoolExp>;
 	_or?: InputMaybe<Array<NotebookBoolExp>>;
 	appointments?: InputMaybe<NotebookAppointmentBoolExp>;
+	appointments_aggregate?: InputMaybe<NotebookAppointmentAggregateBoolExp>;
 	beneficiary?: InputMaybe<BeneficiaryBoolExp>;
 	beneficiaryId?: InputMaybe<UuidComparisonExp>;
 	contractEndDate?: InputMaybe<DateComparisonExp>;
@@ -5914,10 +6074,13 @@ export type NotebookBoolExp = {
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	educationLevel?: InputMaybe<StringComparisonExp>;
 	events?: InputMaybe<NotebookEventBoolExp>;
+	events_aggregate?: InputMaybe<NotebookEventAggregateBoolExp>;
 	focuses?: InputMaybe<NotebookFocusBoolExp>;
+	focuses_aggregate?: InputMaybe<NotebookFocusAggregateBoolExp>;
 	geographicalArea?: InputMaybe<StringComparisonExp>;
 	id?: InputMaybe<UuidComparisonExp>;
 	members?: InputMaybe<NotebookMemberBoolExp>;
+	members_aggregate?: InputMaybe<NotebookMemberAggregateBoolExp>;
 	nbMembers?: InputMaybe<BigintComparisonExp>;
 	notebookInfo?: InputMaybe<NotebookInfoBoolExp>;
 	rightAre?: InputMaybe<BooleanComparisonExp>;
@@ -5927,6 +6090,7 @@ export type NotebookBoolExp = {
 	rightRsa?: InputMaybe<StringComparisonExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 	wantedJobs?: InputMaybe<WantedJobBoolExp>;
+	wantedJobs_aggregate?: InputMaybe<WantedJobAggregateBoolExp>;
 	workSituation?: InputMaybe<StringComparisonExp>;
 	workSituationDate?: InputMaybe<DateComparisonExp>;
 	workSituationEndDate?: InputMaybe<DateComparisonExp>;
@@ -5968,6 +6132,17 @@ export type NotebookEventAggregate = {
 	__typename?: 'notebook_event_aggregate';
 	aggregate?: Maybe<NotebookEventAggregateFields>;
 	nodes: Array<NotebookEvent>;
+};
+
+export type NotebookEventAggregateBoolExp = {
+	count?: InputMaybe<NotebookEventAggregateBoolExpCount>;
+};
+
+export type NotebookEventAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<NotebookEventSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookEventBoolExp>;
+	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "notebook_event" */
@@ -6238,6 +6413,7 @@ export type NotebookEventTypeBoolExp = {
 	_or?: InputMaybe<Array<NotebookEventTypeBoolExp>>;
 	comment?: InputMaybe<StringComparisonExp>;
 	notebook_events?: InputMaybe<NotebookEventBoolExp>;
+	notebook_events_aggregate?: InputMaybe<NotebookEventAggregateBoolExp>;
 	value?: InputMaybe<StringComparisonExp>;
 };
 
@@ -6446,6 +6622,17 @@ export type NotebookFocusAggregate = {
 	nodes: Array<NotebookFocus>;
 };
 
+export type NotebookFocusAggregateBoolExp = {
+	count?: InputMaybe<NotebookFocusAggregateBoolExpCount>;
+};
+
+export type NotebookFocusAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<NotebookFocusSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookFocusBoolExp>;
+	predicate: IntComparisonExp;
+};
+
 /** aggregate fields of "notebook_focus" */
 export type NotebookFocusAggregateFields = {
 	__typename?: 'notebook_focus_aggregate_fields';
@@ -6493,6 +6680,7 @@ export type NotebookFocusBoolExp = {
 	notebookId?: InputMaybe<UuidComparisonExp>;
 	situations?: InputMaybe<JsonbComparisonExp>;
 	targets?: InputMaybe<NotebookTargetBoolExp>;
+	targets_aggregate?: InputMaybe<NotebookTargetAggregateBoolExp>;
 	theme?: InputMaybe<StringComparisonExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 };
@@ -6736,6 +6924,33 @@ export type NotebookInfoAggregate = {
 	nodes: Array<NotebookInfo>;
 };
 
+export type NotebookInfoAggregateBoolExp = {
+	bool_and?: InputMaybe<NotebookInfoAggregateBoolExpBoolAnd>;
+	bool_or?: InputMaybe<NotebookInfoAggregateBoolExpBoolOr>;
+	count?: InputMaybe<NotebookInfoAggregateBoolExpCount>;
+};
+
+export type NotebookInfoAggregateBoolExpBoolAnd = {
+	arguments: NotebookInfoSelectColumnNotebookInfoAggregateBoolExpBoolAndArgumentsColumns;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookInfoBoolExp>;
+	predicate: BooleanComparisonExp;
+};
+
+export type NotebookInfoAggregateBoolExpBoolOr = {
+	arguments: NotebookInfoSelectColumnNotebookInfoAggregateBoolExpBoolOrArgumentsColumns;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookInfoBoolExp>;
+	predicate: BooleanComparisonExp;
+};
+
+export type NotebookInfoAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<NotebookInfoSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookInfoBoolExp>;
+	predicate: IntComparisonExp;
+};
+
 /** aggregate fields of "notebook_info" */
 export type NotebookInfoAggregateFields = {
 	__typename?: 'notebook_info_aggregate_fields';
@@ -6878,6 +7093,18 @@ export enum NotebookInfoSelectColumn {
 	UpdatedAt = 'updatedAt',
 }
 
+/** select "notebook_info_aggregate_bool_exp_bool_and_arguments_columns" columns of table "notebook_info" */
+export enum NotebookInfoSelectColumnNotebookInfoAggregateBoolExpBoolAndArgumentsColumns {
+	/** column name */
+	NeedOrientation = 'needOrientation',
+}
+
+/** select "notebook_info_aggregate_bool_exp_bool_or_arguments_columns" columns of table "notebook_info" */
+export enum NotebookInfoSelectColumnNotebookInfoAggregateBoolExpBoolOrArgumentsColumns {
+	/** column name */
+	NeedOrientation = 'needOrientation',
+}
+
 /** input type for updating data in table "notebook_info" */
 export type NotebookInfoSetInput = {
 	createdAt?: InputMaybe<Scalars['timestamptz']>;
@@ -6998,6 +7225,33 @@ export type NotebookMemberAggregate = {
 	__typename?: 'notebook_member_aggregate';
 	aggregate?: Maybe<NotebookMemberAggregateFields>;
 	nodes: Array<NotebookMember>;
+};
+
+export type NotebookMemberAggregateBoolExp = {
+	bool_and?: InputMaybe<NotebookMemberAggregateBoolExpBoolAnd>;
+	bool_or?: InputMaybe<NotebookMemberAggregateBoolExpBoolOr>;
+	count?: InputMaybe<NotebookMemberAggregateBoolExpCount>;
+};
+
+export type NotebookMemberAggregateBoolExpBoolAnd = {
+	arguments: NotebookMemberSelectColumnNotebookMemberAggregateBoolExpBoolAndArgumentsColumns;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookMemberBoolExp>;
+	predicate: BooleanComparisonExp;
+};
+
+export type NotebookMemberAggregateBoolExpBoolOr = {
+	arguments: NotebookMemberSelectColumnNotebookMemberAggregateBoolExpBoolOrArgumentsColumns;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookMemberBoolExp>;
+	predicate: BooleanComparisonExp;
+};
+
+export type NotebookMemberAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<NotebookMemberSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookMemberBoolExp>;
+	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "notebook_member" */
@@ -7189,6 +7443,18 @@ export enum NotebookMemberSelectColumn {
 	MemberType = 'memberType',
 	/** column name */
 	NotebookId = 'notebookId',
+}
+
+/** select "notebook_member_aggregate_bool_exp_bool_and_arguments_columns" columns of table "notebook_member" */
+export enum NotebookMemberSelectColumnNotebookMemberAggregateBoolExpBoolAndArgumentsColumns {
+	/** column name */
+	Active = 'active',
+}
+
+/** select "notebook_member_aggregate_bool_exp_bool_or_arguments_columns" columns of table "notebook_member" */
+export enum NotebookMemberSelectColumnNotebookMemberAggregateBoolExpBoolOrArgumentsColumns {
+	/** column name */
+	Active = 'active',
 }
 
 /** input type for updating data in table "notebook_member" */
@@ -7400,6 +7666,7 @@ export type NotebookPublicViewBoolExp = {
 	created_at?: InputMaybe<TimestamptzComparisonExp>;
 	id?: InputMaybe<UuidComparisonExp>;
 	members?: InputMaybe<NotebookMemberBoolExp>;
+	members_aggregate?: InputMaybe<NotebookMemberAggregateBoolExp>;
 	notebook?: InputMaybe<NotebookBoolExp>;
 	updated_at?: InputMaybe<TimestamptzComparisonExp>;
 };
@@ -7637,6 +7904,17 @@ export type NotebookTargetAggregate = {
 	nodes: Array<NotebookTarget>;
 };
 
+export type NotebookTargetAggregateBoolExp = {
+	count?: InputMaybe<NotebookTargetAggregateBoolExpCount>;
+};
+
+export type NotebookTargetAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<NotebookTargetSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<NotebookTargetBoolExp>;
+	predicate: IntComparisonExp;
+};
+
 /** aggregate fields of "notebook_target" */
 export type NotebookTargetAggregateFields = {
 	__typename?: 'notebook_target_aggregate_fields';
@@ -7671,6 +7949,7 @@ export type NotebookTargetBoolExp = {
 	_not?: InputMaybe<NotebookTargetBoolExp>;
 	_or?: InputMaybe<Array<NotebookTargetBoolExp>>;
 	actions?: InputMaybe<NotebookActionBoolExp>;
+	actions_aggregate?: InputMaybe<NotebookActionAggregateBoolExp>;
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	creator?: InputMaybe<AccountBoolExp>;
 	creatorId?: InputMaybe<UuidComparisonExp>;
@@ -7973,6 +8252,17 @@ export type OrientationManagerAggregate = {
 	nodes: Array<OrientationManager>;
 };
 
+export type OrientationManagerAggregateBoolExp = {
+	count?: InputMaybe<OrientationManagerAggregateBoolExpCount>;
+};
+
+export type OrientationManagerAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<OrientationManagerSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<OrientationManagerBoolExp>;
+	predicate: IntComparisonExp;
+};
+
 /** aggregate fields of "orientation_manager" */
 export type OrientationManagerAggregateFields = {
 	__typename?: 'orientation_manager_aggregate_fields';
@@ -8008,6 +8298,7 @@ export type OrientationManagerBoolExp = {
 	_or?: InputMaybe<Array<OrientationManagerBoolExp>>;
 	account?: InputMaybe<AccountBoolExp>;
 	accounts?: InputMaybe<AccountBoolExp>;
+	accounts_aggregate?: InputMaybe<AccountAggregateBoolExp>;
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	deployment?: InputMaybe<DeploymentBoolExp>;
 	deploymentId?: InputMaybe<UuidComparisonExp>;
@@ -8252,6 +8543,17 @@ export type OrientationRequestAggregate = {
 	__typename?: 'orientation_request_aggregate';
 	aggregate?: Maybe<OrientationRequestAggregateFields>;
 	nodes: Array<OrientationRequest>;
+};
+
+export type OrientationRequestAggregateBoolExp = {
+	count?: InputMaybe<OrientationRequestAggregateBoolExpCount>;
+};
+
+export type OrientationRequestAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<OrientationRequestSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<OrientationRequestBoolExp>;
+	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "orientation_request" */
@@ -8570,6 +8872,7 @@ export type OrientationTypeBoolExp = {
 	id?: InputMaybe<StringComparisonExp>;
 	label?: InputMaybe<StringComparisonExp>;
 	notebook_infos?: InputMaybe<NotebookInfoBoolExp>;
+	notebook_infos_aggregate?: InputMaybe<NotebookInfoAggregateBoolExp>;
 };
 
 /** unique or primary key constraints on table "orientation_type" */
@@ -8717,6 +9020,17 @@ export type ProfessionalAggregate = {
 	__typename?: 'professional_aggregate';
 	aggregate?: Maybe<ProfessionalAggregateFields>;
 	nodes: Array<Professional>;
+};
+
+export type ProfessionalAggregateBoolExp = {
+	count?: InputMaybe<ProfessionalAggregateBoolExpCount>;
+};
+
+export type ProfessionalAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<ProfessionalSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<ProfessionalBoolExp>;
+	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "professional" */
@@ -10394,6 +10708,7 @@ export type RoleBoolExp = {
 	_not?: InputMaybe<RoleBoolExp>;
 	_or?: InputMaybe<Array<RoleBoolExp>>;
 	accounts?: InputMaybe<AccountBoolExp>;
+	accounts_aggregate?: InputMaybe<AccountAggregateBoolExp>;
 	label?: InputMaybe<StringComparisonExp>;
 };
 
@@ -10571,6 +10886,7 @@ export type RomeCodeBoolExp = {
 	id?: InputMaybe<UuidComparisonExp>;
 	label?: InputMaybe<StringComparisonExp>;
 	wanted_by?: InputMaybe<WantedJobBoolExp>;
+	wanted_by_aggregate?: InputMaybe<WantedJobAggregateBoolExp>;
 };
 
 /** unique or primary key constraints on table "rome_code" */
@@ -10809,6 +11125,17 @@ export type StructureAggregate = {
 	nodes: Array<Structure>;
 };
 
+export type StructureAggregateBoolExp = {
+	count?: InputMaybe<StructureAggregateBoolExpCount>;
+};
+
+export type StructureAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<StructureSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<StructureBoolExp>;
+	predicate: IntComparisonExp;
+};
+
 /** aggregate fields of "structure" */
 export type StructureAggregateFields = {
 	__typename?: 'structure_aggregate_fields';
@@ -10845,7 +11172,9 @@ export type StructureBoolExp = {
 	address1?: InputMaybe<StringComparisonExp>;
 	address2?: InputMaybe<StringComparisonExp>;
 	admins?: InputMaybe<AdminStructureStructureBoolExp>;
+	admins_aggregate?: InputMaybe<AdminStructureStructureAggregateBoolExp>;
 	beneficiaries?: InputMaybe<BeneficiaryStructureBoolExp>;
+	beneficiaries_aggregate?: InputMaybe<BeneficiaryStructureAggregateBoolExp>;
 	city?: InputMaybe<StringComparisonExp>;
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	deployment?: InputMaybe<DeploymentBoolExp>;
@@ -10856,6 +11185,7 @@ export type StructureBoolExp = {
 	phone?: InputMaybe<StringComparisonExp>;
 	postalCode?: InputMaybe<StringComparisonExp>;
 	professionals?: InputMaybe<ProfessionalBoolExp>;
+	professionals_aggregate?: InputMaybe<ProfessionalAggregateBoolExp>;
 	shortDesc?: InputMaybe<StringComparisonExp>;
 	siret?: InputMaybe<StringComparisonExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
@@ -11142,9 +11472,9 @@ export type SubscriptionRoot = {
 	account_info: Array<AccountInfo>;
 	/** fetch aggregated fields from the table: "account_info" */
 	account_info_aggregate: AccountInfoAggregate;
-	/** fetch data from the table in a streaming manner : "account_info" */
+	/** fetch data from the table in a streaming manner: "account_info" */
 	account_info_stream: Array<AccountInfo>;
-	/** fetch data from the table in a streaming manner : "account" */
+	/** fetch data from the table in a streaming manner: "account" */
 	account_stream: Array<Account>;
 	/** fetch data from the table: "admin_cdb" */
 	admin_cdb: Array<AdminCdb>;
@@ -11152,7 +11482,7 @@ export type SubscriptionRoot = {
 	admin_cdb_aggregate: AdminCdbAggregate;
 	/** fetch data from the table: "admin_cdb" using primary key columns */
 	admin_cdb_by_pk?: Maybe<AdminCdb>;
-	/** fetch data from the table in a streaming manner : "admin_cdb" */
+	/** fetch data from the table in a streaming manner: "admin_cdb" */
 	admin_cdb_stream: Array<AdminCdb>;
 	/** fetch data from the table: "admin_structure" */
 	admin_structure: Array<AdminStructure>;
@@ -11160,7 +11490,7 @@ export type SubscriptionRoot = {
 	admin_structure_aggregate: AdminStructureAggregate;
 	/** fetch data from the table: "admin_structure" using primary key columns */
 	admin_structure_by_pk?: Maybe<AdminStructure>;
-	/** fetch data from the table in a streaming manner : "admin_structure" */
+	/** fetch data from the table in a streaming manner: "admin_structure" */
 	admin_structure_stream: Array<AdminStructure>;
 	/** fetch data from the table: "admin_structure_structure" */
 	admin_structure_structure: Array<AdminStructureStructure>;
@@ -11168,7 +11498,7 @@ export type SubscriptionRoot = {
 	admin_structure_structure_aggregate: AdminStructureStructureAggregate;
 	/** fetch data from the table: "admin_structure_structure" using primary key columns */
 	admin_structure_structure_by_pk?: Maybe<AdminStructureStructure>;
-	/** fetch data from the table in a streaming manner : "admin_structure_structure" */
+	/** fetch data from the table in a streaming manner: "admin_structure_structure" */
 	admin_structure_structure_stream: Array<AdminStructureStructure>;
 	/** fetch data from the table: "beneficiary" */
 	beneficiary: Array<Beneficiary>;
@@ -11176,7 +11506,7 @@ export type SubscriptionRoot = {
 	beneficiary_aggregate: BeneficiaryAggregate;
 	/** fetch data from the table: "beneficiary" using primary key columns */
 	beneficiary_by_pk?: Maybe<Beneficiary>;
-	/** fetch data from the table in a streaming manner : "beneficiary" */
+	/** fetch data from the table in a streaming manner: "beneficiary" */
 	beneficiary_stream: Array<Beneficiary>;
 	/** fetch data from the table: "beneficiary_structure" */
 	beneficiary_structure: Array<BeneficiaryStructure>;
@@ -11184,7 +11514,7 @@ export type SubscriptionRoot = {
 	beneficiary_structure_aggregate: BeneficiaryStructureAggregate;
 	/** fetch data from the table: "beneficiary_structure" using primary key columns */
 	beneficiary_structure_by_pk?: Maybe<BeneficiaryStructure>;
-	/** fetch data from the table in a streaming manner : "beneficiary_structure" */
+	/** fetch data from the table in a streaming manner: "beneficiary_structure" */
 	beneficiary_structure_stream: Array<BeneficiaryStructure>;
 	/** fetch data from the table: "deployment" */
 	deployment: Array<Deployment>;
@@ -11192,7 +11522,7 @@ export type SubscriptionRoot = {
 	deployment_aggregate: DeploymentAggregate;
 	/** fetch data from the table: "deployment" using primary key columns */
 	deployment_by_pk?: Maybe<Deployment>;
-	/** fetch data from the table in a streaming manner : "deployment" */
+	/** fetch data from the table in a streaming manner: "deployment" */
 	deployment_stream: Array<Deployment>;
 	/** An array relationship */
 	external_data: Array<ExternalData>;
@@ -11206,9 +11536,9 @@ export type SubscriptionRoot = {
 	external_data_info_aggregate: ExternalDataInfoAggregate;
 	/** fetch data from the table: "external_data_info" using primary key columns */
 	external_data_info_by_pk?: Maybe<ExternalDataInfo>;
-	/** fetch data from the table in a streaming manner : "external_data_info" */
+	/** fetch data from the table in a streaming manner: "external_data_info" */
 	external_data_info_stream: Array<ExternalDataInfo>;
-	/** fetch data from the table in a streaming manner : "external_data" */
+	/** fetch data from the table in a streaming manner: "external_data" */
 	external_data_stream: Array<ExternalData>;
 	/** fetch data from the table: "external_source" */
 	external_source: Array<ExternalSource>;
@@ -11216,7 +11546,7 @@ export type SubscriptionRoot = {
 	external_source_aggregate: ExternalSourceAggregate;
 	/** fetch data from the table: "external_source" using primary key columns */
 	external_source_by_pk?: Maybe<ExternalSource>;
-	/** fetch data from the table in a streaming manner : "external_source" */
+	/** fetch data from the table in a streaming manner: "external_source" */
 	external_source_stream: Array<ExternalSource>;
 	/** fetch data from the table: "manager" */
 	manager: Array<Manager>;
@@ -11224,7 +11554,7 @@ export type SubscriptionRoot = {
 	manager_aggregate: ManagerAggregate;
 	/** fetch data from the table: "manager" using primary key columns */
 	manager_by_pk?: Maybe<Manager>;
-	/** fetch data from the table in a streaming manner : "manager" */
+	/** fetch data from the table in a streaming manner: "manager" */
 	manager_stream: Array<Manager>;
 	/** fetch data from the table: "notebook" */
 	notebook: Array<Notebook>;
@@ -11234,7 +11564,7 @@ export type SubscriptionRoot = {
 	notebook_action_aggregate: NotebookActionAggregate;
 	/** fetch data from the table: "notebook_action" using primary key columns */
 	notebook_action_by_pk?: Maybe<NotebookAction>;
-	/** fetch data from the table in a streaming manner : "notebook_action" */
+	/** fetch data from the table in a streaming manner: "notebook_action" */
 	notebook_action_stream: Array<NotebookAction>;
 	/** fetch aggregated fields from the table: "notebook" */
 	notebook_aggregate: NotebookAggregate;
@@ -11244,7 +11574,7 @@ export type SubscriptionRoot = {
 	notebook_appointment_aggregate: NotebookAppointmentAggregate;
 	/** fetch data from the table: "notebook_appointment" using primary key columns */
 	notebook_appointment_by_pk?: Maybe<NotebookAppointment>;
-	/** fetch data from the table in a streaming manner : "notebook_appointment" */
+	/** fetch data from the table in a streaming manner: "notebook_appointment" */
 	notebook_appointment_stream: Array<NotebookAppointment>;
 	/** fetch data from the table: "notebook" using primary key columns */
 	notebook_by_pk?: Maybe<Notebook>;
@@ -11254,7 +11584,7 @@ export type SubscriptionRoot = {
 	notebook_event_aggregate: NotebookEventAggregate;
 	/** fetch data from the table: "notebook_event" using primary key columns */
 	notebook_event_by_pk?: Maybe<NotebookEvent>;
-	/** fetch data from the table in a streaming manner : "notebook_event" */
+	/** fetch data from the table in a streaming manner: "notebook_event" */
 	notebook_event_stream: Array<NotebookEvent>;
 	/** fetch data from the table: "notebook_event_type" */
 	notebook_event_type: Array<NotebookEventType>;
@@ -11262,7 +11592,7 @@ export type SubscriptionRoot = {
 	notebook_event_type_aggregate: NotebookEventTypeAggregate;
 	/** fetch data from the table: "notebook_event_type" using primary key columns */
 	notebook_event_type_by_pk?: Maybe<NotebookEventType>;
-	/** fetch data from the table in a streaming manner : "notebook_event_type" */
+	/** fetch data from the table in a streaming manner: "notebook_event_type" */
 	notebook_event_type_stream: Array<NotebookEventType>;
 	/** fetch data from the table: "notebook_focus" */
 	notebook_focus: Array<NotebookFocus>;
@@ -11270,7 +11600,7 @@ export type SubscriptionRoot = {
 	notebook_focus_aggregate: NotebookFocusAggregate;
 	/** fetch data from the table: "notebook_focus" using primary key columns */
 	notebook_focus_by_pk?: Maybe<NotebookFocus>;
-	/** fetch data from the table in a streaming manner : "notebook_focus" */
+	/** fetch data from the table in a streaming manner: "notebook_focus" */
 	notebook_focus_stream: Array<NotebookFocus>;
 	/** fetch data from the table: "notebook_info" */
 	notebook_info: Array<NotebookInfo>;
@@ -11278,7 +11608,7 @@ export type SubscriptionRoot = {
 	notebook_info_aggregate: NotebookInfoAggregate;
 	/** fetch data from the table: "notebook_info" using primary key columns */
 	notebook_info_by_pk?: Maybe<NotebookInfo>;
-	/** fetch data from the table in a streaming manner : "notebook_info" */
+	/** fetch data from the table in a streaming manner: "notebook_info" */
 	notebook_info_stream: Array<NotebookInfo>;
 	/** fetch data from the table: "notebook_member" */
 	notebook_member: Array<NotebookMember>;
@@ -11286,15 +11616,15 @@ export type SubscriptionRoot = {
 	notebook_member_aggregate: NotebookMemberAggregate;
 	/** fetch data from the table: "notebook_member" using primary key columns */
 	notebook_member_by_pk?: Maybe<NotebookMember>;
-	/** fetch data from the table in a streaming manner : "notebook_member" */
+	/** fetch data from the table in a streaming manner: "notebook_member" */
 	notebook_member_stream: Array<NotebookMember>;
 	/** fetch data from the table: "notebook_public_view" */
 	notebook_public_view: Array<NotebookPublicView>;
 	/** fetch aggregated fields from the table: "notebook_public_view" */
 	notebook_public_view_aggregate: NotebookPublicViewAggregate;
-	/** fetch data from the table in a streaming manner : "notebook_public_view" */
+	/** fetch data from the table in a streaming manner: "notebook_public_view" */
 	notebook_public_view_stream: Array<NotebookPublicView>;
-	/** fetch data from the table in a streaming manner : "notebook" */
+	/** fetch data from the table in a streaming manner: "notebook" */
 	notebook_stream: Array<Notebook>;
 	/** fetch data from the table: "notebook_target" */
 	notebook_target: Array<NotebookTarget>;
@@ -11302,7 +11632,7 @@ export type SubscriptionRoot = {
 	notebook_target_aggregate: NotebookTargetAggregate;
 	/** fetch data from the table: "notebook_target" using primary key columns */
 	notebook_target_by_pk?: Maybe<NotebookTarget>;
-	/** fetch data from the table in a streaming manner : "notebook_target" */
+	/** fetch data from the table in a streaming manner: "notebook_target" */
 	notebook_target_stream: Array<NotebookTarget>;
 	/** fetch data from the table: "orientation_manager" */
 	orientation_manager: Array<OrientationManager>;
@@ -11310,7 +11640,7 @@ export type SubscriptionRoot = {
 	orientation_manager_aggregate: OrientationManagerAggregate;
 	/** fetch data from the table: "orientation_manager" using primary key columns */
 	orientation_manager_by_pk?: Maybe<OrientationManager>;
-	/** fetch data from the table in a streaming manner : "orientation_manager" */
+	/** fetch data from the table in a streaming manner: "orientation_manager" */
 	orientation_manager_stream: Array<OrientationManager>;
 	/** fetch data from the table: "orientation_request" */
 	orientation_request: Array<OrientationRequest>;
@@ -11318,7 +11648,7 @@ export type SubscriptionRoot = {
 	orientation_request_aggregate: OrientationRequestAggregate;
 	/** fetch data from the table: "orientation_request" using primary key columns */
 	orientation_request_by_pk?: Maybe<OrientationRequest>;
-	/** fetch data from the table in a streaming manner : "orientation_request" */
+	/** fetch data from the table in a streaming manner: "orientation_request" */
 	orientation_request_stream: Array<OrientationRequest>;
 	/** fetch data from the table: "orientation_type" */
 	orientation_type: Array<OrientationType>;
@@ -11326,7 +11656,7 @@ export type SubscriptionRoot = {
 	orientation_type_aggregate: OrientationTypeAggregate;
 	/** fetch data from the table: "orientation_type" using primary key columns */
 	orientation_type_by_pk?: Maybe<OrientationType>;
-	/** fetch data from the table in a streaming manner : "orientation_type" */
+	/** fetch data from the table in a streaming manner: "orientation_type" */
 	orientation_type_stream: Array<OrientationType>;
 	/** fetch data from the table: "professional" */
 	professional: Array<Professional>;
@@ -11334,7 +11664,7 @@ export type SubscriptionRoot = {
 	professional_aggregate: ProfessionalAggregate;
 	/** fetch data from the table: "professional" using primary key columns */
 	professional_by_pk?: Maybe<Professional>;
-	/** fetch data from the table in a streaming manner : "professional" */
+	/** fetch data from the table in a streaming manner: "professional" */
 	professional_stream: Array<Professional>;
 	/** fetch data from the table: "ref_action" */
 	ref_action: Array<RefAction>;
@@ -11342,7 +11672,7 @@ export type SubscriptionRoot = {
 	ref_action_aggregate: RefActionAggregate;
 	/** fetch data from the table: "ref_action" using primary key columns */
 	ref_action_by_pk?: Maybe<RefAction>;
-	/** fetch data from the table in a streaming manner : "ref_action" */
+	/** fetch data from the table in a streaming manner: "ref_action" */
 	ref_action_stream: Array<RefAction>;
 	/** fetch data from the table: "ref_situation" */
 	ref_situation: Array<RefSituation>;
@@ -11350,7 +11680,7 @@ export type SubscriptionRoot = {
 	ref_situation_aggregate: RefSituationAggregate;
 	/** fetch data from the table: "ref_situation" using primary key columns */
 	ref_situation_by_pk?: Maybe<RefSituation>;
-	/** fetch data from the table in a streaming manner : "ref_situation" */
+	/** fetch data from the table in a streaming manner: "ref_situation" */
 	ref_situation_stream: Array<RefSituation>;
 	/** fetch data from the table: "ref_target" */
 	ref_target: Array<RefTarget>;
@@ -11358,7 +11688,7 @@ export type SubscriptionRoot = {
 	ref_target_aggregate: RefTargetAggregate;
 	/** fetch data from the table: "ref_target" using primary key columns */
 	ref_target_by_pk?: Maybe<RefTarget>;
-	/** fetch data from the table in a streaming manner : "ref_target" */
+	/** fetch data from the table in a streaming manner: "ref_target" */
 	ref_target_stream: Array<RefTarget>;
 	/** fetch data from the table: "role" */
 	role: Array<Role>;
@@ -11366,7 +11696,7 @@ export type SubscriptionRoot = {
 	role_aggregate: RoleAggregate;
 	/** fetch data from the table: "role" using primary key columns */
 	role_by_pk?: Maybe<Role>;
-	/** fetch data from the table in a streaming manner : "role" */
+	/** fetch data from the table in a streaming manner: "role" */
 	role_stream: Array<Role>;
 	/** fetch data from the table: "rome_code" */
 	rome_code: Array<RomeCode>;
@@ -11374,7 +11704,7 @@ export type SubscriptionRoot = {
 	rome_code_aggregate: RomeCodeAggregate;
 	/** fetch data from the table: "rome_code" using primary key columns */
 	rome_code_by_pk?: Maybe<RomeCode>;
-	/** fetch data from the table in a streaming manner : "rome_code" */
+	/** fetch data from the table in a streaming manner: "rome_code" */
 	rome_code_stream: Array<RomeCode>;
 	/** execute function "search_beneficiaries" which returns "beneficiary" */
 	search_beneficiaries: Array<Beneficiary>;
@@ -11398,7 +11728,7 @@ export type SubscriptionRoot = {
 	structure_aggregate: StructureAggregate;
 	/** fetch data from the table: "structure" using primary key columns */
 	structure_by_pk?: Maybe<Structure>;
-	/** fetch data from the table in a streaming manner : "structure" */
+	/** fetch data from the table in a streaming manner: "structure" */
 	structure_stream: Array<Structure>;
 	/** fetch data from the table: "wanted_job" */
 	wanted_job: Array<WantedJob>;
@@ -11406,7 +11736,7 @@ export type SubscriptionRoot = {
 	wanted_job_aggregate: WantedJobAggregate;
 	/** fetch data from the table: "wanted_job" using primary key columns */
 	wanted_job_by_pk?: Maybe<WantedJob>;
-	/** fetch data from the table in a streaming manner : "wanted_job" */
+	/** fetch data from the table in a streaming manner: "wanted_job" */
 	wanted_job_stream: Array<WantedJob>;
 };
 
@@ -12390,6 +12720,17 @@ export type WantedJobAggregate = {
 	__typename?: 'wanted_job_aggregate';
 	aggregate?: Maybe<WantedJobAggregateFields>;
 	nodes: Array<WantedJob>;
+};
+
+export type WantedJobAggregateBoolExp = {
+	count?: InputMaybe<WantedJobAggregateBoolExpCount>;
+};
+
+export type WantedJobAggregateBoolExpCount = {
+	arguments?: InputMaybe<Array<WantedJobSelectColumn>>;
+	distinct?: InputMaybe<Scalars['Boolean']>;
+	filter?: InputMaybe<WantedJobBoolExp>;
+	predicate: IntComparisonExp;
 };
 
 /** aggregate fields of "wanted_job" */
@@ -14229,34 +14570,19 @@ export type SearchNotebookMemberQuery = {
 
 export type SearchPublicNotebooksQueryVariables = Exact<{
 	filter?: InputMaybe<Scalars['String']>;
-	accountId: Scalars['uuid'];
 }>;
 
 export type SearchPublicNotebooksQuery = {
 	__typename?: 'query_root';
-	search_public_notebooks: Array<{
+	notebooks: Array<{
 		__typename?: 'notebook_public_view';
 		id?: string | null;
-		beneficiary?: {
-			__typename?: 'beneficiary';
-			dateOfBirth: string;
-			firstname: string;
-			id: string;
-			lastname: string;
-			mobileNumber?: string | null;
-			orientationRequest: Array<{
-				__typename?: 'orientation_request';
-				id: string;
-				status?: string | null;
-				createdAt: string;
-				decidedAt?: string | null;
-				requestedOrientationType?: { __typename?: 'orientation_type'; label: string } | null;
-			}>;
-		} | null;
-	}>;
-	notebooks_member_of: Array<{
-		__typename?: 'notebook_public_view';
-		id?: string | null;
+		members: Array<{
+			__typename?: 'notebook_member';
+			active?: boolean | null;
+			accountId: string;
+			memberType: string;
+		}>;
 		beneficiary?: {
 			__typename?: 'beneficiary';
 			dateOfBirth: string;
@@ -22516,20 +22842,13 @@ export const SearchPublicNotebooksDocument = {
 					variable: { kind: 'Variable', name: { kind: 'Name', value: 'filter' } },
 					type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
 				},
-				{
-					kind: 'VariableDefinition',
-					variable: { kind: 'Variable', name: { kind: 'Name', value: 'accountId' } },
-					type: {
-						kind: 'NonNullType',
-						type: { kind: 'NamedType', name: { kind: 'Name', value: 'uuid' } },
-					},
-				},
 			],
 			selectionSet: {
 				kind: 'SelectionSet',
 				selections: [
 					{
 						kind: 'Field',
+						alias: { kind: 'Name', value: 'notebooks' },
 						name: { kind: 'Name', value: 'search_public_notebooks' },
 						arguments: [
 							{
@@ -22550,79 +22869,55 @@ export const SearchPublicNotebooksDocument = {
 								kind: 'Argument',
 								name: { kind: 'Name', value: 'order_by' },
 								value: {
-									kind: 'ObjectValue',
-									fields: [
+									kind: 'ListValue',
+									values: [
 										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'updated_at' },
-											value: { kind: 'EnumValue', value: 'desc_nulls_first' },
-										},
-									],
-								},
-							},
-							{
-								kind: 'Argument',
-								name: { kind: 'Name', value: 'where' },
-								value: {
-									kind: 'ObjectValue',
-									fields: [
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: '_not' },
-											value: {
-												kind: 'ObjectValue',
-												fields: [
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: 'notebook' },
-														value: {
-															kind: 'ObjectValue',
-															fields: [
-																{
-																	kind: 'ObjectField',
-																	name: { kind: 'Name', value: 'members' },
-																	value: {
-																		kind: 'ObjectValue',
-																		fields: [
-																			{
-																				kind: 'ObjectField',
-																				name: { kind: 'Name', value: 'active' },
-																				value: {
-																					kind: 'ObjectValue',
-																					fields: [
-																						{
-																							kind: 'ObjectField',
-																							name: { kind: 'Name', value: '_eq' },
-																							value: { kind: 'BooleanValue', value: true },
-																						},
-																					],
-																				},
-																			},
-																			{
-																				kind: 'ObjectField',
-																				name: { kind: 'Name', value: 'accountId' },
-																				value: {
-																					kind: 'ObjectValue',
-																					fields: [
-																						{
-																							kind: 'ObjectField',
-																							name: { kind: 'Name', value: '_eq' },
-																							value: {
-																								kind: 'Variable',
-																								name: { kind: 'Name', value: 'accountId' },
-																							},
-																						},
-																					],
-																				},
-																			},
-																		],
-																	},
-																},
-															],
-														},
+											kind: 'ObjectValue',
+											fields: [
+												{
+													kind: 'ObjectField',
+													name: { kind: 'Name', value: 'beneficiary' },
+													value: {
+														kind: 'ObjectValue',
+														fields: [
+															{
+																kind: 'ObjectField',
+																name: { kind: 'Name', value: 'lastname' },
+																value: { kind: 'EnumValue', value: 'asc_nulls_first' },
+															},
+														],
 													},
-												],
-											},
+												},
+											],
+										},
+										{
+											kind: 'ObjectValue',
+											fields: [
+												{
+													kind: 'ObjectField',
+													name: { kind: 'Name', value: 'beneficiary' },
+													value: {
+														kind: 'ObjectValue',
+														fields: [
+															{
+																kind: 'ObjectField',
+																name: { kind: 'Name', value: 'firstname' },
+																value: { kind: 'EnumValue', value: 'asc_nulls_first' },
+															},
+														],
+													},
+												},
+											],
+										},
+										{
+											kind: 'ObjectValue',
+											fields: [
+												{
+													kind: 'ObjectField',
+													name: { kind: 'Name', value: 'updated_at' },
+													value: { kind: 'EnumValue', value: 'desc_nulls_first' },
+												},
+											],
 										},
 									],
 								},
@@ -22634,161 +22929,16 @@ export const SearchPublicNotebooksDocument = {
 								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
 								{
 									kind: 'Field',
-									name: { kind: 'Name', value: 'beneficiary' },
+									name: { kind: 'Name', value: 'members' },
 									selectionSet: {
 										kind: 'SelectionSet',
 										selections: [
-											{ kind: 'Field', name: { kind: 'Name', value: 'dateOfBirth' } },
-											{ kind: 'Field', name: { kind: 'Name', value: 'firstname' } },
-											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
-											{ kind: 'Field', name: { kind: 'Name', value: 'lastname' } },
-											{ kind: 'Field', name: { kind: 'Name', value: 'mobileNumber' } },
-											{
-												kind: 'Field',
-												name: { kind: 'Name', value: 'orientationRequest' },
-												arguments: [
-													{
-														kind: 'Argument',
-														name: { kind: 'Name', value: 'order_by' },
-														value: {
-															kind: 'ObjectValue',
-															fields: [
-																{
-																	kind: 'ObjectField',
-																	name: { kind: 'Name', value: 'createdAt' },
-																	value: { kind: 'EnumValue', value: 'desc' },
-																},
-															],
-														},
-													},
-													{
-														kind: 'Argument',
-														name: { kind: 'Name', value: 'limit' },
-														value: { kind: 'IntValue', value: '1' },
-													},
-												],
-												selectionSet: {
-													kind: 'SelectionSet',
-													selections: [
-														{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
-														{ kind: 'Field', name: { kind: 'Name', value: 'status' } },
-														{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
-														{ kind: 'Field', name: { kind: 'Name', value: 'decidedAt' } },
-														{
-															kind: 'Field',
-															name: { kind: 'Name', value: 'requestedOrientationType' },
-															selectionSet: {
-																kind: 'SelectionSet',
-																selections: [
-																	{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
-																],
-															},
-														},
-													],
-												},
-											},
+											{ kind: 'Field', name: { kind: 'Name', value: 'active' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'accountId' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'memberType' } },
 										],
 									},
 								},
-							],
-						},
-					},
-					{
-						kind: 'Field',
-						alias: { kind: 'Name', value: 'notebooks_member_of' },
-						name: { kind: 'Name', value: 'search_public_notebooks' },
-						arguments: [
-							{
-								kind: 'Argument',
-								name: { kind: 'Name', value: 'args' },
-								value: {
-									kind: 'ObjectValue',
-									fields: [
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'search' },
-											value: { kind: 'Variable', name: { kind: 'Name', value: 'filter' } },
-										},
-									],
-								},
-							},
-							{
-								kind: 'Argument',
-								name: { kind: 'Name', value: 'order_by' },
-								value: {
-									kind: 'ObjectValue',
-									fields: [
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'updated_at' },
-											value: { kind: 'EnumValue', value: 'desc_nulls_first' },
-										},
-									],
-								},
-							},
-							{
-								kind: 'Argument',
-								name: { kind: 'Name', value: 'where' },
-								value: {
-									kind: 'ObjectValue',
-									fields: [
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'notebook' },
-											value: {
-												kind: 'ObjectValue',
-												fields: [
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: 'members' },
-														value: {
-															kind: 'ObjectValue',
-															fields: [
-																{
-																	kind: 'ObjectField',
-																	name: { kind: 'Name', value: 'active' },
-																	value: {
-																		kind: 'ObjectValue',
-																		fields: [
-																			{
-																				kind: 'ObjectField',
-																				name: { kind: 'Name', value: '_eq' },
-																				value: { kind: 'BooleanValue', value: true },
-																			},
-																		],
-																	},
-																},
-																{
-																	kind: 'ObjectField',
-																	name: { kind: 'Name', value: 'accountId' },
-																	value: {
-																		kind: 'ObjectValue',
-																		fields: [
-																			{
-																				kind: 'ObjectField',
-																				name: { kind: 'Name', value: '_eq' },
-																				value: {
-																					kind: 'Variable',
-																					name: { kind: 'Name', value: 'accountId' },
-																				},
-																			},
-																		],
-																	},
-																},
-															],
-														},
-													},
-												],
-											},
-										},
-									],
-								},
-							},
-						],
-						selectionSet: {
-							kind: 'SelectionSet',
-							selections: [
-								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
 								{
 									kind: 'Field',
 									name: { kind: 'Name', value: 'beneficiary' },

--- a/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
+++ b/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
@@ -10,13 +10,11 @@
 
 	function displayMemberType(members: PublicNotebook['members']): string {
 		const member = members.find((member) => member.accountId === accountId && member.active);
-		if (member) {
-			if (member.memberType === 'referent') {
-				return 'Oui (Référent)';
-			}
-			return 'Oui';
+		if (!member) {
+		  return 'Non';
 		}
-		return 'Non';
+		
+		return member.memberType === 'referent' ? 'Oui (Référent)' : 'Oui';
 	}
 </script>
 

--- a/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
+++ b/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import type { SearchPublicNotebooksQuery } from '$lib/graphql/_gen/typed-document-nodes';
+	import { formatDateLocale } from '$lib/utils/date';
+	import { displayFullName } from '$lib/ui/format';
+
+	type PublicNotebook = SearchPublicNotebooksQuery['notebooks'][0];
+
+	export let notebooks: PublicNotebook[];
+	export let accountId: string;
+
+	function displayMemberType(members: PublicNotebook['members']): string {
+		const member = members.find((member) => member.accountId === accountId && member.active);
+		if (member) {
+			if (member.memberType === 'referent') {
+				return 'Oui (Référent)';
+			}
+			return 'Oui';
+		}
+		return 'Non';
+	}
+</script>
+
+<table class="w-full fr-table fr-table--layout-fixed">
+	<caption class="sr-only">Liste des bénéficiaires</caption>
+	<thead>
+		<tr>
+			<th class="text-left">Nom</th>
+			<th class="text-left">Prénom</th>
+			<th class="text-left">Date de naissance</th>
+			<th class="text-left">Membre du groupe de suivi</th>
+			<th class="!text-center">Voir le carnet</th>
+		</tr>
+	</thead>
+	<tbody>
+		{#each notebooks as notebook}
+			<tr>
+				<td>{notebook.beneficiary.lastname}</td>
+				<td>{notebook.beneficiary.firstname}</td>
+				<td>{formatDateLocale(notebook.beneficiary.dateOfBirth)}</td>
+				<td>
+					{displayMemberType(notebook.members)}
+				</td>
+				<td class="!text-center">
+					<a
+						href={`carnets/${notebook.id}`}
+						rel="noreferrer"
+						class="fr-link"
+						title={`Voir le carnet de ${displayFullName(notebook.beneficiary)}`}
+					>
+						<span class="fr-icon-file-line" aria-hidden />
+					</a>
+				</td>
+			</tr>
+		{/each}
+		{#if notebooks.length === 0}
+			<tr><td colspan="10">Aucun bénéficiaire.</td></tr>
+		{/if}
+	</tbody>
+</table>

--- a/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
+++ b/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
@@ -11,9 +11,9 @@
 	function displayMemberType(members: PublicNotebook['members']): string {
 		const member = members.find((member) => member.accountId === accountId && member.active);
 		if (!member) {
-		  return 'Non';
+			return 'Non';
 		}
-		
+
 		return member.memberType === 'referent' ? 'Oui (Référent)' : 'Oui';
 	}
 </script>

--- a/app/src/lib/ui/ProBeneficiarySearchBar.svelte
+++ b/app/src/lib/ui/ProBeneficiarySearchBar.svelte
@@ -15,7 +15,7 @@
 
 <SearchBar
 	inputLabel="Rechercher un bénéficiaire"
-	inputHint="Nom, téléphone, n° CAF/MSA, n° Pôle emploi"
+	inputHint="Prénom, Nom, téléphone, n° CAF/MSA, n° Pôle emploi"
 	btnLabel="Rechercher"
 	bind:search
 	{handleSubmit}

--- a/app/src/routes/(auth)/pro/+layout.svelte
+++ b/app/src/routes/(auth)/pro/+layout.svelte
@@ -10,7 +10,7 @@
 		{
 			id: 'annuaire',
 			path: `${baseUrlForRole(RoleEnum.Professional)}/annuaire`,
-			label: 'Annuaire de mes bénéficiaires',
+			label: 'Annuaire des bénéficiaires',
 		},
 	];
 </script>

--- a/app/src/routes/(auth)/pro/annuaire/+page.svelte
+++ b/app/src/routes/(auth)/pro/annuaire/+page.svelte
@@ -47,7 +47,6 @@
 		updateResult();
 	}
 
-	/* TODO: find a way without cheating on that type */
 	$: notebooks = $result.data ? $result.data.notebooks : [];
 
 	function openCrisp() {

--- a/app/src/routes/(auth)/pro/annuaire/+page.svelte
+++ b/app/src/routes/(auth)/pro/annuaire/+page.svelte
@@ -13,6 +13,7 @@
 
 	import type { PageData } from './$types';
 	import { dt } from './+page';
+	import { accountData } from '$lib/stores';
 
 	export let data: PageData;
 
@@ -44,7 +45,7 @@
 			visitDate._lt = addMonths(today, -12);
 		}
 
-		const variables: SearchPublicNotebooksQueryVariables = {};
+		const variables: SearchPublicNotebooksQueryVariables = { accountId: $accountData.id };
 		variables.filter = `${search ?? ''}`;
 		return variables;
 	}

--- a/app/src/routes/(auth)/pro/annuaire/+page.svelte
+++ b/app/src/routes/(auth)/pro/annuaire/+page.svelte
@@ -68,7 +68,7 @@
 			<label class="fr-label" for="search-beneficiary">Rechercher un bénéficiaire</label>
 			<input
 				class="fr-input"
-				placeholder="Nom, téléphone, n° CAF, n° Pôle emploi"
+				placeholder="Prénom, Nom, téléphone, n° CAF/MSA, n° Pôle emploi"
 				type="search"
 				id="search-beneficiary"
 				name="search"

--- a/app/src/routes/(auth)/pro/annuaire/+page.ts
+++ b/app/src/routes/(auth)/pro/annuaire/+page.ts
@@ -1,20 +1,7 @@
 import type { PageLoad } from './$types';
 
-export const dt = {
-	none: 'none',
-	'3months': '3months',
-	'3-6months': '3-6months',
-	'6-12months': '6-12months',
-	'12months': '12months',
-};
-
 export const load: PageLoad = async ({ url }) => {
 	const search = url.searchParams.get('search');
 
-	let selected = dt.none;
-	if (url.searchParams.get('dt') && dt[url.searchParams.get('dt')]) {
-		selected = dt[url.searchParams.get('dt')];
-	}
-
-	return { search, selected };
+	return { search };
 };

--- a/app/src/routes/(auth)/pro/annuaire/_searchPublicNotebooks.gql
+++ b/app/src/routes/(auth)/pro/annuaire/_searchPublicNotebooks.gql
@@ -1,51 +1,33 @@
-query SearchPublicNotebooks(
-  $filter: String,
-  $accountId: uuid!
-) {
- search_public_notebooks(
-   args: { search: $filter },
-   order_by: { updated_at: desc_nulls_first },
-   where: {_not:{notebook:{members:{active:{_eq: true}, accountId:{_eq:$accountId}}}}}
- ) {
-   id
-   beneficiary {
-     dateOfBirth
-     firstname
-     id
-     lastname
-     mobileNumber
-     orientationRequest(order_by: {createdAt: desc}, limit: 1) {
-       id
-       status
-       createdAt
-       decidedAt
-       requestedOrientationType {
-         label
-       }
-     }
-   }
- },
- notebooks_member_of:search_public_notebooks(
-   args: { search: $filter },
-   order_by: { updated_at: desc_nulls_first }
-   where: {notebook:{members:{active:{_eq: true}, accountId:{_eq:$accountId}}}}
- ) {
-   id
-   beneficiary {
-     dateOfBirth
-     firstname
-     id
-     lastname
-     mobileNumber
-     orientationRequest(order_by: {createdAt: desc}, limit: 1) {
-       id
-       status
-       createdAt
-       decidedAt
-       requestedOrientationType {
-         label
-       }
-     }
-   }
- }
+query SearchPublicNotebooks($filter: String) {
+  notebooks: search_public_notebooks(
+    args: { search: $filter }
+    order_by: [
+      { beneficiary: { lastname: asc_nulls_first } }
+      { beneficiary: { firstname: asc_nulls_first } }
+      { updated_at: desc_nulls_first }
+    ]
+  ) {
+    id
+    members {
+      active
+      accountId
+      memberType
+    }
+    beneficiary {
+      dateOfBirth
+      firstname
+      id
+      lastname
+      mobileNumber
+      orientationRequest(order_by: { createdAt: desc }, limit: 1) {
+        id
+        status
+        createdAt
+        decidedAt
+        requestedOrientationType {
+          label
+        }
+      }
+    }
+  }
 }

--- a/app/src/routes/(auth)/pro/annuaire/_searchPublicNotebooks.gql
+++ b/app/src/routes/(auth)/pro/annuaire/_searchPublicNotebooks.gql
@@ -1,0 +1,26 @@
+query SearchPublicNotebooks(
+  $filter: String
+) {
+ search_public_notebooks(
+   args: { search: $filter },
+   order_by: { updated_at: desc_nulls_first }
+ ) {
+   id
+   beneficiary {
+     dateOfBirth
+     firstname
+     id
+     lastname
+     mobileNumber
+     orientationRequest(order_by: {createdAt: desc}, limit: 1) {
+       id
+       status
+       createdAt
+       decidedAt
+       requestedOrientationType {
+         label
+       }
+     }
+   }
+ }
+}

--- a/app/src/routes/(auth)/pro/annuaire/_searchPublicNotebooks.gql
+++ b/app/src/routes/(auth)/pro/annuaire/_searchPublicNotebooks.gql
@@ -1,9 +1,34 @@
 query SearchPublicNotebooks(
-  $filter: String
+  $filter: String,
+  $accountId: uuid!
 ) {
  search_public_notebooks(
    args: { search: $filter },
+   order_by: { updated_at: desc_nulls_first },
+   where: {_not:{notebook:{members:{active:{_eq: true}, accountId:{_eq:$accountId}}}}}
+ ) {
+   id
+   beneficiary {
+     dateOfBirth
+     firstname
+     id
+     lastname
+     mobileNumber
+     orientationRequest(order_by: {createdAt: desc}, limit: 1) {
+       id
+       status
+       createdAt
+       decidedAt
+       requestedOrientationType {
+         label
+       }
+     }
+   }
+ },
+ notebooks_member_of:search_public_notebooks(
+   args: { search: $filter },
    order_by: { updated_at: desc_nulls_first }
+   where: {notebook:{members:{active:{_eq: true}, accountId:{_eq:$accountId}}}}
  ) {
    id
    beneficiary {

--- a/app/src/routes/+layout.server.ts
+++ b/app/src/routes/+layout.server.ts
@@ -24,7 +24,6 @@ export const load: LayoutServerLoad = async (event) => {
 			event.url.pathname === '/' ||
 			(needAuth(event.url.pathname) && !event.url.pathname.startsWith(baseUrlForRole(user.role)))
 		) {
-			console.log(event.url, homeForRole);
 			throw redirect(302, homeForRole(user.role));
 		}
 	} else if (needAuth(event.url.pathname)) {

--- a/e2e/features/pro/annuaire/recherche.feature
+++ b/e2e/features/pro/annuaire/recherche.feature
@@ -6,30 +6,28 @@ Fonctionnalité: Recherche de bénéficiaires sur l'annuaire
 
 Scénario: Annuaire des bénéficiaires
 	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
-	Quand je clique sur "Annuaire de mes bénéficiaires"
-	Alors je vois "Annuaire de mes bénéficiaires"
-	Alors je vois "Sophie"
-	Alors je vois "Tifour"
+	Quand je clique sur "Annuaire des bénéficiaires"
+	Alors je vois "Annuaire des bénéficiaires"
+	Alors je vois "Vous pouvez recherche un bénéficiaire"
 
 Scénario: Recherche d'un carnet existant depuis l'annuaire
 	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
-	Quand je clique sur "Annuaire de mes bénéficiaires"
+	Quand je clique sur "Annuaire des bénéficiaires"
 	Quand je renseigne "Tifour" dans le champ "Rechercher un bénéficiaire"
 	Quand je clique sur "Rechercher"
 	Alors je vois "Sophie"
 	Alors je vois "Tifour"
 
-Scénario: Recherche de carnet inexistant depuis l'annuaire
+Scénario: Recherche de carnet hors groupe de suivi
 	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
-	Quand je clique sur "Annuaire de mes bénéficiaires"
+	Quand je clique sur "Annuaire des bénéficiaires"
 	Quand je renseigne "Connor" dans le champ "Rechercher un bénéficiaire"
-	Alors je vois "Connor" dans le champ "Rechercher un bénéficiaire"
 	Quand je clique sur "Rechercher"
-	Alors je vois "aucun bénéficiaire"
+	Alors je vois "Oconnor"
 
 Scénario: Recherche d'un bénéficiaire hors déploiement
 	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
-	Quand je clique sur "Annuaire de mes bénéficiaires"
+	Quand je clique sur "Annuaire des bénéficiaires"
 	Quand je renseigne "Saintpa" dans le champ "Rechercher un bénéficiaire"
 	Quand je clique sur "Rechercher"
 	Alors je vois "aucun bénéficiaire"

--- a/e2e/features/pro/annuaire/recherche.feature
+++ b/e2e/features/pro/annuaire/recherche.feature
@@ -22,7 +22,7 @@ Scénario: Recherche de carnet hors groupe de suivi
 	Quand je clique sur "Annuaire des bénéficiaires"
 	Quand je renseigne "Connor" dans le champ "Rechercher un bénéficiaire"
 	Quand je clique sur "Rechercher"
-	Alors je vois "Carslon" dans le tableau "Liste des bénéficiaires"
+	Alors je vois "Carlson" dans le tableau "Liste des bénéficiaires"
 
 Scénario: Recherche d'un bénéficiaire hors déploiement
 	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion

--- a/e2e/features/pro/annuaire/recherche.feature
+++ b/e2e/features/pro/annuaire/recherche.feature
@@ -26,3 +26,10 @@ Scénario: Recherche de carnet inexistant depuis l'annuaire
 	Alors je vois "Connor" dans le champ "Rechercher un bénéficiaire"
 	Quand je clique sur "Rechercher"
 	Alors je vois "aucun bénéficiaire"
+
+Scénario: Recherche d'un bénéficiaire hors déploiement
+	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
+	Quand je clique sur "Annuaire de mes bénéficiaires"
+	Quand je renseigne "Saintpa" dans le champ "Rechercher un bénéficiaire"
+	Quand je clique sur "Rechercher"
+	Alors je vois "aucun bénéficiaire"

--- a/e2e/features/pro/annuaire/recherche.feature
+++ b/e2e/features/pro/annuaire/recherche.feature
@@ -8,22 +8,21 @@ Scénario: Annuaire des bénéficiaires
 	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
 	Quand je clique sur "Annuaire des bénéficiaires"
 	Alors je vois "Annuaire des bénéficiaires"
-	Alors je vois "Vous pouvez recherche un bénéficiaire"
+	Alors je vois "Vous pouvez rechercher un bénéficiaire"
 
 Scénario: Recherche d'un carnet existant depuis l'annuaire
 	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
 	Quand je clique sur "Annuaire des bénéficiaires"
 	Quand je renseigne "Tifour" dans le champ "Rechercher un bénéficiaire"
 	Quand je clique sur "Rechercher"
-	Alors je vois "Sophie"
-	Alors je vois "Tifour"
+	Alors je vois "Tifour" dans le tableau "Liste des bénéficiaires"
 
 Scénario: Recherche de carnet hors groupe de suivi
 	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
 	Quand je clique sur "Annuaire des bénéficiaires"
 	Quand je renseigne "Connor" dans le champ "Rechercher un bénéficiaire"
 	Quand je clique sur "Rechercher"
-	Alors je vois "Oconnor"
+	Alors je vois "Carslon" dans le tableau "Liste des bénéficiaires"
 
 Scénario: Recherche d'un bénéficiaire hors déploiement
 	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion

--- a/hasura/metadata/databases/carnet_de_bord/functions/functions.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/functions/functions.yaml
@@ -1,3 +1,4 @@
 - "!include public_search_beneficiaries.yaml"
 - "!include public_search_notebook_members.yaml"
+- "!include public_search_public_notebooks.yaml"
 - "!include public_search_rome_codes.yaml"

--- a/hasura/metadata/databases/carnet_de_bord/functions/public_search_public_notebooks.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/functions/public_search_public_notebooks.yaml
@@ -1,0 +1,3 @@
+function:
+  name: search_public_notebooks
+  schema: public

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_public_view.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_public_view.yaml
@@ -47,7 +47,10 @@ select_permissions:
         - updated_at
         - beneficiary_id
         - id
-      filter: {}
+      filter:
+        beneficiary:
+          deployment_id:
+            _eq: X-Hasura-Deployment-Id
       allow_aggregations: true
   - role: manager
     permission:
@@ -56,7 +59,10 @@ select_permissions:
         - updated_at
         - beneficiary_id
         - id
-      filter: {}
+      filter:
+        beneficiary:
+          deployment_id:
+            _eq: X-Hasura-Deployment-Id
       allow_aggregations: true
   - role: orientation_manager
     permission:
@@ -65,7 +71,10 @@ select_permissions:
         - updated_at
         - beneficiary_id
         - id
-      filter: {}
+      filter:
+        beneficiary:
+          deployment_id:
+            _eq: X-Hasura-Deployment-Id
       allow_aggregations: true
   - role: professional
     permission:
@@ -74,5 +83,8 @@ select_permissions:
         - updated_at
         - beneficiary_id
         - id
-      filter: {}
+      filter:
+        beneficiary:
+          deployment_id:
+            _eq: X-Hasura-Deployment-Id
       allow_aggregations: true

--- a/hasura/migrations/carnet_de_bord/1671012020468_search_public_notebooks/down.sql
+++ b/hasura/migrations/carnet_de_bord/1671012020468_search_public_notebooks/down.sql
@@ -1,4 +1,3 @@
--- Could not auto-generate a down migration.
 -- Please write an appropriate down migration for the SQL below:
 -- CREATE OR REPLACE FUNCTION public.search_public_notebooks(search text)
 -- RETURNS SETOF notebook_public_view
@@ -17,3 +16,4 @@
 --     OR search <% beneficiary.caf_number
 --     OR search <% beneficiary.mobile_number
 -- $function$;
+DROP FUNCTION public.search_public_notebooks;

--- a/hasura/migrations/carnet_de_bord/1671012020468_search_public_notebooks/down.sql
+++ b/hasura/migrations/carnet_de_bord/1671012020468_search_public_notebooks/down.sql
@@ -1,19 +1,1 @@
--- Please write an appropriate down migration for the SQL below:
--- CREATE OR REPLACE FUNCTION public.search_public_notebooks(search text)
--- RETURNS SETOF notebook_public_view
--- LANGUAGE sql
--- STABLE
--- AS $function$
---   SELECT
---     notebook_public_view.*
---   FROM
---     notebook_public_view
---     JOIN beneficiary ON beneficiary.id = notebook_public_view.beneficiary_id
---   WHERE
---     search = ''
---     OR unaccent(search) <% unaccent(CONCAT(beneficiary.firstname, ' ', beneficiary.lastname))
---     OR search <% beneficiary.pe_number
---     OR search <% beneficiary.caf_number
---     OR search <% beneficiary.mobile_number
--- $function$;
 DROP FUNCTION public.search_public_notebooks;

--- a/hasura/migrations/carnet_de_bord/1671012020468_search_public_notebooks/down.sql
+++ b/hasura/migrations/carnet_de_bord/1671012020468_search_public_notebooks/down.sql
@@ -1,0 +1,19 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE OR REPLACE FUNCTION public.search_public_notebooks(search text)
+-- RETURNS SETOF notebook_public_view
+-- LANGUAGE sql
+-- STABLE
+-- AS $function$
+--   SELECT
+--     notebook_public_view.*
+--   FROM
+--     notebook_public_view
+--     JOIN beneficiary ON beneficiary.id = notebook_public_view.beneficiary_id
+--   WHERE
+--     search = ''
+--     OR unaccent(search) <% unaccent(CONCAT(beneficiary.firstname, ' ', beneficiary.lastname))
+--     OR search <% beneficiary.pe_number
+--     OR search <% beneficiary.caf_number
+--     OR search <% beneficiary.mobile_number
+-- $function$;

--- a/hasura/migrations/carnet_de_bord/1671012020468_search_public_notebooks/up.sql
+++ b/hasura/migrations/carnet_de_bord/1671012020468_search_public_notebooks/up.sql
@@ -9,8 +9,7 @@ AS $function$
     notebook_public_view
     JOIN beneficiary ON beneficiary.id = notebook_public_view.beneficiary_id
   WHERE
-    search = ''
-    OR unaccent(search) <% unaccent(CONCAT(beneficiary.firstname, ' ', beneficiary.lastname))
+    unaccent(search) <% unaccent(CONCAT(beneficiary.firstname, ' ', beneficiary.lastname))
     OR search <% beneficiary.pe_number
     OR search <% beneficiary.caf_number
     OR search <% beneficiary.mobile_number

--- a/hasura/migrations/carnet_de_bord/1671012020468_search_public_notebooks/up.sql
+++ b/hasura/migrations/carnet_de_bord/1671012020468_search_public_notebooks/up.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION public.search_public_notebooks(search text)
+RETURNS SETOF notebook_public_view
+LANGUAGE sql
+STABLE
+AS $function$
+  SELECT
+    notebook_public_view.*
+  FROM
+    notebook_public_view
+    JOIN beneficiary ON beneficiary.id = notebook_public_view.beneficiary_id
+  WHERE
+    search = ''
+    OR unaccent(search) <% unaccent(CONCAT(beneficiary.firstname, ' ', beneficiary.lastname))
+    OR search <% beneficiary.pe_number
+    OR search <% beneficiary.caf_number
+    OR search <% beneficiary.mobile_number
+$function$;


### PR DESCRIPTION
## :wrench: Problème

Depuis l'annuaire un pro accède uniquement à l'annuaire de ses bénéficiaires la barre de recherche de l'écran d'accueil ne lui permet pas de voir ceux dont il n'est pas dans le groupe de suivi

## :cake: Solution

Permettre aux profils professional de rechercher, et d'accéder au carnet de bord de n'importe quel bénéficiaire uniquement en lecture.

Pour ce faire on change la requête graphql qui interrogeait les `notebook_member` pour la faire interroger la nouvelle vue contentant les `public_notebook`.


## :rotating_light:  Points d'attention / Remarques

On cherche maintenant dans les prénoms ET les noms

## :desert_island: Comment tester

Se connecter en tant que `pierre.chevalier`, chercher dans l'annuaire des bénéficiaires 'myrna' et s'assurer que son notebook s'affiche bien dans les résultats de recherche.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1360.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

fix #1270 
