### PR TITLE
fix: afficher seulement les bénéficiaires de la structure avec l'option tous

### DIFF
--- a/app/src/lib/ui/BeneficiaryList/Container.svelte
+++ b/app/src/lib/ui/BeneficiaryList/Container.svelte
@@ -104,7 +104,6 @@
 					},
 				];
 			}
-		}
 		if (filter === 'noMember') {
 			if (structureId) {
 				graphqlFilter.structures = {

--- a/app/src/lib/ui/BeneficiaryList/Container.svelte
+++ b/app/src/lib/ui/BeneficiaryList/Container.svelte
@@ -91,8 +91,7 @@
 			},
 		};
 
-		if (filter === 'all') {
-			if (structureId) {
+		if (filter === 'all' && structureId) {
 				graphqlFilter._or = [
 					{ structures: { structureId: { _eq: structureId } } },
 					{

--- a/app/src/lib/ui/BeneficiaryList/Container.svelte
+++ b/app/src/lib/ui/BeneficiaryList/Container.svelte
@@ -92,18 +92,18 @@
 		};
 
 		if (filter === 'all' && structureId) {
-				graphqlFilter._or = [
-					{ structures: { structureId: { _eq: structureId } } },
-					{
-						notebook: {
-							members: {
-								active: { _eq: true },
-								account: { professional: { structureId: { _eq: structureId } } },
-							},
+			graphqlFilter._or = [
+				{ structures: { structureId: { _eq: structureId } } },
+				{
+					notebook: {
+						members: {
+							active: { _eq: true },
+							account: { professional: { structureId: { _eq: structureId } } },
 						},
 					},
-				];
-			}
+				},
+			];
+		}
 		if (filter === 'noMember') {
 			if (structureId) {
 				graphqlFilter.structures = {

--- a/app/src/lib/ui/BeneficiaryList/Container.svelte
+++ b/app/src/lib/ui/BeneficiaryList/Container.svelte
@@ -91,6 +91,21 @@
 			},
 		};
 
+		if (filter === 'all') {
+			if (structureId) {
+				graphqlFilter._or = [
+					{ structures: { structureId: { _eq: structureId } } },
+					{
+						notebook: {
+							members: {
+								active: { _eq: true },
+								account: { professional: { structureId: { _eq: structureId } } },
+							},
+						},
+					},
+				];
+			}
+		}
 		if (filter === 'noMember') {
 			if (structureId) {
 				graphqlFilter.structures = {

--- a/app/src/routes/(auth)/structures/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/structures/[uuid]/+page.svelte
@@ -67,7 +67,7 @@
 			label: `${pluralize(
 				'Bénéficiaire',
 				structure?.beneficiaries?.aggregate?.count ?? 0
-			)} non ${pluralize('rattaché', structure?.beneficiaries?.aggregate?.count ?? 0)}`,
+			)} non ${pluralize('accompagné', structure?.beneficiaries?.aggregate?.count ?? 0)}`,
 			amount: structure?.beneficiaries?.aggregate?.count ?? 0,
 			classNames:
 				structure?.beneficiaries?.aggregate?.count > 0 ? 'text-marianne-red' : 'text-success',

--- a/e2e/features/structureAdmin/beneficiary_list.feature
+++ b/e2e/features/structureAdmin/beneficiary_list.feature
@@ -1,7 +1,7 @@
 #language: fr
 
 Fonctionnalité: Liste des bénéficiaires
-	Pour permettre aux administrateur de structure de gérer les bénéficiaires attachés à leur structure
+	Pour permettre aux administrateur de structure de gérer les bénéficiaires accompagnés par leur structure
 	En tant qu'administrateur de structure
 	Je veux pouvoir filter les bénéficiaires de ma structure
 

--- a/e2e/features/structureAdmin/beneficiary_list.feature
+++ b/e2e/features/structureAdmin/beneficiary_list.feature
@@ -1,0 +1,16 @@
+#language: fr
+
+Fonctionnalité: Liste des bénéficiaires
+	Pour permettre aux administrateur de structure de gérer les bénéficiaires attachés à leur structure
+	En tant qu'administrateur de structure
+	Je veux pouvoir filter les bénéficiaires de ma structure
+
+	Scénario: Voir tout les bénéficiaires
+		Soit un "administrateur de structures" authentifié avec l'email "lara.pafromage@cd93.fr"
+		Alors je clique sur "Interlogement 93"
+		Alors je vois "2" dans la tuile "Bénéficiaires non accompagnés"
+		Alors je vois "4" dans la tuile "Bénéficiaires accompagnés"
+		Alors je clique sur "Bénéficiaires non accompagnés"
+		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
+		Alors je selectionne l'option "Tous" dans la liste "Rattachement"
+		Alors je vois "6" lignes dans la table "Liste des bénéficiaires"

--- a/e2e/features/structureAdmin/dashboard.feature
+++ b/e2e/features/structureAdmin/dashboard.feature
@@ -16,11 +16,11 @@ Fonctionnalité: Voir les infos de ma structure
 		Alors je vois "Orial Edith" sur la ligne "Lindsay"
 		Alors je vois "Orial Edith" sur la ligne "Valenzuela"
 
-	Scénario: Bénéficiaires non rattachés
+	Scénario: Bénéficiaires non accompagnés
 		Soit un "administrateur de structures" authentifié avec l'email "lara.pafromage@cd93.fr"
 		Quand je clique sur "Interlogement 93"
 		Alors je vois "Portefeuille de la structure"
-		Alors je vois "2" dans la tuile "Bénéficiaires non rattachés"
-		Quand je clique sur "Bénéficiaires non rattachés"
+		Alors je vois "2" dans la tuile "Bénéficiaires non accompagnés"
+		Quand je clique sur "Bénéficiaires non accompagnés"
 		Alors je vois "Non rattaché" sur la ligne "Gallegos"
 		Alors je vois "Non rattaché" sur la ligne "Carlson"

--- a/e2e/features/structureAdmin/rattachementBeneficiaires.feature
+++ b/e2e/features/structureAdmin/rattachementBeneficiaires.feature
@@ -23,8 +23,8 @@ Fonctionnalité: Rattachement liste de bénéficiaires
 		Soit un "administrateur de structures" authentifié avec l'email "vincent.timaitre@groupe-ns.fr"
 		Quand je vois "Groupe NS"
 		Alors je clique sur "Groupe NS"
-		Alors je vois "18" dans la tuile "Bénéficiaires non rattachés"
-		Alors je clique sur "Bénéficiaires non rattachés"
+		Alors je vois "18" dans la tuile "Bénéficiaires non accompagnés"
+		Alors je clique sur "Bénéficiaires non accompagnés"
 		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Alors je selectionne l'option "Tous" dans la liste "Rattachement"
 		Alors je choisis "Sélectionner Katrina Beach"
@@ -42,8 +42,8 @@ Fonctionnalité: Rattachement liste de bénéficiaires
 		Soit un "administrateur de structures" authentifié avec l'email "vincent.timaitre@groupe-ns.fr"
 		Quand je vois "Groupe NS"
 		Alors je clique sur "Groupe NS"
-		Alors je vois "18" dans la tuile "Bénéficiaires non rattachés"
-		Alors je clique sur "Bénéficiaires non rattachés"
+		Alors je vois "18" dans la tuile "Bénéficiaires non accompagnés"
+		Alors je clique sur "Bénéficiaires non accompagnés"
 		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Alors je selectionne l'option "Tous" dans la liste "Rattachement"
 		Quand je recherche "Beach"

--- a/e2e/features/structureAdmin/viewNotebook.feature
+++ b/e2e/features/structureAdmin/viewNotebook.feature
@@ -7,7 +7,7 @@ Fonctionnalité: Consultation d'un carnet par un gestionnaire de structure
 	Scénario: voir un carnet par un gestionnaire de structure
 		Soit un "administrateur de structures" authentifié avec l'email "jacques.celaire@livry-gargan.fr"
 		Quand je clique sur "Centre Communal d'action social Livry-Gargan"
-		Alors je clique sur "Bénéficiaires non rattachés"
+		Alors je clique sur "Bénéficiaires non accompagnés"
 		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
 		Quand je clique sur "Voir le carnet de Lindsay Aguilar"
 		Quand je vais sur l'onglet suivant

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -229,6 +229,12 @@ Alors('je vois {int} résultats sous le texte {string}', (num, title) => {
 	);
 });
 
+Alors('je vois {string} lignes dans la table {string}', (num, tableName) => {
+	const locator = locate('tbody tr').inside(locate('//table/caption').withText(tableName));
+
+	I.seeNumberOfVisibleElements(locator, parseInt(num, 10));
+});
+
 Alors('je vois {string} dans la tuile {string}', (text, tileText) => {
 	const locator = locate('.fr-card').withDescendant(locate('*').withText(tileText));
 	I.see(text, locator);


### PR DESCRIPTION
## :wrench: Problème

ETQ admin de structure lorsque je choisi `Tous` dans la liste des bénéficiaires je vois trop de bénéficiaires, je vois des bénéficiaires qui ne sont pas dans ma structure.

## :cake: Solution

Réparer le filtre pour n'afficher que les bénéficiaires de la structure

## :rotating_light:  Points d'attention / Remarques


## :desert_island: Comment tester

Se connecter en tant `lara.pafromage`
Aller sur la structure `Interlogement 93`
cliquer sur `Bénéficiaires non accompagnés`
Selectionner le filtre `Tous`
Valider qu'on affiche seulement 6 lignes


fix: #1380

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1381.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->