### PR TITLE
chore: Correction de l'indentation dans le schéma GQL généré (backend).

### DIFF
--- a/backend/api/_gen/schema_gql.py
+++ b/backend/api/_gen/schema_gql.py
@@ -16824,5 +16824,5 @@ input wanted_job_updates {
   _set: wanted_job_set_input
   where: wanted_job_bool_exp!
 }
-'''
+    '''
 )

--- a/backend/scripts/codegen.sh
+++ b/backend/scripts/codegen.sh
@@ -13,8 +13,8 @@ cat > $pyfile <<EOF
 from graphql import build_schema
 
 schema = build_schema(
-'''
+    '''
 $(poetry run gql-cli http://localhost:5000/v1/graphql --print-schema -H 'x-hasura-admin-secret:admin')
-'''
+    '''
 )
 EOF


### PR DESCRIPTION
## :wrench: Problème

Le script qui génère le schéma GQL pour l'usage dans le backend ne respecte pas le format du linter `black`.
Ainsi, à chaque génération du fichier, le script de pre-commit modifie le fichier et il faut l'ajouter par la suite au commit.

## :cake: Solution

On modifie le template contenu dans `backend/scripts/codegen.sh` pour que les `'''` soient correctement indentées.

## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Lancer le script `backend/scripts/odegen.sh`.
Lancer le script de pre-commit avec `pre-commit run all`.
Constater que toutes les vérifications sont des succès.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1409.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
