### PR TITLE
fix: carnet url

### DIFF
--- a/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
+++ b/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
@@ -40,7 +40,7 @@
 				</td>
 				<td class="!text-center">
 					<a
-						href={`carnets/${notebook.id}`}
+						href={`carnet/${notebook.id}`}
 						rel="noreferrer"
 						class="fr-link"
 						title={`Voir le carnet de ${displayFullName(notebook.beneficiary)}`}

--- a/e2e/features/pro/carnet/read_only_other_notebook.feature
+++ b/e2e/features/pro/carnet/read_only_other_notebook.feature
@@ -5,7 +5,11 @@ Fonctionnalité: Accès en lecture seule à un carnet dont je ne suis pas membre
 	Je veux uniquement voir les informations personnelles et le groupe de suivi du bénificiaire
 
 	Scénario: Accès au carnet
-		Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Henderson"
+		Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
+		Alors je vois "Rechercher un bénéficiaire"
+		Quand je renseigne "myrna" dans le champ "Rechercher un bénéficiaire"
+		Quand je clique sur "Rechercher"
+		Alors je clique sur "Voir le carnet de Myrna Henderson"
 		Alors j'attends que le texte "Myrna Henderson" apparaisse
 		Alors je ne vois pas "Plan d'action"
 		Alors je ne vois pas "Situation socioprofessionnelle"


### PR DESCRIPTION
## :wrench: Problème

ETQ Pro, quand j'effectue une recherche d'usagers depuis la page annuaire des bénéficiaires et que je cherches à accéder à un carnet depuis les résultats de cette recherche, j'arrive sur une page qui n'existe pas. il y a une erreur dans l'url (un s en trop à carnet)

## :cake: Solution

On met à jour le lien avec la bonne url


## :rotating_light:  Points d'attention / Remarques

on en profite pour mettre à jour le test d'acces au carnet anonyme pour avoir un parcours complet

## :desert_island: Comment tester

- Se connecter en tant que `pierre.chevalier`
- lancer une recherche sur `myrna`
- cliquer sur le lien dans les résultats
- voir le carnet de myrna henderson

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1377.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


fix #1376
