### PR TITLE
feat: ajout de la liste de bénéficaires sur la page d'accueil pro

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -14581,8 +14581,11 @@ export type GetLastVisitedOrUpdatedQuery = {
 		id: string;
 		members: Array<{
 			__typename?: 'notebook_member';
+			accountId: string;
 			lastVisitedAt?: string | null;
 			lastModifiedAt?: string | null;
+			active?: boolean | null;
+			memberType: string;
 		}>;
 		beneficiary: {
 			__typename?: 'beneficiary';
@@ -23256,8 +23259,11 @@ export const GetLastVisitedOrUpdatedDocument = {
 									selectionSet: {
 										kind: 'SelectionSet',
 										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'accountId' } },
 											{ kind: 'Field', name: { kind: 'Name', value: 'lastVisitedAt' } },
 											{ kind: 'Field', name: { kind: 'Name', value: 'lastModifiedAt' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'active' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'memberType' } },
 										],
 									},
 								},

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -14576,73 +14576,31 @@ export type GetLastVisitedOrUpdatedQueryVariables = Exact<{
 
 export type GetLastVisitedOrUpdatedQuery = {
 	__typename?: 'query_root';
-	lastVisited: Array<{
-		__typename?: 'notebook_member';
-		notebook: {
-			__typename?: 'notebook';
-			id: string;
-			beneficiary: {
-				__typename?: 'beneficiary';
-				id: string;
-				firstname: string;
-				lastname: string;
-				mobileNumber?: string | null;
-				dateOfBirth: string;
-				orientationRequest: Array<{
-					__typename?: 'orientation_request';
-					id: string;
-					status?: string | null;
-					createdAt: string;
-					decidedAt?: string | null;
-					requestedOrientationType?: { __typename?: 'orientation_type'; label: string } | null;
-				}>;
-			};
-		};
-	}>;
-	lastUpdated: Array<{
-		__typename?: 'notebook_member';
-		notebook: {
-			__typename?: 'notebook';
-			id: string;
-			beneficiary: {
-				__typename?: 'beneficiary';
-				id: string;
-				firstname: string;
-				lastname: string;
-				mobileNumber?: string | null;
-				dateOfBirth: string;
-				orientationRequest: Array<{
-					__typename?: 'orientation_request';
-					id: string;
-					status?: string | null;
-					createdAt: string;
-					decidedAt?: string | null;
-					requestedOrientationType?: { __typename?: 'orientation_type'; label: string } | null;
-				}>;
-			};
-		};
-	}>;
-};
-
-export type NotebookRecentFragmentFragment = {
-	__typename?: 'notebook';
-	id: string;
-	beneficiary: {
-		__typename?: 'beneficiary';
+	notebook: Array<{
+		__typename?: 'notebook';
 		id: string;
-		firstname: string;
-		lastname: string;
-		mobileNumber?: string | null;
-		dateOfBirth: string;
-		orientationRequest: Array<{
-			__typename?: 'orientation_request';
-			id: string;
-			status?: string | null;
-			createdAt: string;
-			decidedAt?: string | null;
-			requestedOrientationType?: { __typename?: 'orientation_type'; label: string } | null;
+		members: Array<{
+			__typename?: 'notebook_member';
+			lastVisitedAt?: string | null;
+			lastModifiedAt?: string | null;
 		}>;
-	};
+		beneficiary: {
+			__typename?: 'beneficiary';
+			id: string;
+			firstname: string;
+			lastname: string;
+			mobileNumber?: string | null;
+			dateOfBirth: string;
+			orientationRequest: Array<{
+				__typename?: 'orientation_request';
+				id: string;
+				status?: string | null;
+				createdAt: string;
+				decidedAt?: string | null;
+				requestedOrientationType?: { __typename?: 'orientation_type'; label: string } | null;
+			}>;
+		};
+	}>;
 };
 
 export type SearchNotebookMemberQueryVariables = Exact<{
@@ -15956,78 +15914,6 @@ export const NotebookFragmentFragmentDoc = {
 		},
 	],
 } as unknown as DocumentNode<NotebookFragmentFragment, unknown>;
-export const NotebookRecentFragmentFragmentDoc = {
-	kind: 'Document',
-	definitions: [
-		{
-			kind: 'FragmentDefinition',
-			name: { kind: 'Name', value: 'notebookRecentFragment' },
-			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'notebook' } },
-			selectionSet: {
-				kind: 'SelectionSet',
-				selections: [
-					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
-					{
-						kind: 'Field',
-						name: { kind: 'Name', value: 'beneficiary' },
-						selectionSet: {
-							kind: 'SelectionSet',
-							selections: [
-								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'firstname' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'lastname' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'mobileNumber' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'dateOfBirth' } },
-								{
-									kind: 'Field',
-									name: { kind: 'Name', value: 'orientationRequest' },
-									arguments: [
-										{
-											kind: 'Argument',
-											name: { kind: 'Name', value: 'order_by' },
-											value: {
-												kind: 'ObjectValue',
-												fields: [
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: 'createdAt' },
-														value: { kind: 'EnumValue', value: 'desc' },
-													},
-												],
-											},
-										},
-										{
-											kind: 'Argument',
-											name: { kind: 'Name', value: 'limit' },
-											value: { kind: 'IntValue', value: '1' },
-										},
-									],
-									selectionSet: {
-										kind: 'SelectionSet',
-										selections: [
-											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
-											{ kind: 'Field', name: { kind: 'Name', value: 'status' } },
-											{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
-											{ kind: 'Field', name: { kind: 'Name', value: 'decidedAt' } },
-											{
-												kind: 'Field',
-												name: { kind: 'Name', value: 'requestedOrientationType' },
-												selectionSet: {
-													kind: 'SelectionSet',
-													selections: [{ kind: 'Field', name: { kind: 'Name', value: 'label' } }],
-												},
-											},
-										],
-									},
-								},
-							],
-						},
-					},
-				],
-			},
-		},
-	],
-} as unknown as DocumentNode<NotebookRecentFragmentFragment, unknown>;
 export const EventFieldsFragmentDoc = {
 	kind: 'Document',
 	definitions: [
@@ -23282,75 +23168,51 @@ export const GetLastVisitedOrUpdatedDocument = {
 				selections: [
 					{
 						kind: 'Field',
-						alias: { kind: 'Name', value: 'lastVisited' },
-						name: { kind: 'Name', value: 'notebook_member' },
+						name: { kind: 'Name', value: 'notebook' },
 						arguments: [
 							{
 								kind: 'Argument',
 								name: { kind: 'Name', value: 'order_by' },
 								value: {
-									kind: 'ObjectValue',
-									fields: [
+									kind: 'ListValue',
+									values: [
 										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'lastVisitedAt' },
-											value: { kind: 'EnumValue', value: 'desc_nulls_last' },
-										},
-									],
-								},
-							},
-							{
-								kind: 'Argument',
-								name: { kind: 'Name', value: 'limit' },
-								value: { kind: 'IntValue', value: '3' },
-							},
-							{
-								kind: 'Argument',
-								name: { kind: 'Name', value: 'where' },
-								value: {
-									kind: 'ObjectValue',
-									fields: [
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'active' },
-											value: {
-												kind: 'ObjectValue',
-												fields: [
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: '_eq' },
-														value: { kind: 'BooleanValue', value: true },
+											kind: 'ObjectValue',
+											fields: [
+												{
+													kind: 'ObjectField',
+													name: { kind: 'Name', value: 'beneficiary' },
+													value: {
+														kind: 'ObjectValue',
+														fields: [
+															{
+																kind: 'ObjectField',
+																name: { kind: 'Name', value: 'lastname' },
+																value: { kind: 'EnumValue', value: 'asc_nulls_first' },
+															},
+														],
 													},
-												],
-											},
+												},
+											],
 										},
 										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'accountId' },
-											value: {
-												kind: 'ObjectValue',
-												fields: [
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: '_eq' },
-														value: { kind: 'Variable', name: { kind: 'Name', value: 'accountId' } },
+											kind: 'ObjectValue',
+											fields: [
+												{
+													kind: 'ObjectField',
+													name: { kind: 'Name', value: 'beneficiary' },
+													value: {
+														kind: 'ObjectValue',
+														fields: [
+															{
+																kind: 'ObjectField',
+																name: { kind: 'Name', value: 'firstname' },
+																value: { kind: 'EnumValue', value: 'asc_nulls_first' },
+															},
+														],
 													},
-												],
-											},
-										},
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'lastVisitedAt' },
-											value: {
-												kind: 'ObjectValue',
-												fields: [
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: '_is_null' },
-														value: { kind: 'BooleanValue', value: false },
-													},
-												],
-											},
+												},
+											],
 										},
 									],
 								},
@@ -23359,110 +23221,100 @@ export const GetLastVisitedOrUpdatedDocument = {
 						selectionSet: {
 							kind: 'SelectionSet',
 							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
 								{
 									kind: 'Field',
-									name: { kind: 'Name', value: 'notebook' },
+									name: { kind: 'Name', value: 'members' },
+									arguments: [
+										{
+											kind: 'Argument',
+											name: { kind: 'Name', value: 'where' },
+											value: {
+												kind: 'ObjectValue',
+												fields: [
+													{
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: 'accountId' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: '_eq' },
+																	value: {
+																		kind: 'Variable',
+																		name: { kind: 'Name', value: 'accountId' },
+																	},
+																},
+															],
+														},
+													},
+												],
+											},
+										},
+									],
 									selectionSet: {
 										kind: 'SelectionSet',
 										selections: [
-											{
-												kind: 'FragmentSpread',
-												name: { kind: 'Name', value: 'notebookRecentFragment' },
-											},
+											{ kind: 'Field', name: { kind: 'Name', value: 'lastVisitedAt' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'lastModifiedAt' } },
 										],
 									},
 								},
-							],
-						},
-					},
-					{
-						kind: 'Field',
-						alias: { kind: 'Name', value: 'lastUpdated' },
-						name: { kind: 'Name', value: 'notebook_member' },
-						arguments: [
-							{
-								kind: 'Argument',
-								name: { kind: 'Name', value: 'order_by' },
-								value: {
-									kind: 'ObjectValue',
-									fields: [
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'lastModifiedAt' },
-											value: { kind: 'EnumValue', value: 'desc_nulls_last' },
-										},
-									],
-								},
-							},
-							{
-								kind: 'Argument',
-								name: { kind: 'Name', value: 'limit' },
-								value: { kind: 'IntValue', value: '3' },
-							},
-							{
-								kind: 'Argument',
-								name: { kind: 'Name', value: 'where' },
-								value: {
-									kind: 'ObjectValue',
-									fields: [
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'active' },
-											value: {
-												kind: 'ObjectValue',
-												fields: [
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: '_eq' },
-														value: { kind: 'BooleanValue', value: true },
-													},
-												],
-											},
-										},
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'accountId' },
-											value: {
-												kind: 'ObjectValue',
-												fields: [
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: '_eq' },
-														value: { kind: 'Variable', name: { kind: 'Name', value: 'accountId' } },
-													},
-												],
-											},
-										},
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'lastModifiedAt' },
-											value: {
-												kind: 'ObjectValue',
-												fields: [
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: '_is_null' },
-														value: { kind: 'BooleanValue', value: false },
-													},
-												],
-											},
-										},
-									],
-								},
-							},
-						],
-						selectionSet: {
-							kind: 'SelectionSet',
-							selections: [
 								{
 									kind: 'Field',
-									name: { kind: 'Name', value: 'notebook' },
+									name: { kind: 'Name', value: 'beneficiary' },
 									selectionSet: {
 										kind: 'SelectionSet',
 										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'firstname' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'lastname' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'mobileNumber' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'dateOfBirth' } },
 											{
-												kind: 'FragmentSpread',
-												name: { kind: 'Name', value: 'notebookRecentFragment' },
+												kind: 'Field',
+												name: { kind: 'Name', value: 'orientationRequest' },
+												arguments: [
+													{
+														kind: 'Argument',
+														name: { kind: 'Name', value: 'order_by' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'createdAt' },
+																	value: { kind: 'EnumValue', value: 'desc' },
+																},
+															],
+														},
+													},
+													{
+														kind: 'Argument',
+														name: { kind: 'Name', value: 'limit' },
+														value: { kind: 'IntValue', value: '1' },
+													},
+												],
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'status' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'decidedAt' } },
+														{
+															kind: 'Field',
+															name: { kind: 'Name', value: 'requestedOrientationType' },
+															selectionSet: {
+																kind: 'SelectionSet',
+																selections: [
+																	{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
+																],
+															},
+														},
+													],
+												},
 											},
 										],
 									},
@@ -23473,7 +23325,6 @@ export const GetLastVisitedOrUpdatedDocument = {
 				],
 			},
 		},
-		...NotebookRecentFragmentFragmentDoc.definitions,
 	],
 } as unknown as DocumentNode<GetLastVisitedOrUpdatedQuery, GetLastVisitedOrUpdatedQueryVariables>;
 export const SearchNotebookMemberDocument = {

--- a/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
+++ b/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-	import type { SearchPublicNotebooksQuery } from '$lib/graphql/_gen/typed-document-nodes';
+	import type { SearchPublicNotebooksQuery, GetLastVisitedOrUpdatedQuery } from '$lib/graphql/_gen/typed-document-nodes';
 	import { formatDateLocale } from '$lib/utils/date';
 	import { displayFullName } from '$lib/ui/format';
 
-	type PublicNotebook = SearchPublicNotebooksQuery['notebooks'][0];
+  type PublicNotebook = SearchPublicNotebooksQuery['notebooks'][0] | GetLastVisitedOrUpdatedQuery['notebook'][0];
+
+
 
 	export let notebooks: PublicNotebook[];
 	export let accountId: string;

--- a/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
+++ b/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
@@ -2,6 +2,8 @@
 	import type { SearchPublicNotebooksQuery, GetLastVisitedOrUpdatedQuery } from '$lib/graphql/_gen/typed-document-nodes';
 	import { formatDateLocale } from '$lib/utils/date';
 	import { displayFullName } from '$lib/ui/format';
+  import { baseUrlForRole } from '$lib/routes';
+  import { accountData } from '$lib/stores'
 
   type PublicNotebook = SearchPublicNotebooksQuery['notebooks'][0] | GetLastVisitedOrUpdatedQuery['notebook'][0];
 
@@ -42,7 +44,7 @@
 				</td>
 				<td class="!text-center">
 					<a
-						href={`carnet/${notebook.id}`}
+            href={`${baseUrlForRole($accountData.type)}/carnet/${notebook.id}`}
 						rel="noreferrer"
 						class="fr-link"
 						title={`Voir le carnet de ${displayFullName(notebook.beneficiary)}`}

--- a/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
+++ b/app/src/lib/ui/BeneficiaryList/ProSearchResults.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
-	import type { SearchPublicNotebooksQuery, GetLastVisitedOrUpdatedQuery } from '$lib/graphql/_gen/typed-document-nodes';
+	import type {
+		SearchPublicNotebooksQuery,
+		GetLastVisitedOrUpdatedQuery,
+	} from '$lib/graphql/_gen/typed-document-nodes';
 	import { formatDateLocale } from '$lib/utils/date';
 	import { displayFullName } from '$lib/ui/format';
-  import { baseUrlForRole } from '$lib/routes';
-  import { accountData } from '$lib/stores'
+	import { baseUrlForRole } from '$lib/routes';
+	import { accountData } from '$lib/stores';
 
-  type PublicNotebook = SearchPublicNotebooksQuery['notebooks'][0] | GetLastVisitedOrUpdatedQuery['notebook'][0];
-
-
+	type PublicNotebook =
+		| SearchPublicNotebooksQuery['notebooks'][0]
+		| GetLastVisitedOrUpdatedQuery['notebook'][0];
 
 	export let notebooks: PublicNotebook[];
 	export let accountId: string;
@@ -44,7 +47,7 @@
 				</td>
 				<td class="!text-center">
 					<a
-            href={`${baseUrlForRole($accountData.type)}/carnet/${notebook.id}`}
+						href={`${baseUrlForRole($accountData.type)}/carnet/${notebook.id}`}
 						rel="noreferrer"
 						class="fr-link"
 						title={`Voir le carnet de ${displayFullName(notebook.beneficiary)}`}

--- a/app/src/routes/(auth)/pro/+page.svelte
+++ b/app/src/routes/(auth)/pro/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-	import { GetLastVisitedOrUpdatedDocument, type GetLastVisitedOrUpdatedQuery } from '$lib/graphql/_gen/typed-document-nodes';
+	import {
+		GetLastVisitedOrUpdatedDocument,
+		type GetLastVisitedOrUpdatedQuery,
+	} from '$lib/graphql/_gen/typed-document-nodes';
 	import LoaderIndicator from '$lib/ui/utils/LoaderIndicator.svelte';
 	import { operationStore, query } from '@urql/svelte';
 	import { goto } from '$app/navigation';
@@ -11,19 +14,25 @@
 
 	query(result);
 
-  type Notebook = GetLastVisitedOrUpdatedQuery['notebook'][0]
+	type Notebook = GetLastVisitedOrUpdatedQuery['notebook'][0];
 
 	$: notebooks = $result.data ? $result.data.notebook : [];
-  $: lastVisitedNotebooks = notebooks.slice().sort(sortByLastVisited).slice(0, 3)
-  $: lastModifiedNotebooks = notebooks.slice().sort(sortByLastModified).slice(0, 3)
+	$: lastVisitedNotebooks = notebooks.slice().sort(sortByLastVisited).slice(0, 3);
+	$: lastModifiedNotebooks = notebooks.slice().sort(sortByLastModified).slice(0, 3);
 
-  function sortByLastVisited(n1: Notebook, n2: Notebook): number {
-    return new Date(n2.members[0].lastVisitedAt).getTime() - new Date(n1.members[0].lastVisitedAt).getTime()
-  }
+	function sortByLastVisited(n1: Notebook, n2: Notebook): number {
+		return (
+			new Date(n2.members[0].lastVisitedAt).getTime() -
+			new Date(n1.members[0].lastVisitedAt).getTime()
+		);
+	}
 
-  function sortByLastModified(n1: Notebook, n2: Notebook): number {
-    return new Date(n2.members[0].lastModifiedAt).getTime() - new Date(n1.members[0].lastModifiedAt).getTime()
-  }
+	function sortByLastModified(n1: Notebook, n2: Notebook): number {
+		return (
+			new Date(n2.members[0].lastModifiedAt).getTime() -
+			new Date(n1.members[0].lastModifiedAt).getTime()
+		);
+	}
 
 	function onSearch({ detail }) {
 		const { search } = detail;
@@ -77,9 +86,6 @@
 
 	<div>
 		<h2 class="fr-h5 text-france-blue">Mes bénéficiaires</h2>
-    <ProSearchResults {notebooks} accountId={$accountData.id} />
+		<ProSearchResults {notebooks} accountId={$accountData.id} />
 	</div>
 </LoaderIndicator>
-
- 
- 

--- a/app/src/routes/(auth)/pro/+page.svelte
+++ b/app/src/routes/(auth)/pro/+page.svelte
@@ -17,8 +17,8 @@
 	type Notebook = GetLastVisitedOrUpdatedQuery['notebook'][0];
 
 	$: notebooks = $result.data ? $result.data.notebook : [];
-	$: lastVisitedNotebooks = notebooks.slice().sort(sortByLastVisited).slice(0, 3);
-	$: lastModifiedNotebooks = notebooks.slice().sort(sortByLastModified).slice(0, 3);
+	$: lastVisitedNotebooks = [...notebooks].sort(sortByLastVisited).slice(0, 3);
+	$: lastModifiedNotebooks = [...notebooks].sort(sortByLastModified).slice(0, 3);
 
 	function sortByLastVisited(n1: Notebook, n2: Notebook): number {
 		return (

--- a/app/src/routes/(auth)/pro/_query.gql
+++ b/app/src/routes/(auth)/pro/_query.gql
@@ -4,8 +4,11 @@ query GetLastVisitedOrUpdated($accountId: uuid!) {
     ) {
     id
     members(where: {accountId: {_eq: $accountId}}) {
+      accountId
       lastVisitedAt
       lastModifiedAt
+      active
+      memberType
     }
     beneficiary {
       id

--- a/app/src/routes/(auth)/pro/_query.gql
+++ b/app/src/routes/(auth)/pro/_query.gql
@@ -1,47 +1,26 @@
 query GetLastVisitedOrUpdated($accountId: uuid!) {
-  lastVisited: notebook_member(
-    order_by: { lastVisitedAt: desc_nulls_last }
-    limit: 3
-    where: {
-      active: { _eq: true }
-      accountId: { _eq: $accountId }
-      lastVisitedAt: { _is_null: false }
-    }
-  ) {
-    notebook {
-      ...notebookRecentFragment
-    }
-  }
-  lastUpdated: notebook_member(
-    order_by: { lastModifiedAt: desc_nulls_last }
-    limit: 3
-    where: {
-      active: { _eq: true }
-      accountId: { _eq: $accountId }
-      lastModifiedAt: { _is_null: false }
-    }
-  ) {
-    notebook {
-      ...notebookRecentFragment
-    }
-  }
-}
-
-fragment notebookRecentFragment on notebook {
-  id
-  beneficiary {
+  notebook(
+    order_by: [{beneficiary:{lastname: asc_nulls_first}}, {beneficiary:{firstname: asc_nulls_first}}]
+    ) {
     id
-    firstname
-    lastname
-    mobileNumber
-    dateOfBirth
-    orientationRequest(order_by: { createdAt: desc }, limit: 1) {
+    members(where: {accountId: {_eq: $accountId}}) {
+      lastVisitedAt
+      lastModifiedAt
+    }
+    beneficiary {
       id
-      status
-      createdAt
-      decidedAt
-      requestedOrientationType {
-        label
+      firstname
+      lastname
+      mobileNumber
+      dateOfBirth
+      orientationRequest(order_by: { createdAt: desc }, limit: 1) {
+        id
+        status
+        createdAt
+        decidedAt
+        requestedOrientationType {
+          label
+        }
       }
     }
   }

--- a/e2e/features/admin_cdb/add_manager.feature
+++ b/e2e/features/admin_cdb/add_manager.feature
@@ -7,7 +7,7 @@ Fonctionnalité: Ajout d'un manager
 
 	Scénario: Ajout d'un manager
 		Soit un "administrateur cdb" authentifié avec l'email "support.carnet-de-bord+admin@fabrique.social.gouv.fr"
-		Quand j'attends que la table "Liste des déploiements" apparaisse
+		Quand j'attends que le tableau "Liste des déploiements" apparaisse
 		Quand je clique sur "expérimentation 93"
 		Alors je vois "Déploiement expérimentation 93"
 		Quand je clique sur "Ajouter un admin pdi"

--- a/e2e/features/manager/importBeneficiaires.feature
+++ b/e2e/features/manager/importBeneficiaires.feature
@@ -59,7 +59,7 @@ Fonctionnalité: Import de bénéficiaires
 		Quand je clique sur "Confirmer"
 		Quand je clique sur "Fermer"
 		Quand je clique sur "Bénéficiaires"
-		Quand j'attends que la table "Liste des bénéficiaires" apparaisse
+		Quand j'attends que le tableau "Liste des bénéficiaires" apparaisse
 		Alors je recherche "fon"
 		Quand je clique sur "Rechercher"
 		Alors je vois "à orienter" sur la ligne "Fondue"

--- a/e2e/features/manager/showListBeneficiairies.feature
+++ b/e2e/features/manager/showListBeneficiairies.feature
@@ -7,7 +7,7 @@ Fonctionnalité: Consultation de la liste des bénéficiaires par un manager
 	Scénario: Voir la liste
 		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
-		Quand j'attends que la table "Liste des bénéficiaires" apparaisse
+		Quand j'attends que le tableau "Liste des bénéficiaires" apparaisse
 		Alors je vois la colonne "Date de naissance"
 		Alors je vois "22/06/1996" sur la ligne "Lindsay"
 
@@ -32,7 +32,7 @@ Fonctionnalité: Consultation de la liste des bénéficiaires par un manager
 		Quand je clique sur "Bénéficiaires"
 		Quand je recherche "gon"
 		Quand je clique sur "Rechercher"
-		Quand j'attends que la table "Liste des bénéficiaires" apparaisse
+		Quand j'attends que le tableau "Liste des bénéficiaires" apparaisse
 		Alors je vois "Gônzalez" sur la ligne "Bolton"
 
 	Scénario: rechercher un bénéficiaire par suffixe
@@ -40,5 +40,5 @@ Fonctionnalité: Consultation de la liste des bénéficiaires par un manager
 		Quand je clique sur "Bénéficiaires"
 		Quand je recherche "alez"
 		Quand je clique sur "Rechercher"
-		Quand j'attends que la table "Liste des bénéficiaires" apparaisse
+		Quand j'attends que le tableau "Liste des bénéficiaires" apparaisse
 		Alors je vois "Gônzalez" sur la ligne "Bolton"

--- a/e2e/features/manager/showListProfessionals.feature
+++ b/e2e/features/manager/showListProfessionals.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Consultation de la liste des professionnels par un administrate
 		Soit un "administrateur de structures" authentifié avec l'email "jacques.celaire@livry-gargan.fr"
 		Quand je clique sur "Centre Communal d'action social Livry-Gargan"
 		Quand je clique sur "Professionnels"
-		Quand j'attends que la table "Liste des professionnels" apparaisse
+		Quand j'attends que le tableau "Liste des professionnels" apparaisse
 		Alors je vois la colonne "Prénom nom"
 		Alors je vois la colonne "Téléphone"
 		Alors je vois la colonne "Email"

--- a/e2e/features/manager/validateAccount.feature
+++ b/e2e/features/manager/validateAccount.feature
@@ -8,14 +8,14 @@ Fonctionnalité: Gestion de professionnels d'un déploiement
 	Scénario: Liste des professionnels
 		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Professionnels"
-		Quand j'attends que la table "Liste des professionnels" apparaisse
+		Quand j'attends que le tableau "Liste des professionnels" apparaisse
 		Alors je vois "1" sur la ligne "Giulia Diaby"
 		Alors je vois "0" sur la ligne "Blaise Alaise"
 
 	Scénario: Validation d'un professionnel
 		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Professionnels"
-		Quand j'attends que la table "Liste des professionnels" apparaisse
+		Quand j'attends que le tableau "Liste des professionnels" apparaisse
 		Quand je clique sur "Activer"
 		Quand j'attends 1 secondes
 		Alors je vois "Actif" sur la ligne "Lejeune Bienvenu"

--- a/e2e/features/orientationManager/filterBeneficiary.feature
+++ b/e2e/features/orientationManager/filterBeneficiary.feature
@@ -38,7 +38,7 @@ Fonctionnalité: Fitrer la liste des bénéficiaires
 		Soit un "chargé d'orientation" authentifié avec l'email "samy.rouate@cd93.fr"
 		Quand je clique sur "Bénéficiaires"
 		Quand je selectionne l'option "Autres bénéficiaires du territoire" dans la liste "Bénéficiaires"
-		Alors j'attends que la table "Liste des bénéficiaires" apparaisse
+		Alors j'attends que le tableau "Liste des bénéficiaires" apparaisse
 		Alors je vois "Giulia Diaby" sur la ligne "Benjamin"
 		Alors je vois "Non assigné" sur la ligne "Conley"
 
@@ -47,8 +47,8 @@ Fonctionnalité: Fitrer la liste des bénéficiaires
 		Quand je clique sur "Bénéficiaires"
 		Quand je selectionne l'option "Autres bénéficiaires du territoire" dans la liste "Bénéficiaires"
 		Quand je choisis "Bénéficiaires non pris en charge par un chargé d'orientation"
-		Alors j'attends que la table "Liste des bénéficiaires" apparaisse
-		Alors j'attends que la table "Liste des bénéficiaires" apparaisse
+		Alors j'attends que le tableau "Liste des bénéficiaires" apparaisse
+		Alors j'attends que le tableau "Liste des bénéficiaires" apparaisse
 		Alors je vois "Non assigné" sur la ligne "Conley"
 		Alors je ne vois pas "Benjamin"
 
@@ -57,7 +57,7 @@ Fonctionnalité: Fitrer la liste des bénéficiaires
 		Quand je clique sur "Bénéficiaires"
 		Quand je selectionne l'option "Autres bénéficiaires du territoire" dans la liste "Bénéficiaires"
 		Quand je selectionne l'option "Orienté" dans la liste "Statut"
-		Alors j'attends que la table "Liste des bénéficiaires" apparaisse
+		Alors j'attends que le tableau "Liste des bénéficiaires" apparaisse
 		Alors je vois "Non assigné" sur la ligne "Aguilar"
 		Alors je vois "Non assigné" sur la ligne "Beach"
 		Alors je vois "Giulia Diaby" sur la ligne "Cobb"

--- a/e2e/features/pro/accueil/accueil.feature
+++ b/e2e/features/pro/accueil/accueil.feature
@@ -1,0 +1,20 @@
+#language: fr
+
+Fonctionnalité: Page d'accueil pro
+	En tant que pro
+	Je veux pouvoir consulter les informations importantes sur ma page d'accueil
+
+Scénario: Accueil pro
+	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
+	Alors je vois "Rechercher un bénéficiaire"
+
+Scénario: Affichage des derniers carnet consultés
+	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
+	Alors je vois "Sophie Tifour"
+
+Scénario: Affichage de la liste de mes bénéficiaires
+	Soit le pro "sanka@groupe-ns.fr" qui a cliqué sur le lien de connexion
+	Alors je vois 3 lignes dans le tableau "Liste des bénéficiaires"
+  Alors je vois "Tifour" dans le tableau "Liste des bénéficiaires"
+  Alors je vois "Herring" dans le tableau "Liste des bénéficiaires"
+  Alors je vois "Gallegos" dans le tableau "Liste des bénéficiaires"

--- a/e2e/features/pro/accueil/accueil.feature
+++ b/e2e/features/pro/accueil/accueil.feature
@@ -18,3 +18,8 @@ Scénario: Affichage de la liste de mes bénéficiaires
   Alors je vois "Tifour" dans le tableau "Liste des bénéficiaires"
   Alors je vois "Herring" dans le tableau "Liste des bénéficiaires"
   Alors je vois "Gallegos" dans le tableau "Liste des bénéficiaires"
+
+Scénario: Affichage du détail d'un carnet depuis la page d'accueil
+	Soit le pro "sanka@groupe-ns.fr" qui a cliqué sur le lien de connexion
+	Alors je clique sur "Voir le carnet de Winnie Gallegos"
+  Alors je vois "winnie.gallegos@ut.com"

--- a/e2e/features/pro/carnet/members.feature
+++ b/e2e/features/pro/carnet/members.feature
@@ -6,12 +6,12 @@ Fonctionnalité: Groupe de suivi
 
 Scénario: Consulter le groupe de suivi
 	Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Tifour"
-	Quand j'attends que la table "Liste des membres du groupe de suivi" apparaisse
+	Quand j'attends que le tableau "Liste des membres du groupe de suivi" apparaisse
 	Alors je vois "référent" sur la ligne "Pierre Chevalier"
 
 Scénario: Inviter un membre dans le groupe de suivi
 	Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Tifour"
-	Quand j'attends que la table "Liste des membres du groupe de suivi" apparaisse
+	Quand j'attends que le tableau "Liste des membres du groupe de suivi" apparaisse
 	Alors je clique sur "Inviter un accompagnateur"
 	Alors je renseigne "social" dans le champ "Rechercher un accompagnateur"
 	Quand je clique sur "Rechercher"
@@ -22,7 +22,7 @@ Scénario: Inviter un membre dans le groupe de suivi
 
 Scénario: Se retirer du groupe de suivi et de la structure
 	Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Tifour"
-	Quand j'attends que la table "Liste des membres du groupe de suivi" apparaisse
+	Quand j'attends que le tableau "Liste des membres du groupe de suivi" apparaisse
 	Quand je clique sur "Se détacher"
 	Alors je vois "Souhaitez-vous être détaché du carnet de bord et ne plus accéder en écriture à celui-ci ?"
 	Quand je clique sur "Oui"

--- a/e2e/features/pro/login.feature
+++ b/e2e/features/pro/login.feature
@@ -9,11 +9,3 @@ Scénario: Login pro
 	Quand je renseigne "pierre.chevalier@livry-gargan.fr" dans le champ "Courriel"
 	Quand je clique sur "Se connecter"
 	Alors je vois "Un lien vous a été envoyé pour vous connecter au Carnet de bord."
-
-Scénario: Accueil pro
-	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
-	Alors je vois "Rechercher un bénéficiaire"
-
-Scénario: Affichage des derniers carnet consultés
-	Soit le pro "pierre.chevalier@livry-gargan.fr" qui a cliqué sur le lien de connexion
-	Alors je vois "Sophie Tifour"

--- a/e2e/features/structureAdmin/beneficiary_list.feature
+++ b/e2e/features/structureAdmin/beneficiary_list.feature
@@ -13,4 +13,4 @@ Fonctionnalité: Liste des bénéficiaires
 		Alors je clique sur "Bénéficiaires non accompagnés"
 		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Alors je selectionne l'option "Tous" dans la liste "Rattachement"
-		Alors je vois "6" lignes dans la table "Liste des bénéficiaires"
+		Alors je vois 6 lignes dans le tableau "Liste des bénéficiaires"

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -164,7 +164,7 @@ Quand("j'attends que le texte {string} apparaisse", (text) => {
 	I.waitForText(text, 5);
 });
 
-Quand("j'attends que la table {string} apparaisse", (text) => {
+Quand("j'attends que le tableau {string} apparaisse", (text) => {
 	I.waitForElement(`//caption[contains(., "${text}")]`, 3);
 });
 
@@ -229,10 +229,10 @@ Alors('je vois {int} résultats sous le texte {string}', (num, title) => {
 	);
 });
 
-Alors('je vois {string} lignes dans la table {string}', (num, tableName) => {
+Alors('je vois {int} lignes dans le tableau {string}', (num, tableName) => {
 	const locator = locate('tbody tr').inside(locate('//table/caption').withText(tableName));
 
-	I.seeNumberOfVisibleElements(locator, parseInt(num, 10));
+	I.seeNumberOfVisibleElements(locator, num);
 });
 
 Alors('je vois {string} dans la tuile {string}', (text, tileText) => {


### PR DESCRIPTION
## :wrench: Problème

ETQ Pro j'ai besoin d'accéder à la liste des bénéficiaires de mon portefeuille depuis la page d'accueil

## :cake: Solution

Afficher la liste des bénéficiaires du pro en bas de sa page d'accueil.


## :rotating_light:  Points d'attention / Remarques


## :desert_island: Comment tester

Se connecter avec `sanka` et vérifier, en bas de sa page d'accueil, la présence d'un tableau « Mes bénéficiaires » avec 3 bénéficiaires.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1401.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

fix #1385 
