### PR TITLE
feat: get rid of 'default' and 'done' definitely

### DIFF
--- a/hasura/migrations/carnet_de_bord/1671553444065_migrate_pending_and_done_beneficiary_structures/down.sql
+++ b/hasura/migrations/carnet_de_bord/1671553444065_migrate_pending_and_done_beneficiary_structures/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE beneficiary_structure
+  ALTER COLUMN status
+  SET DEFAULT 'pending';

--- a/hasura/migrations/carnet_de_bord/1671553444065_migrate_pending_and_done_beneficiary_structures/up.sql
+++ b/hasura/migrations/carnet_de_bord/1671553444065_migrate_pending_and_done_beneficiary_structures/up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE beneficiary_structure
+  ALTER COLUMN status
+  SET DEFAULT 'current';
+
+UPDATE beneficiary_structure
+  SET status = 'current'
+  WHERE status = 'done'
+  OR status = 'pending';


### PR DESCRIPTION
## :wrench: Problème

Il reste des `beneficiary_structure` avec le statut `done` ou `pending`.

## :cake: Solution

Changer le default pour la colonne `status`, et migrer les données.

## :desert_island: Comment tester

Tester la migration en local.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1369.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
