### PR TITLE
fix: suppression de la propriété nullable du champ active

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -7205,7 +7205,7 @@ export type NotebookMember = {
 	/** An object relationship */
 	account: Account;
 	accountId: Scalars['uuid'];
-	active?: Maybe<Scalars['Boolean']>;
+	active: Scalars['Boolean'];
 	createdAt: Scalars['timestamptz'];
 	/** An object relationship */
 	creator?: Maybe<Account>;
@@ -13670,7 +13670,7 @@ export type RemoveMemberFromNotebookMutation = {
 			__typename?: 'notebook_member';
 			id: string;
 			accountId: string;
-			active?: boolean | null;
+			active: boolean;
 			notebookId: string;
 		}>;
 	} | null;
@@ -14584,7 +14584,7 @@ export type GetLastVisitedOrUpdatedQuery = {
 			accountId: string;
 			lastVisitedAt?: string | null;
 			lastModifiedAt?: string | null;
-			active?: boolean | null;
+			active: boolean;
 			memberType: string;
 		}>;
 		beneficiary: {
@@ -14651,7 +14651,7 @@ export type SearchPublicNotebooksQuery = {
 		id?: string | null;
 		members: Array<{
 			__typename?: 'notebook_member';
-			active?: boolean | null;
+			active: boolean;
 			accountId: string;
 			memberType: string;
 		}>;

--- a/backend/api/_gen/schema_gql.py
+++ b/backend/api/_gen/schema_gql.py
@@ -8834,7 +8834,7 @@ type notebook_member {
   """An object relationship"""
   account: account!
   accountId: uuid!
-  active: Boolean
+  active: Boolean!
   createdAt: timestamptz!
 
   """An object relationship"""

--- a/backend/api/db/models/notebook_member.py
+++ b/backend/api/db/models/notebook_member.py
@@ -13,7 +13,7 @@ class NotebookMemberInsert(BaseModel):
     last_modified_at: datetime | None = None
     creator_id: UUID | None = None
     invitation_sent_at: datetime | None = None
-    active: bool | None = None
+    active: bool = True
 
 
 class NotebookMember(NotebookMemberInsert):

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_structure.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_structure.yaml
@@ -52,7 +52,7 @@ computed_fields:
       function:
         name: nb_beneficiary_for_structure
         schema: public
-    comment: "a computed field, executes function nb_beneficiary_for_structure "
+    comment: 'a computed field, executes function nb_beneficiary_for_structure '
 insert_permissions:
   - role: admin_cdb
     permission:

--- a/hasura/migrations/carnet_de_bord/1672908864766_alter_table_public_notebook_member_alter_column_active/down.sql
+++ b/hasura/migrations/carnet_de_bord/1672908864766_alter_table_public_notebook_member_alter_column_active/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."notebook_member" alter column "active" drop not null;

--- a/hasura/migrations/carnet_de_bord/1672908864766_alter_table_public_notebook_member_alter_column_active/up.sql
+++ b/hasura/migrations/carnet_de_bord/1672908864766_alter_table_public_notebook_member_alter_column_active/up.sql
@@ -1,0 +1,3 @@
+update notebook_member set active = true where active is null;
+
+alter table "public"."notebook_member" alter column "active" set not null;


### PR DESCRIPTION
## :wrench: Problème

Lors que l'import de bénéficiaire, il est possible d'assigner directement un référent depuis son email si celui-ci existe déjà.
Malheureusement cela le fonctionne pas. Les notebook member sont bien créés mais le champ active est laissé à NULL ce qui ne permet pas de les voir.  

## :cake: Solution

On supprime le fait que active puisse etre nullable  car il a une valeur par defaut à true. 

## :rotating_light:  Points d'attention / Remarques

Un migration des données de prod est appliqué avant de supprimer la propriété nullable 

## :desert_island: Comment tester

Se connecter en tant que manager.cd93 et réaliser un import en assignant un pro (pierre.chevalier).
voir la liste des bénéficiaires et valider que le pro est bien référent.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1412.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


fix #1411
