### PR TITLE
feat: afficher le nombre de carnet suivi par pro

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -34,7 +34,7 @@ Il existe 2 déploiement dans le jeu de données de test qui sert à peupler la 
 | --- | --- | --- |
 | giulia.diaby | giulia.diaby@cd93.fr | non |
 | laure.loge | laure.loge@cd51.fr | non |
-| samy.rouate | sami.rouate@cd93.fr | oui |
+| samy.rouate | samy.rouate@cd93.fr | oui |
 
 ## Compte d'accompagnant (role: professional)
 | username | email |  structure | onboarding |

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -13165,7 +13165,14 @@ export type GetStructuresWithProQuery = {
 			position?: string | null;
 			email: string;
 			structureId: string;
-			account?: { __typename?: 'account'; id: string } | null;
+			account?: {
+				__typename?: 'account';
+				id: string;
+				referentCount: {
+					__typename?: 'notebook_member_aggregate';
+					aggregate?: { __typename?: 'notebook_member_aggregate_fields'; count: number } | null;
+				};
+			} | null;
 			structure: { __typename?: 'structure'; id: string; name: string };
 		}>;
 	}>;
@@ -17075,7 +17082,72 @@ export const GetStructuresWithProDocument = {
 												name: { kind: 'Name', value: 'account' },
 												selectionSet: {
 													kind: 'SelectionSet',
-													selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }],
+													selections: [
+														{
+															kind: 'Field',
+															alias: { kind: 'Name', value: 'referentCount' },
+															name: { kind: 'Name', value: 'notebooksWhereMember_aggregate' },
+															arguments: [
+																{
+																	kind: 'Argument',
+																	name: { kind: 'Name', value: 'where' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: 'memberType' },
+																				value: {
+																					kind: 'ObjectValue',
+																					fields: [
+																						{
+																							kind: 'ObjectField',
+																							name: { kind: 'Name', value: '_eq' },
+																							value: {
+																								kind: 'StringValue',
+																								value: 'referent',
+																								block: false,
+																							},
+																						},
+																					],
+																				},
+																			},
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: 'active' },
+																				value: {
+																					kind: 'ObjectValue',
+																					fields: [
+																						{
+																							kind: 'ObjectField',
+																							name: { kind: 'Name', value: '_eq' },
+																							value: { kind: 'BooleanValue', value: true },
+																						},
+																					],
+																				},
+																			},
+																		],
+																	},
+																},
+															],
+															selectionSet: {
+																kind: 'SelectionSet',
+																selections: [
+																	{
+																		kind: 'Field',
+																		name: { kind: 'Name', value: 'aggregate' },
+																		selectionSet: {
+																			kind: 'SelectionSet',
+																			selections: [
+																				{ kind: 'Field', name: { kind: 'Name', value: 'count' } },
+																			],
+																		},
+																	},
+																],
+															},
+														},
+														{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+													],
 												},
 											},
 											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },

--- a/app/src/lib/ui/BeneficiaryList/_getStructuresWithPro.gql
+++ b/app/src/lib/ui/BeneficiaryList/_getStructuresWithPro.gql
@@ -4,6 +4,13 @@ query GetStructuresWithPro {
     name
     professionals {
       account {
+        referentCount: notebooksWhereMember_aggregate(
+          where: { memberType: { _eq: "referent" }, active: { _eq: true } }
+        ) {
+          aggregate {
+            count
+          }
+        }
         id
       }
       id

--- a/app/src/lib/ui/OrientationManager/OrientationForm.svelte
+++ b/app/src/lib/ui/OrientationManager/OrientationForm.svelte
@@ -46,7 +46,9 @@
 		})) ?? [];
 
 	let structures: OperationStore<GetStructuresWithProQuery> = operationStore(
-		GetStructuresWithProDocument
+		GetStructuresWithProDocument,
+		null,
+		{ requestPolicy: 'network-only' }
 	);
 	query(structures);
 	$: structureOptions =
@@ -60,7 +62,7 @@
 	$: professionalOptions =
 		structure?.professionals.map((pro) => ({
 			name: pro.account.id,
-			label: displayFullName(pro),
+			label: `${displayFullName(pro)} (${pro.account.referentCount.aggregate.count})`,
 		})) ?? [];
 
 	const initialValues = { structureId };
@@ -108,7 +110,7 @@
 			<Select
 				selectLabel="Nom du référent unique"
 				selectHint="Sélectionner un professionnel"
-				additionalLabel="La sélection du professionnel n’est pas obligatoire."
+				additionalLabel="La sélection du professionnel n’est pas obligatoire. Le nombre de bénéficiaires affiché correspond au nombre de bénéficiaires pour lequel le professionnel est désigné référent"
 				options={professionalOptions}
 				name="professionalAccountId"
 				disabled={!form.structureId}

--- a/app/src/lib/ui/OrientationManager/OrientationForm.svelte
+++ b/app/src/lib/ui/OrientationManager/OrientationForm.svelte
@@ -52,10 +52,18 @@
 	);
 	query(structures);
 	$: structureOptions =
-		$structures.data?.structure.map(({ id, name }) => ({
-			name: id,
-			label: name,
-		})) ?? [];
+		$structures.data?.structure.map(({ id, name, professionals }) => {
+			const beneficiaryCount = professionals.reduce(
+				(total: number, value: GetStructuresWithProQuery['structure'][0]['professionals'][0]) => {
+					return total + value.account.referentCount.aggregate.count;
+				},
+				0
+			);
+			return {
+				name: id,
+				label: `${name} (${beneficiaryCount})`,
+			};
+		}) ?? [];
 
 	$: structure = $structures.data?.structure.find(({ id }) => id === selectedStructureId) ?? null;
 
@@ -99,6 +107,7 @@
 					required
 					selectLabel="Nom de la structure"
 					selectHint="Sélectionner une structure"
+					additionalLabel="Le nombre de bénéficiaires affiché correspond au nombre de bénéficiaires actuellement pris en charge par la structure"
 					options={structureOptions}
 					name="structureId"
 					on:select={(event) => {

--- a/app/src/lib/ui/OrientationManager/OrientationForm.svelte
+++ b/app/src/lib/ui/OrientationManager/OrientationForm.svelte
@@ -107,7 +107,7 @@
 					required
 					selectLabel="Nom de la structure"
 					selectHint="Sélectionner une structure"
-					additionalLabel="Le nombre de bénéficiaires affiché correspond au nombre de bénéficiaires actuellement pris en charge par la structure"
+					additionalLabel="Le nombre affiché correspond au nombre de bénéficiaires actuellement pris en charge par la structure"
 					options={structureOptions}
 					name="structureId"
 					on:select={(event) => {
@@ -119,7 +119,7 @@
 			<Select
 				selectLabel="Nom du référent unique"
 				selectHint="Sélectionner un professionnel"
-				additionalLabel="La sélection du professionnel n’est pas obligatoire. Le nombre de bénéficiaires affiché correspond au nombre de bénéficiaires pour lequel le professionnel est désigné référent"
+				additionalLabel="La sélection du professionnel n’est pas obligatoire. Le nombre affiché correspond au nombre de bénéficiaires pour lequel le professionnel est désigné référent"
 				options={professionalOptions}
 				name="professionalAccountId"
 				disabled={!form.structureId}

--- a/e2e/features/manager/home.feature
+++ b/e2e/features/manager/home.feature
@@ -15,7 +15,7 @@ Fonctionnalité: Rattachement à une structure
 		Alors je vois "Réorienter" dans le volet
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
-		Alors je selectionne l'option "AFPA" dans la liste "Nom de la structure"
+		Alors je selectionne l'option "AFPA (0)" dans la liste "Nom de la structure"
 		Quand je clique sur "Valider"
 		Alors je vois "AFPA" sur la ligne "Aguilar"
 		Quand je clique sur "Accueil"

--- a/e2e/features/manager/rattachement.feature
+++ b/e2e/features/manager/rattachement.feature
@@ -16,7 +16,7 @@ Fonctionnalité: Rattachement pro
 		Alors je vois "Réorienter" dans le volet
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
-		Alors je selectionne l'option "Groupe NS" dans la liste "Nom de la structure"
+		Alors je selectionne l'option "Groupe NS (0)" dans la liste "Nom de la structure"
 		Alors je selectionne l'option "Simon Anka (0)" dans la liste "Nom du référent"
 		Quand je clique sur "Valider" dans le volet
 		Alors je vois "Simon Anka" sur la ligne "Tifour"
@@ -33,7 +33,7 @@ Fonctionnalité: Rattachement pro
 		Alors je vois "Réorienter" dans le volet
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
-		Alors je selectionne l'option "Service Social Départemental" dans la liste "Nom de la structure"
+		Alors je selectionne l'option "Service Social Départemental (2)" dans la liste "Nom de la structure"
 		Quand je clique sur "Valider" dans le volet
 		Alors je vois "Non rattaché" sur la ligne "Cash"
 		Alors je vois "Service Social Départemental" sur la ligne "Cash"

--- a/e2e/features/manager/rattachement.feature
+++ b/e2e/features/manager/rattachement.feature
@@ -17,7 +17,7 @@ Fonctionnalité: Rattachement pro
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
 		Alors je selectionne l'option "Groupe NS" dans la liste "Nom de la structure"
-		Alors je selectionne l'option "Simon Anka" dans la liste "Nom du référent"
+		Alors je selectionne l'option "Simon Anka (0)" dans la liste "Nom du référent"
 		Quand je clique sur "Valider" dans le volet
 		Alors je vois "Simon Anka" sur la ligne "Tifour"
 		Alors je vois "Groupe NS" sur la ligne "Tifour"

--- a/e2e/features/orientationManager/changeBeneficiaryOrientation.feature
+++ b/e2e/features/orientationManager/changeBeneficiaryOrientation.feature
@@ -11,7 +11,7 @@ Fonctionnalité: Changer l'orientation d'un bénéficiaire
 		Alors je vois "Orienter" dans le volet
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
-		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan" dans la liste "Nom de la structure"
+		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan (0)" dans la liste "Nom de la structure"
 		Alors je selectionne l'option "Thierry Dunord (0)" dans la liste "Nom du référent"
 		Quand je clique sur "Valider" dans le volet
 		Alors je ne vois pas "Orienter"
@@ -25,7 +25,7 @@ Fonctionnalité: Changer l'orientation d'un bénéficiaire
 		Alors je vois "Réorienter" dans le volet
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
-		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan" dans la liste "Nom de la structure"
+		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan (0)" dans la liste "Nom de la structure"
 		Alors je selectionne l'option "Thierry Dunord (0)" dans la liste "Nom du référent"
 		Quand je clique sur "Valider" dans le volet
 		Alors je ne vois pas "Orienter"

--- a/e2e/features/orientationManager/changeBeneficiaryOrientation.feature
+++ b/e2e/features/orientationManager/changeBeneficiaryOrientation.feature
@@ -12,7 +12,7 @@ Fonctionnalité: Changer l'orientation d'un bénéficiaire
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
 		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan" dans la liste "Nom de la structure"
-		Alors je selectionne l'option "Thierry Dunord" dans la liste "Nom du référent"
+		Alors je selectionne l'option "Thierry Dunord (0)" dans la liste "Nom du référent"
 		Quand je clique sur "Valider" dans le volet
 		Alors je ne vois pas "Orienter"
 		Alors je vois "Réorienter"
@@ -26,7 +26,7 @@ Fonctionnalité: Changer l'orientation d'un bénéficiaire
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
 		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan" dans la liste "Nom de la structure"
-		Alors je selectionne l'option "Thierry Dunord" dans la liste "Nom du référent"
+		Alors je selectionne l'option "Thierry Dunord (0)" dans la liste "Nom du référent"
 		Quand je clique sur "Valider" dans le volet
 		Alors je ne vois pas "Orienter"
 		Alors je vois "Réorienter"

--- a/e2e/features/orientationManager/filterBeneficiary.feature
+++ b/e2e/features/orientationManager/filterBeneficiary.feature
@@ -52,7 +52,7 @@ Fonctionnalité: Fitrer la liste des bénéficiaires
 		Alors je vois "Non assigné" sur la ligne "Conley"
 		Alors je ne vois pas "Benjamin"
 
-	Scénario: Afficher la liste des autres bénéficiaires déjà orienter
+	Scénario: Afficher la liste des autres bénéficiaires déjà orienté
 		Soit un "chargé d'orientation" authentifié avec l'email "samy.rouate@cd93.fr"
 		Quand je clique sur "Bénéficiaires"
 		Quand je selectionne l'option "Autres bénéficiaires du territoire" dans la liste "Bénéficiaires"
@@ -62,7 +62,7 @@ Fonctionnalité: Fitrer la liste des bénéficiaires
 		Alors je vois "Non assigné" sur la ligne "Beach"
 		Alors je vois "Giulia Diaby" sur la ligne "Cobb"
 
-	Scénario: Afficher la liste des autres bénéficiaires déjà orienter sans chargé d'orientation
+	Scénario: Afficher la liste des autres bénéficiaires déjà orienté sans chargé d'orientation
 		Soit un "chargé d'orientation" authentifié avec l'email "samy.rouate@cd93.fr"
 		Quand je clique sur "Bénéficiaires"
 		Quand je selectionne l'option "Autres bénéficiaires du territoire" dans la liste "Bénéficiaires"

--- a/e2e/features/orientationManager/manageOrientationRequest.feature
+++ b/e2e/features/orientationManager/manageOrientationRequest.feature
@@ -51,7 +51,7 @@ Fonctionnalité: Gestion d'une demande de réorientation
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
 		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan" dans la liste "Nom de la structure"
-		Alors je selectionne l'option "Thierry Dunord" dans la liste "Nom du référent"
+		Alors je selectionne l'option "Thierry Dunord (0)" dans la liste "Nom du référent"
 		Quand je clique sur "Valider" dans le volet
 		Alors je ne vois pas "Demande de réorientation envoyée le 01/09/2022"
 		Alors je ne vois pas "Orientation recommandée : Social"

--- a/e2e/features/orientationManager/manageOrientationRequest.feature
+++ b/e2e/features/orientationManager/manageOrientationRequest.feature
@@ -35,7 +35,7 @@ Fonctionnalité: Gestion d'une demande de réorientation
 		Alors je vois "Réorienter" dans le volet
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
-		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan" dans la liste "Nom de la structure"
+		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan (0)" dans la liste "Nom de la structure"
 		Quand je clique sur "Valider" dans le volet
 		Alors je ne vois pas "Demande de réorientation envoyée le 01/09/2022"
 		Alors je ne vois pas "Orientation recommandée : Social"
@@ -50,7 +50,7 @@ Fonctionnalité: Gestion d'une demande de réorientation
 		Alors je vois "Réorienter" dans le volet
 		Alors je vois "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent." dans le volet
 		Alors je selectionne l'option "Professionnel" dans la liste "Type d'orientation"
-		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan" dans la liste "Nom de la structure"
+		Alors je selectionne l'option "Pole Emploi Agence Livry-Gargnan (0)" dans la liste "Nom de la structure"
 		Alors je selectionne l'option "Thierry Dunord (0)" dans la liste "Nom du référent"
 		Quand je clique sur "Valider" dans le volet
 		Alors je ne vois pas "Demande de réorientation envoyée le 01/09/2022"

--- a/e2e/features/orientationManager/rattachement.feature
+++ b/e2e/features/orientationManager/rattachement.feature
@@ -15,7 +15,7 @@ Fonctionnalité: Rattachement d'un pro par un chargé d'orientation
 		Alors je vois "Réorienter"
 		Alors j'attends que le texte "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent" apparaisse
 		Alors je selectionne l'option "Social" dans la liste "Type d'orientation"
-		Alors je selectionne l'option "Groupe NS" dans la liste "Nom de la structure"
+		Alors je selectionne l'option "Groupe NS (0)" dans la liste "Nom de la structure"
 		Alors je selectionne l'option "Simon Anka (0)" dans la liste "Nom du référent unique"
 		Quand je clique sur "Valider"
 		Alors je vois "Social" sur la ligne "Tifour"
@@ -33,7 +33,7 @@ Fonctionnalité: Rattachement d'un pro par un chargé d'orientation
 		Alors je vois "Réorienter"
 		Alors j'attends que le texte "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent" apparaisse
 		Alors je selectionne l'option "Social" dans la liste "Type d'orientation"
-		Alors je selectionne l'option "Service Social Départemental" dans la liste "Nom de la structure"
+		Alors je selectionne l'option "Service Social Départemental (2)" dans la liste "Nom de la structure"
 		Quand je clique sur "Valider" dans le volet
 		Alors je ne vois pas "Henderson"
 		Alors je ne vois pas "Lynch"

--- a/e2e/features/orientationManager/rattachement.feature
+++ b/e2e/features/orientationManager/rattachement.feature
@@ -16,7 +16,7 @@ Fonctionnalité: Rattachement d'un pro par un chargé d'orientation
 		Alors j'attends que le texte "Veuillez sélectionner l'orientation ainsi que la nouvelle structure et le nouveau référent" apparaisse
 		Alors je selectionne l'option "Social" dans la liste "Type d'orientation"
 		Alors je selectionne l'option "Groupe NS" dans la liste "Nom de la structure"
-		Alors je selectionne l'option "Simon Anka" dans la liste "Nom du référent unique"
+		Alors je selectionne l'option "Simon Anka (0)" dans la liste "Nom du référent unique"
 		Quand je clique sur "Valider"
 		Alors je vois "Social" sur la ligne "Tifour"
 		Alors je vois "Simon Anka" sur la ligne "Tifour"

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_member.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_member.yaml
@@ -207,6 +207,7 @@ select_permissions:
           beneficiary:
             deployment_id:
               _eq: X-Hasura-Deployment-Id
+      allow_aggregations: true
   - role: professional
     permission:
       columns:


### PR DESCRIPTION

## :wrench: Problème

Actuellement les CO n'ont pas la possibilité de visualiser le nombre de place disponible pour la prise en charge des structures et des référents pour faire l'orientation/réorientation. 

## :cake: Solution

N'ayant pas encore l'information de la jauge d'une structure, 
on affiche le nombre de carnets dans lequel le pro est référent (ex: Pierre Chevalier (3) 
et pour chaque structure le nombre de carnet dans lequel un pro de la structure est référent (ex: Groupe NS (1))


## :rotating_light:  Points d'attention / Remarques

Etant donné qu'on utilise aussi ce formulaire pour les manager et pour les admin de structure, l'information remontera aussi pour ces derniers.

## :desert_island: Comment tester

Se connecter en tant que `samy.rouate`
Aller sur la liste des bénéficiaires et faire une orientation 
Sélectionner le type d'orientation "Professionnel"
Sélectionner la structure Interlogement
Selectionner Edit Orial (4)
 
<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1413.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


 fix #1397
fix #1396