### PR TITLE
fix: update python structure model and transform empty string to null

### DIFF
--- a/app/src/lib/ui/AdminStructure/AdminStructureForm.svelte
+++ b/app/src/lib/ui/AdminStructure/AdminStructureForm.svelte
@@ -17,6 +17,10 @@
 	export let hiddenFields: Partial<
 		Record<keyof (AccountRequest & { phoneNumbers?: string }), boolean>
 	> = {};
+
+	function submitHandler(values: AdminStructureAccountInput) {
+		onSubmit(adminStructureAccountSchema.cast(values));
+	}
 </script>
 
 <Form
@@ -27,7 +31,7 @@
 		phoneNumbers: initialValues.phoneNumbers,
 	}}
 	validationSchema={adminStructureAccountSchema}
-	{onSubmit}
+	onSubmit={submitHandler}
 	let:isSubmitting
 	let:isSubmitted
 	let:isValid

--- a/app/src/lib/ui/AdminStructure/adminStructure.schema.test.ts
+++ b/app/src/lib/ui/AdminStructure/adminStructure.schema.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'vitest';
+import { adminStructureAccountSchema } from './adminStructure.schema';
+
+describe('adminStructure schema', () => {
+	it('should return a parsed object', () => {
+		expect(
+			adminStructureAccountSchema.cast({
+				firstname: 'Lara',
+				lastname: 'Pafromage',
+				email: 'lara.pafromage@cd93.fr',
+				phoneNumbers: '',
+			})
+		).toMatchInlineSnapshot(`
+			{
+			  "email": "lara.pafromage@cd93.fr",
+			  "firstname": "Lara",
+			  "lastname": "Pafromage",
+			  "phoneNumbers": null,
+			}
+		`);
+	});
+});

--- a/app/src/lib/ui/AdminStructure/adminStructure.schema.ts
+++ b/app/src/lib/ui/AdminStructure/adminStructure.schema.ts
@@ -1,4 +1,4 @@
-import { cityOrNameValidation, validatePhoneNumber } from '$lib/validation';
+import { cityOrNameValidation, nullifyEmptyString, validatePhoneNumber } from '$lib/validation';
 import * as yup from 'yup';
 
 export const adminStructureAccountSchema = yup.object().shape({
@@ -17,6 +17,7 @@ export const adminStructureAccountSchema = yup.object().shape({
 			}
 			return true;
 		})
+		.transform(nullifyEmptyString)
 		.nullable(),
 });
 

--- a/app/src/lib/ui/ProBeneficiaryUpdate/beneficiary.schema.ts
+++ b/app/src/lib/ui/ProBeneficiaryUpdate/beneficiary.schema.ts
@@ -1,5 +1,6 @@
 import {
 	cityOrNameValidation,
+	nullifyEmptyString,
 	validateCodePostal,
 	validateDateInput,
 	validatePhoneNumber,
@@ -25,8 +26,9 @@ const beneficiaryAccountSchemaObject = {
 			}
 			return true;
 		})
+		.transform(nullifyEmptyString)
 		.nullable(),
-	email: yup.string().trim().email().nullable(),
+	email: yup.string().trim().email().transform(nullifyEmptyString).nullable(),
 	address1: yup.string().trim().nullable(),
 	address2: yup.string().trim().nullable(),
 	postalCode: yup

--- a/app/src/lib/ui/StructureEdit/StructureCreationForm.svelte
+++ b/app/src/lib/ui/StructureEdit/StructureCreationForm.svelte
@@ -9,12 +9,15 @@
 	export let initialValues: GetStructuresForDeploymentQuery['structure'][0];
 	export let onSubmit: (values: StructureFormInput) => void;
 	export let onCancel: () => void = null;
+	function submitHandler(values: StructureFormInput) {
+		onSubmit(structureSchema.cast(values));
+	}
 </script>
 
 <Form
 	{initialValues}
 	validationSchema={structureSchema}
-	{onSubmit}
+	onSubmit={submitHandler}
 	let:isSubmitting
 	let:isSubmitted
 	let:isValid

--- a/app/src/lib/ui/StructureEdit/structure.schema.test.ts
+++ b/app/src/lib/ui/StructureEdit/structure.schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'vitest';
+import { structureSchema } from './structure.schema';
+
+describe('structureSchema model', () => {
+	it('should return a parsed structure model', async () => {
+		expect(
+			structureSchema.cast({
+				id: '939364c2-d825-4e42-8dac-e7126fdb2f1c',
+				siret: '',
+				name: 'test lionel',
+				shortDesc: 'testée',
+				phone: '',
+				email: '',
+				postalCode: '08000',
+				city: 'CHARLEVILLE MEZIERES',
+				address1: '6 RUE JEAN BAPTISTE LEFORT',
+				address2: '',
+				website: '',
+			})
+		).toMatchInlineSnapshot(`
+			{
+			  "address1": "6 RUE JEAN BAPTISTE LEFORT",
+			  "address2": null,
+			  "city": "CHARLEVILLE MEZIERES",
+			  "email": null,
+			  "id": "939364c2-d825-4e42-8dac-e7126fdb2f1c",
+			  "name": "test lionel",
+			  "phone": null,
+			  "postalCode": "08000",
+			  "shortDesc": "testée",
+			  "siret": null,
+			  "website": null,
+			}
+		`);
+	});
+});

--- a/app/src/lib/ui/StructureEdit/structure.schema.ts
+++ b/app/src/lib/ui/StructureEdit/structure.schema.ts
@@ -1,5 +1,6 @@
 import {
 	cityOrNameValidation,
+	nullifyEmptyString,
 	validateCodePostal,
 	validateLuhn,
 	validatePhoneNumber,
@@ -16,6 +17,7 @@ export const structureSchema = yup.object().shape({
 			}
 			return true;
 		})
+		.transform(nullifyEmptyString)
 		.nullable(),
 	name: yup.string().trim().required(),
 	shortDesc: yup.string().trim().nullable(),
@@ -31,8 +33,9 @@ export const structureSchema = yup.object().shape({
 			}
 			return true;
 		})
+		.transform(nullifyEmptyString)
 		.nullable(),
-	email: yup.string().trim().email().nullable(),
+	email: yup.string().trim().email().transform(nullifyEmptyString).nullable(true),
 	postalCode: yup
 		.string()
 		.trim()
@@ -46,8 +49,8 @@ export const structureSchema = yup.object().shape({
 		.nullable(),
 	city: cityOrNameValidation.trim().nullable(),
 	address1: yup.string().trim().nullable(),
-	address2: yup.string().trim().nullable(),
-	website: yup.string().trim().nullable(),
+	address2: yup.string().trim().nullable().transform(nullifyEmptyString),
+	website: yup.string().trim().transform(nullifyEmptyString).nullable(),
 });
 
 export type StructureFormInput = yup.InferType<typeof structureSchema>;

--- a/app/src/lib/validation.test.ts
+++ b/app/src/lib/validation.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from 'vitest';
+import { nullifyEmptyString } from './validation';
+
+describe('nullify empty string', () => {
+	it('should return null when string is empty', async () => {
+		expect(nullifyEmptyString('')).eq(null);
+	});
+	it('should return the string when string is not empty', async () => {
+		expect(nullifyEmptyString('toto')).eq('toto');
+	});
+});

--- a/app/src/lib/validation.ts
+++ b/app/src/lib/validation.ts
@@ -42,3 +42,5 @@ export const cityOrNameValidation = yupString().matches(
 	/^[A-Za-zÀ-ÖØ-öø-ÿ\- ']+$/,
 	'Seuls les espaces, les lettres, l’apostrophe et le tiret sont acceptés'
 );
+
+export const nullifyEmptyString = (value) => (value ? value : null);

--- a/backend/api/db/crud/structure.py
+++ b/backend/api/db/crud/structure.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from asyncpg import Record
 from asyncpg.connection import Connection
+from pydantic import EmailStr
 
 from api.db.models.structure import Structure, StructureInsert
 from pe.models.agence import Agence
@@ -23,7 +24,17 @@ async def insert_structure(
         INSERT INTO public.structure (siret, name, short_desc, phone, email, postal_code, city, address1, address2, website, deployment_id)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) returning id, siret, name, short_desc, phone, email, postal_code, city, address1, address2, website, deployment_id, created_at, updated_at
         """,
-        *structure_insert.dict().values(),
+        structure_insert.siret,
+        structure_insert.name,
+        structure_insert.short_desc,
+        structure_insert.phone,
+        structure_insert.email,
+        structure_insert.postal_code,
+        structure_insert.city,
+        structure_insert.address1,
+        structure_insert.address2,
+        structure_insert.website,
+        structure_insert.deployment_id,
     )
 
     if record:
@@ -100,7 +111,7 @@ async def create_structure_from_agences_list(
             name=agence.libelleEtendu,
             short_desc=agence.libelle,
             phone=agence.contact.telephonePublic,
-            email=agence.contact.email,
+            email=EmailStr(agence.contact.email),
             postal_code=postal_code,
             city=city,
             address1=agence.adressePrincipale.ligne4,

--- a/backend/api/db/models/structure.py
+++ b/backend/api/db/models/structure.py
@@ -9,22 +9,27 @@ from api.db.models.csv import CsvFieldError
 from api.db.models.validator import phone_validator, postal_code_validator
 
 
-class StructureInsert(BaseModel):
+class BaseStructure(BaseModel):
     siret: str | None
     name: str | None
     short_desc: str | None
     phone: str | None
-    email: EmailStr | None
     postal_code: str | None
     city: str | None
     address1: str | None
     address2: str | None
-    website: str | None
     deployment_id: UUID | None
 
 
-class Structure(StructureInsert):
+class StructureInsert(BaseStructure):
+    email: EmailStr | None
+    website: HttpUrl | None
+
+
+class Structure(BaseStructure):
     id: UUID
+    website: str | None
+    email: str | None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/api/v1/routers/structures.py
+++ b/backend/api/v1/routers/structures.py
@@ -51,6 +51,8 @@ async def create_structures(
     for structure_row in data.structures:
         try:
             async with db.transaction():
+                # TODO Filter By Deployement Id
+                # TODO deployement should be not nullable on DB
                 structure: Structure | None = await get_structure_by_name(
                     db, structure_row.name
                 )
@@ -116,6 +118,7 @@ async def create_structures(
                 )
                 if not uuid:
                     raise InsertFailError("add admin structure to structure failed")
+
                 response_row = StructureCsvRowResponse(valid=True, data=structure_row)
         except InsertFailError as error:
             logging.error(error)

--- a/backend/tests/test_structure.py
+++ b/backend/tests/test_structure.py
@@ -1,3 +1,5 @@
+from pydantic import EmailStr, HttpUrl, parse_obj_as
+
 from api.db.crud.structure import get_structure_by_name, insert_structure
 from api.db.models.structure import Structure, StructureInsert
 
@@ -9,12 +11,12 @@ async def test_insert_structure(db_connection):
         name="test name",
         short_desc="short desc",
         phone="0666666666",
-        email="test@test.com",
+        email=EmailStr("test@test.com"),
         postal_code="72000",
         city="Le Mans",
         address1="Rue des coquelicots",
         address2="addresse 2",
-        website="https://test.com",
+        website=HttpUrl(url="www.test.com", scheme="https"),
         deployment_id=None,
     )
     structure: Structure | None = await insert_structure(
@@ -37,6 +39,32 @@ async def test_get_structure_by_name_case_insensitive(db_connection):
 
     structure: Structure | None = await get_structure_by_name(
         db_connection, "pole emploi agence livry-gargnan"
+    )
+
+    assert structure is not None
+
+
+async def test_get_structure_does_not_validate_email_nor_website(db_connection):
+
+    await db_connection.fetchrow(
+        """
+        INSERT INTO public.structure (siret, name, phone, email, postal_code, city, website, deployment_id)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        """,
+        *{
+            "siret": "",
+            "name": "test validate",
+            "phone": "",
+            "email": "",
+            "postal_code": "",
+            "city": "",
+            "website": "",
+            "deployment_id": None,
+        }.values(),
+    )
+
+    structure: Structure | None = await get_structure_by_name(
+        db_connection, "test validate"
     )
 
     assert structure is not None


### PR DESCRIPTION
## :wrench: Problème

Certaines structures ne sont pas importés parce qu'elle contienne des champs email vide dans la base ce qui leve une exception car le model Pydantic actuel s'attend à trouver des adresses email valide.

## :cake: Solution

Modifier les modèles pydantic et éviter d'enregistrer des chaines vides depuis le client.


## :rotating_light:  Points d'attention / Remarques

> _Précisez si il y a des cas particuliers ou des sujets connexes à partager ?_

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1374.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

fix  #1373