### PR TITLE
chore: Amélioration des remontées d'erreur vers Sentry.

### DIFF
--- a/app/src/hooks.server.ts
+++ b/app/src/hooks.server.ts
@@ -37,5 +37,8 @@ export const handleError: HandleServerError = ({ error, event }) => {
 		method: event.request.method,
 		url: event.url,
 	});
+	if (err?.message.match(/^Not found:/)) {
+		return;
+	}
 	captureException(err);
 };


### PR DESCRIPTION
## :wrench: Problème

L'application front (Svelte) envoie toutes les erreurs de navigation vers Sentry.
Cela résulte en beaucoup de bruits concernant des routes non trouvées (eg. /wp-index.php) pour lesquelles aucune analyse ni action n'est nécessaire, au détriment des vrais erreurs qu'on souhaite traitées.

## :cake: Solution

Avant d'envoyer l'erreur vers Sentry, on vérifie qu'il ne s'agit pas d'une 404 (`Not found`).

## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Sur la review app, accéder à une page inexistante.
Vérifier qu'aucune erreur Sentry n'est levée sur l'environnement `review`.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Ne pas supprimer ce bloc, qui sera mis à jour [automatiquement](.github/workflows/review-scalingo.yml).
<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
