### PR TITLE
feat: Remplacement du volet du formulaire "Editer une structure" par une page.

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -2,7 +2,7 @@
 
 Il existe plusieurs roles dans l'application Carnet de bord. Chacun correspondant à un profil d'usager.
 - admin_cdb
-- admin_pdi (manager dans les permissions hasura)
+- administrateur de territoire (manager dans les permissions hasura)
 - admin_structure
 - orientation_manager
 - professional
@@ -13,10 +13,10 @@ Il existe plusieurs roles dans l'application Carnet de bord. Chacun correspondan
 | --- | --- |
 | admin | support.carnet-de-bord+admin@fabrique.social.gouv.fr |
 
-Ce compte permet de créer un déploiement et d'y assigner un admin pdi.
+Ce compte permet de créer un déploiement et d'y assigner un administrateur de structure.
 Il existe 2 déploiement dans le jeu de données de test qui sert à peupler la base de données.
 
-## Compte admin PDI (role: manager)
+## Compte admin de territoire (role: manager)
 | username | email |
 | --- | --- |
 | manager.cd93 | support.carnet-de-bord+cd93@fabrique.social.gouv.fr |

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -15348,14 +15348,10 @@ export type GetStructuresForDeploymentQuery = {
 		id: string;
 		siret?: string | null;
 		name: string;
-		shortDesc?: string | null;
 		phone?: string | null;
 		email?: string | null;
 		postalCode?: string | null;
 		city?: string | null;
-		address1?: string | null;
-		address2?: string | null;
-		website?: string | null;
 	}>;
 };
 
@@ -23406,14 +23402,10 @@ export const GetStructuresForDeploymentDocument = {
 								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'siret' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'shortDesc' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'phone' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'postalCode' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'city' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'address1' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'address2' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'website' } },
 							],
 						},
 					},

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -15948,6 +15948,7 @@ export type GetStructureByIdQuery = {
 		address1?: string | null;
 		address2?: string | null;
 		website?: string | null;
+		deployment?: { __typename?: 'deployment'; id: string; label: string } | null;
 	} | null;
 };
 
@@ -24299,6 +24300,17 @@ export const GetStructureByIdDocument = {
 								{ kind: 'Field', name: { kind: 'Name', value: 'address1' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'address2' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'website' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'deployment' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'label' } },
+										],
+									},
+								},
 							],
 						},
 					},

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -15929,6 +15929,28 @@ export type GetAccountsSummaryQuery = {
 	}>;
 };
 
+export type GetStructureByIdQueryVariables = Exact<{
+	structureId: Scalars['uuid'];
+}>;
+
+export type GetStructureByIdQuery = {
+	__typename?: 'query_root';
+	structure_by_pk?: {
+		__typename?: 'structure';
+		id: string;
+		siret?: string | null;
+		name: string;
+		shortDesc?: string | null;
+		phone?: string | null;
+		email?: string | null;
+		postalCode?: string | null;
+		city?: string | null;
+		address1?: string | null;
+		address2?: string | null;
+		website?: string | null;
+	} | null;
+};
+
 export type BeneficiariesWithOrientationRequestCountQueryVariables = Exact<{
 	[key: string]: never;
 }>;
@@ -24233,6 +24255,58 @@ export const GetAccountsSummaryDocument = {
 		},
 	],
 } as unknown as DocumentNode<GetAccountsSummaryQuery, GetAccountsSummaryQueryVariables>;
+export const GetStructureByIdDocument = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'OperationDefinition',
+			operation: 'query',
+			name: { kind: 'Name', value: 'GetStructureById' },
+			variableDefinitions: [
+				{
+					kind: 'VariableDefinition',
+					variable: { kind: 'Variable', name: { kind: 'Name', value: 'structureId' } },
+					type: {
+						kind: 'NonNullType',
+						type: { kind: 'NamedType', name: { kind: 'Name', value: 'uuid' } },
+					},
+				},
+			],
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'structure_by_pk' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'id' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'structureId' } },
+							},
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'siret' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'shortDesc' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'phone' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'postalCode' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'city' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'address1' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'address2' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'website' } },
+							],
+						},
+					},
+				],
+			},
+		},
+	],
+} as unknown as DocumentNode<GetStructureByIdQuery, GetStructureByIdQueryVariables>;
 export const BeneficiariesWithOrientationRequestCountDocument = {
 	kind: 'Document',
 	definitions: [
@@ -29489,6 +29563,10 @@ export type GetDeploymentInfosQueryStore = OperationStore<
 export type GetAccountsSummaryQueryStore = OperationStore<
 	GetAccountsSummaryQuery,
 	GetAccountsSummaryQueryVariables
+>;
+export type GetStructureByIdQueryStore = OperationStore<
+	GetStructureByIdQuery,
+	GetStructureByIdQueryVariables
 >;
 export type BeneficiariesWithOrientationRequestCountQueryStore = OperationStore<
 	BeneficiariesWithOrientationRequestCountQuery,

--- a/app/src/lib/routes/index.ts
+++ b/app/src/lib/routes/index.ts
@@ -1,6 +1,6 @@
 export type Segment = {
-	name: string;
-	path: string;
+	name?: string;
+	path?: string;
 	label: string;
 };
 

--- a/app/src/lib/ui/Deployment/View.svelte
+++ b/app/src/lib/ui/Deployment/View.svelte
@@ -26,7 +26,7 @@
 	export let professional_aggregate: ProfessionalAggregateSub;
 	export let refreshStore: () => void;
 
-	function onAddAdminPdiClick() {
+	function onAddManagerClick() {
 		openComponent.open({
 			component: AdminCreate,
 			props: {
@@ -43,7 +43,9 @@
 	Déploiement <span class="text-france-blue-500">{deployment?.label ?? ''}</span>
 </h1>
 <div class="flex justify-between items-center">
-	<Button classNames="self-end" on:click={onAddAdminPdiClick}>Ajouter un admin pdi</Button>
+	<Button classNames="self-end" on:click={onAddManagerClick}
+		>Ajouter un administrateur de territoire</Button
+	>
 </div>
 <div class="fr-container--fluid">
 	<div class="fr-grid-row fr-grid-row--gutters">

--- a/app/src/lib/ui/StructureEdit/StructureCreationForm.svelte
+++ b/app/src/lib/ui/StructureEdit/StructureCreationForm.svelte
@@ -22,33 +22,35 @@
 	let:isSubmitted
 	let:isValid
 >
-	<Input placeholder="Pole insertion" inputLabel="Nom" name="name" />
-	<Input placeholder="service d'insertion" inputLabel="Description" name="shortDesc" />
-	<Input placeholder="agence@cd08.fr" inputLabel="Courriel" name="email" />
-	<Input
-		placeholder=""
-		inputLabel="Téléphones"
-		name="phone"
-		class="max-w-max"
-		inputHint="Si plusieurs téléphones, utiliser une virgule pour les séparer"
-	/>
-	<Input placeholder="" inputLabel="Siret" name="siret" class="max-w-max" />
-	<Input placeholder="" inputLabel="Adresse" name="address1" />
-	<Input placeholder="10 rue des mésanges" inputLabel="Complément d'adresse" name="address2" />
-	<div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+	<div class="max-w-lg">
+		<Input placeholder="Pole insertion" inputLabel="Nom" name="name" />
+		<Input placeholder="service d'insertion" inputLabel="Description" name="shortDesc" />
+		<Input placeholder="agence@cd08.fr" inputLabel="Courriel" name="email" />
 		<Input
-			class="fr-col-3 max-w-max"
-			inputLabel="Code postal"
-			placeholder="75008"
-			name="postalCode"
+			placeholder=""
+			inputLabel="Téléphones"
+			name="phone"
+			inputHint="Si plusieurs téléphones, utiliser une virgule pour les séparer"
 		/>
-		<Input class="fr-col-9" inputLabel="Ville" placeholder="Paris" name="city" />
-	</div>
-	<Input placeholder="https://monsite.url" inputLabel="Site web" name="website" />
+		<Input placeholder="" inputLabel="Siret" name="siret" />
+		<Input placeholder="" inputLabel="Adresse" name="address1" />
+		<Input placeholder="10 rue des mésanges" inputLabel="Complément d'adresse" name="address2" />
+		<div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+			<Input
+				class="fr-col-3 max-w-max"
+				inputLabel="Code postal"
+				placeholder="75008"
+				name="postalCode"
+			/>
+			<Input class="fr-col-9" inputLabel="Ville" placeholder="Paris" name="city" />
+		</div>
+		<Input placeholder="https://monsite.url" inputLabel="Site web" name="website" />
 
-	<div class="flex flex-row gap-6 mt-12">
-		<Button type="submit" disabled={(isSubmitted && !isValid) || isSubmitting}>{submitLabel}</Button
-		>
-		{#if onCancel}<Button outline={true} on:click={onCancel}>Annuler</Button>{/if}
+		<div class="flex flex-row gap-6 mt-12">
+			<Button type="submit" disabled={(isSubmitted && !isValid) || isSubmitting}
+				>{submitLabel}</Button
+			>
+			{#if onCancel}<Button outline={true} on:click={onCancel}>Annuler</Button>{/if}
+		</div>
 	</div>
 </Form>

--- a/app/src/lib/ui/StructureEdit/StructureCreationForm.svelte
+++ b/app/src/lib/ui/StructureEdit/StructureCreationForm.svelte
@@ -34,7 +34,7 @@
 	/>
 	<Input placeholder="" inputLabel="Siret" name="siret" class="max-w-max" />
 	<Input placeholder="" inputLabel="Adresse" name="address1" />
-	<Input placeholder="1o rue des mésanges" inputLabel="Complément d'adresse" name="address2" />
+	<Input placeholder="10 rue des mésanges" inputLabel="Complément d'adresse" name="address2" />
 	<div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
 		<Input
 			class="fr-col-3 max-w-max"

--- a/app/src/lib/ui/StructureEdit/StructureEditLayer.svelte
+++ b/app/src/lib/ui/StructureEdit/StructureEditLayer.svelte
@@ -9,16 +9,13 @@
 	import StructureCreationForm from './StructureCreationForm.svelte';
 
 	export let structure: GetStructuresForDeploymentQuery['structure'][0];
+	export let onClose: () => void;
 	const updateResult = operationStore(UpdateStructureDocument);
 	const updateStructure = mutation(updateResult);
 
-	let alertMessage: string;
-	let showAlert = false;
-	let alertType: 'success' | 'error' = 'success';
+	let errorMessage: string;
 
 	async function handleSubmit(values: StructureFormInput) {
-		showAlert = false;
-
 		await updateStructure({
 			id: structure.id,
 			name: values.name,
@@ -33,24 +30,20 @@
 			website: values.website,
 		});
 
-		showAlert = true;
-
 		if (updateResult.error) {
-			alertMessage = "L'enregistrement a échoué.";
-			alertType = 'error';
+			errorMessage = "L'enregistrement a échoué.";
 		} else {
-			alertMessage = 'Les informations de la structure ont été mises à jour.';
-			alertType = 'success';
+			onClose();
 		}
 	}
 </script>
 
 <div class="flex flex-col gap-4">
 	<h1>Mettre à jour les informations de structure</h1>
-	<StructureCreationForm onSubmit={handleSubmit} initialValues={structure} />
-	{#if showAlert}
+	<StructureCreationForm onSubmit={handleSubmit} onCancel={onClose} initialValues={structure} />
+	{#if errorMessage}
 		<div class="mb-8">
-			<Alert type={alertType} description={alertMessage} />
+			<Alert type="error" description={errorMessage} />
 		</div>
 	{/if}
 </div>

--- a/app/src/lib/ui/StructureEdit/StructureEditLayer.svelte
+++ b/app/src/lib/ui/StructureEdit/StructureEditLayer.svelte
@@ -2,50 +2,55 @@
 	import {
 		type GetStructuresForDeploymentQuery,
 		UpdateStructureDocument,
-		RoleEnum,
 	} from '$lib/graphql/_gen/typed-document-nodes';
 	import { mutation, operationStore } from '@urql/svelte';
 	import { Alert } from '$lib/ui/base';
 	import type { StructureFormInput } from './structure.schema';
 	import StructureCreationForm from './StructureCreationForm.svelte';
-	import { homeForRole } from '$lib/routes';
-	import { goto } from '$app/navigation';
 
 	export let structure: GetStructuresForDeploymentQuery['structure'][0];
 	const updateResult = operationStore(UpdateStructureDocument);
 	const updateStructure = mutation(updateResult);
 
-	let error: string;
+	let alertMessage: string;
+	let showAlert = false;
+	let alertType: 'success' | 'error' = 'success';
+
 	async function handleSubmit(values: StructureFormInput) {
-		delete values.__typename;
+		showAlert = false;
 
 		await updateStructure({
 			id: structure.id,
-			...values,
+			name: values.name,
+			shortDesc: values.shortDesc,
+			email: values.email,
+			phone: values.phone,
+			siret: values.siret,
+			address1: values.address1,
+			address2: values.address2,
+			postalCode: values.postalCode,
+			city: values.city,
+			website: values.website,
 		});
 
+		showAlert = true;
+
 		if (updateResult.error) {
-			error = "L'enregistrement a échoué.";
+			alertMessage = "L'enregistrement a échoué.";
+			alertType = 'error';
 		} else {
-			goToStructuresList();
+			alertMessage = 'Les informations de la structure ont été mises à jour.';
+			alertType = 'success';
 		}
-	}
-
-	function onCancel() {
-		goToStructuresList();
-	}
-
-	function goToStructuresList() {
-		goto(`${homeForRole(RoleEnum.Manager)}/structures`);
 	}
 </script>
 
 <div class="flex flex-col gap-4">
 	<h1>Mettre à jour les informations de structure</h1>
-	<StructureCreationForm onSubmit={handleSubmit} {onCancel} initialValues={structure} />
-	{#if error}
+	<StructureCreationForm onSubmit={handleSubmit} initialValues={structure} />
+	{#if showAlert}
 		<div class="mb-8">
-			<Alert type="error" description={error} />
+			<Alert type={alertType} description={alertMessage} />
 		</div>
 	{/if}
 </div>

--- a/app/src/lib/ui/StructureEdit/StructureEditLayer.svelte
+++ b/app/src/lib/ui/StructureEdit/StructureEditLayer.svelte
@@ -2,12 +2,14 @@
 	import {
 		type GetStructuresForDeploymentQuery,
 		UpdateStructureDocument,
+		RoleEnum,
 	} from '$lib/graphql/_gen/typed-document-nodes';
 	import { mutation, operationStore } from '@urql/svelte';
-	import { openComponent } from '$lib/stores';
 	import { Alert } from '$lib/ui/base';
 	import type { StructureFormInput } from './structure.schema';
 	import StructureCreationForm from './StructureCreationForm.svelte';
+	import { homeForRole } from '$lib/routes';
+	import { goto } from '$app/navigation';
 
 	export let structure: GetStructuresForDeploymentQuery['structure'][0];
 	const updateResult = operationStore(UpdateStructureDocument);
@@ -15,6 +17,8 @@
 
 	let error: string;
 	async function handleSubmit(values: StructureFormInput) {
+		delete values.__typename;
+
 		await updateStructure({
 			id: structure.id,
 			...values,
@@ -23,12 +27,16 @@
 		if (updateResult.error) {
 			error = "L'enregistrement a échoué.";
 		} else {
-			openComponent.close();
+			goToStructuresList();
 		}
 	}
 
 	function onCancel() {
-		openComponent.close();
+		goToStructuresList();
+	}
+
+	function goToStructuresList() {
+		goto(`${homeForRole(RoleEnum.Manager)}/structures`);
 	}
 </script>
 

--- a/app/src/routes/(auth)/admin/deployment/[uuid]/structures/+page.svelte
+++ b/app/src/routes/(auth)/admin/deployment/[uuid]/structures/+page.svelte
@@ -2,21 +2,17 @@
 	import {
 		GetDeploymentByIdDocument,
 		GetStructuresForDeploymentDocument,
-		type GetStructuresForDeploymentQuery,
 	} from '$lib/graphql/_gen/typed-document-nodes';
 	import { operationStore, query } from '@urql/svelte';
 	import LoaderIndicator from '$lib/ui/utils/LoaderIndicator.svelte';
 
 	import { SearchBar } from '$lib/ui/base';
 	import StructureList from '$lib/ui/StructureList/StructureList.svelte';
-	import { openComponent } from '$lib/stores';
-	import StructureEditLayer from '$lib/ui/StructureEdit/StructureEditLayer.svelte';
 	import Breadcrumbs from '$lib/ui/base/Breadcrumbs.svelte';
 	import type { PageData } from './$types';
+	import { goto } from '$app/navigation';
 
 	export let data: PageData;
-
-	type Structure = GetStructuresForDeploymentQuery['structure'][0];
 
 	const getDeploymentStore = operationStore(GetDeploymentByIdDocument, { id: data.deploymentId });
 	query(getDeploymentStore);
@@ -52,15 +48,6 @@
 	};
 
 	$: filteredStructures = structures;
-
-	function openEditLayer(structure: Structure) {
-		openComponent.open({
-			component: StructureEditLayer,
-			props: {
-				structure: structure,
-			},
-		});
-	}
 
 	$: breadcrumbs = [
 		{
@@ -104,7 +91,7 @@
 			</div>
 			<StructureList
 				structures={filteredStructures}
-				on:edit={(event) => openEditLayer(event.detail.structure)}
+				on:edit={(event) => goto(`structures/${event.detail.structure.id}`)}
 			/>
 		</div>
 	</LoaderIndicator>

--- a/app/src/routes/(auth)/admin/deployment/[uuid]/structures/[structure_id]/+page.svelte
+++ b/app/src/routes/(auth)/admin/deployment/[uuid]/structures/[structure_id]/+page.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import Breadcrumbs from '$lib/ui/base/Breadcrumbs.svelte';
+	import { operationStore, query } from '@urql/svelte';
+	import { GetStructureByIdDocument } from '$lib/graphql/_gen/typed-document-nodes';
+	import StructureEditLayer from '$lib/ui/StructureEdit/StructureEditLayer.svelte';
+	import LoaderIndicator from '$lib/ui/utils/LoaderIndicator.svelte';
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	const getStructure = operationStore(GetStructureByIdDocument, { structureId: data.structureId });
+	query(getStructure);
+
+	$: structure = $getStructure.data?.structure_by_pk;
+
+	$: breadcrumbs = [
+		{
+			name: 'accueil',
+			path: '/admin',
+			label: 'Accueil',
+		},
+		{
+			name: 'deploiement',
+			path: `/admin/deployment/${structure?.deployment.id}`,
+			label: `${structure?.deployment.label ?? ''}`,
+		},
+		{
+			name: 'structures',
+			path: `/admin/deployment/${structure?.deployment.id}/structures`,
+			label: 'Structures',
+		},
+		{
+			name: 'Mettre à jour les informations de structure',
+			path: `/admin/deployment/${structure?.deployment.id}/structures/${data.structureId}`,
+			label: `${structure?.name ?? ''}`,
+		},
+	];
+</script>
+
+<Breadcrumbs segments={breadcrumbs} />
+<LoaderIndicator result={$getStructure}>
+	<StructureEditLayer {structure} />
+</LoaderIndicator>

--- a/app/src/routes/(auth)/admin/deployment/[uuid]/structures/[structure_id]/+page.svelte
+++ b/app/src/routes/(auth)/admin/deployment/[uuid]/structures/[structure_id]/+page.svelte
@@ -5,6 +5,7 @@
 	import StructureEditLayer from '$lib/ui/StructureEdit/StructureEditLayer.svelte';
 	import LoaderIndicator from '$lib/ui/utils/LoaderIndicator.svelte';
 	import type { PageData } from './$types';
+	import { goto } from '$app/navigation';
 
 	export let data: PageData;
 
@@ -12,6 +13,8 @@
 	query(getStructure);
 
 	$: structure = $getStructure.data?.structure_by_pk;
+
+	$: structuresListPath = `/admin/deployment/${structure?.deployment.id}/structures`;
 
 	$: breadcrumbs = [
 		{
@@ -26,16 +29,20 @@
 		},
 		{
 			name: 'structures',
-			path: `/admin/deployment/${structure?.deployment.id}/structures`,
+			path: structuresListPath,
 			label: 'Structures',
 		},
 		{
 			label: `${structure?.name ?? ''}`,
 		},
 	];
+
+	function goToStructuresList() {
+		goto(structuresListPath);
+	}
 </script>
 
 <Breadcrumbs segments={breadcrumbs} />
 <LoaderIndicator result={$getStructure}>
-	<StructureEditLayer {structure} />
+	<StructureEditLayer {structure} onClose={goToStructuresList} />
 </LoaderIndicator>

--- a/app/src/routes/(auth)/admin/deployment/[uuid]/structures/[structure_id]/+page.svelte
+++ b/app/src/routes/(auth)/admin/deployment/[uuid]/structures/[structure_id]/+page.svelte
@@ -30,8 +30,6 @@
 			label: 'Structures',
 		},
 		{
-			name: 'Mettre à jour les informations de structure',
-			path: `/admin/deployment/${structure?.deployment.id}/structures/${data.structureId}`,
 			label: `${structure?.name ?? ''}`,
 		},
 	];

--- a/app/src/routes/(auth)/admin/deployment/[uuid]/structures/[structure_id]/+page.ts
+++ b/app/src/routes/(auth)/admin/deployment/[uuid]/structures/[structure_id]/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = ({ params }) => {
+	return {
+		structureId: params.structure_id,
+	};
+};

--- a/app/src/routes/(auth)/admin/deployment/_getStructuresForDeployment.gql
+++ b/app/src/routes/(auth)/admin/deployment/_getStructuresForDeployment.gql
@@ -3,13 +3,9 @@ query GetStructuresForDeployment($deployment: deployment_bool_exp = {}) {
     id
     siret
     name
-    shortDesc
     phone
     email
     postalCode
     city
-    address1
-    address2
-    website
   }
 }

--- a/app/src/routes/(auth)/manager/structures/+page.svelte
+++ b/app/src/routes/(auth)/manager/structures/+page.svelte
@@ -3,15 +3,10 @@
 	import Dialog from '$lib/ui/Dialog.svelte';
 	import AdminDeploymentStructuresImport from '$lib/ui/Manager/ImportStructures.svelte';
 	import StructureList from '$lib/ui/StructureList/StructureList.svelte';
-	import { openComponent } from '$lib/stores';
-	import StructureEditLayer from '$lib/ui/StructureEdit/StructureEditLayer.svelte';
-	import {
-		GetStructuresForDeploymentDocument,
-		type GetStructuresForDeploymentQuery,
-	} from '$lib/graphql/_gen/typed-document-nodes';
+	import { GetStructuresForDeploymentDocument } from '$lib/graphql/_gen/typed-document-nodes';
 	import { operationStore, query } from '@urql/svelte';
 	import LoaderIndicator from '$lib/ui/utils/LoaderIndicator.svelte';
-	type Structure = GetStructuresForDeploymentQuery['structure'][0];
+	import { goto } from '$app/navigation';
 
 	const result = operationStore(
 		GetStructuresForDeploymentDocument,
@@ -44,15 +39,6 @@
 	};
 
 	$: filteredStructures = structures;
-
-	function openEditLayer(structure: Structure) {
-		openComponent.open({
-			component: StructureEditLayer,
-			props: {
-				structure: structure,
-			},
-		});
-	}
 </script>
 
 <svelte:head>
@@ -86,7 +72,7 @@
 		</div>
 		<StructureList
 			structures={filteredStructures}
-			on:edit={(event) => openEditLayer(event.detail.structure)}
+			on:edit={(event) => goto(`structures/${event.detail.structure.id}`)}
 		/>
 	</div>
 </LoaderIndicator>

--- a/app/src/routes/(auth)/manager/structures/[structure_id]/+page.svelte
+++ b/app/src/routes/(auth)/manager/structures/[structure_id]/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import Breadcrumbs from '$lib/ui/base/Breadcrumbs.svelte';
+	import { operationStore, query } from '@urql/svelte';
+	import { GetStructureByIdDocument, RoleEnum } from '$lib/graphql/_gen/typed-document-nodes';
+	import StructureEditLayer from '$lib/ui/StructureEdit/StructureEditLayer.svelte';
+	import LoaderIndicator from '$lib/ui/utils/LoaderIndicator.svelte';
+	import type { PageData } from './$types';
+	import { homeForRole } from '$lib/routes';
+
+	export let data: PageData;
+
+	const getStructure = operationStore(GetStructureByIdDocument, { structureId: data.structureId });
+	query(getStructure);
+
+	$: structure = $getStructure.data?.structure_by_pk;
+
+	$: breadcrumbs = [
+		{
+			name: 'Liste des structures',
+			path: `${homeForRole(RoleEnum.Manager)}/structures`,
+			label: 'Liste des Structures',
+		},
+		{
+			name: 'Mettre à jour les informations de structure',
+			path: `${homeForRole(RoleEnum.Manager)}/${data.structureId}`,
+			label: `${structure?.name ?? ''}`,
+		},
+	];
+</script>
+
+<Breadcrumbs segments={breadcrumbs} />
+<LoaderIndicator result={$getStructure}>
+	<StructureEditLayer {structure} />
+</LoaderIndicator>

--- a/app/src/routes/(auth)/manager/structures/[structure_id]/+page.svelte
+++ b/app/src/routes/(auth)/manager/structures/[structure_id]/+page.svelte
@@ -6,6 +6,7 @@
 	import LoaderIndicator from '$lib/ui/utils/LoaderIndicator.svelte';
 	import type { PageData } from './$types';
 	import { homeForRole } from '$lib/routes';
+	import { goto } from '$app/navigation';
 
 	export let data: PageData;
 
@@ -14,19 +15,25 @@
 
 	$: structure = $getStructure.data?.structure_by_pk;
 
+	const structuresListPath = `${homeForRole(RoleEnum.Manager)}/structures`;
+
 	$: breadcrumbs = [
 		{
 			name: 'Liste des structures',
-			path: `${homeForRole(RoleEnum.Manager)}/structures`,
+			path: structuresListPath,
 			label: 'Liste des Structures',
 		},
 		{
 			label: `${structure?.name ?? ''}`,
 		},
 	];
+
+	function goToStructuresList() {
+		goto(structuresListPath);
+	}
 </script>
 
 <Breadcrumbs segments={breadcrumbs} />
 <LoaderIndicator result={$getStructure}>
-	<StructureEditLayer {structure} />
+	<StructureEditLayer {structure} onClose={goToStructuresList} />
 </LoaderIndicator>

--- a/app/src/routes/(auth)/manager/structures/[structure_id]/+page.svelte
+++ b/app/src/routes/(auth)/manager/structures/[structure_id]/+page.svelte
@@ -21,8 +21,6 @@
 			label: 'Liste des Structures',
 		},
 		{
-			name: 'Mettre à jour les informations de structure',
-			path: `${homeForRole(RoleEnum.Manager)}/${data.structureId}`,
 			label: `${structure?.name ?? ''}`,
 		},
 	];

--- a/app/src/routes/(auth)/manager/structures/[structure_id]/+page.ts
+++ b/app/src/routes/(auth)/manager/structures/[structure_id]/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = ({ params }) => {
+	return {
+		structureId: params.structure_id,
+	};
+};

--- a/app/src/routes/(auth)/manager/structures/[structure_id]/_getStructureById.gql
+++ b/app/src/routes/(auth)/manager/structures/[structure_id]/_getStructureById.gql
@@ -1,0 +1,15 @@
+query GetStructureById($structureId: uuid!) {
+  structure_by_pk(id: $structureId) {
+    id
+    siret
+    name
+    shortDesc
+    phone
+    email
+    postalCode
+    city
+    address1
+    address2
+    website
+  }
+}

--- a/app/src/routes/(auth)/manager/structures/[structure_id]/_getStructureById.gql
+++ b/app/src/routes/(auth)/manager/structures/[structure_id]/_getStructureById.gql
@@ -11,5 +11,9 @@ query GetStructureById($structureId: uuid!) {
     address1
     address2
     website
+    deployment {
+      id
+      label
+    }
   }
 }

--- a/e2e/features/admin_cdb/add_manager.feature
+++ b/e2e/features/admin_cdb/add_manager.feature
@@ -3,14 +3,14 @@
 Fonctionnalité: Ajout d'un manager
 	Pour pouvoir gérer plus facilement l'administration d'un déploiement
 	En tant qu'admininstrateur carnet de bord
-	Je veux pouvoir rajouter un admin pdi à un déploiement
+	Je veux pouvoir rajouter un administrateur de territoire à un déploiement
 
 	Scénario: Ajout d'un manager
 		Soit un "administrateur cdb" authentifié avec l'email "support.carnet-de-bord+admin@fabrique.social.gouv.fr"
 		Quand j'attends que le tableau "Liste des déploiements" apparaisse
 		Quand je clique sur "expérimentation 93"
 		Alors je vois "Déploiement expérimentation 93"
-		Quand je clique sur "Ajouter un admin pdi"
+		Quand je clique sur "Ajouter un administrateur de territoire"
 		Alors je renseigne "juste.leblanc@cd93.fr" dans le champ "Courriel"
 		Alors je renseigne "Juste" dans le champ "Prénom"
 		Alors je renseigne "Leblanc" dans le champ "Nom"

--- a/e2e/features/admin_cdb/updateStructure.feature
+++ b/e2e/features/admin_cdb/updateStructure.feature
@@ -1,6 +1,6 @@
 #language: fr
 
-Fonctionnalité: Modification d'un structure
+Fonctionnalité: Modification d'une structure
 	Pour pouvoir garder des informations d'une structure à jour
 	En tant qu'admin de CdB
 	Je veux pouvoir modifier à les informations d'une structure

--- a/e2e/features/admin_cdb/updateStructure.feature
+++ b/e2e/features/admin_cdb/updateStructure.feature
@@ -12,6 +12,7 @@ Fonctionnalité: Modification d'une structure
 		Quand je clique sur "1 structures"
 		Alors je vois "Interlogement 51" dans le tableau "Liste des structures"
 		Quand je clique sur "Éditer la structure Interlogement 51"
+		Alors je suis sur la page "admin/deployment/c5c3a933-6f4a-4b2b-aa49-7a816eaef16b/structures/c0b8aee3-c061-4023-b57e-92880627d589"
 		Alors je renseigne "51000" dans le champ "Code postal"
 		Alors je renseigne "Châlons-en-Champagne" dans le champ "Ville"
 		Quand je clique sur "Mettre à jour"

--- a/e2e/features/manager/home.feature
+++ b/e2e/features/manager/home.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Rattachement à une structure
 	Je veux pouvoir assigner une nouvelle structure à un bénéficiaire
 
 	Scénario: Modifier la structure de rattachement d'un bénéficiaire
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Alors je vois "5"
 		Quand je clique sur "Bénéficiaires"
 		Quand j'attends que le titre de page "Bénéficiaires" apparaisse

--- a/e2e/features/manager/importBeneficiaires.feature
+++ b/e2e/features/manager/importBeneficiaires.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Import de bénéficiaires
 	Je veux pouvoir importer une liste de bénéficiaires
 
 	Scénario: Import de bénéficiaires
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Importer des bénéficiaires"
 		Quand je clique sur "Importer des nouveaux bénéficiaires"
 		Alors le lien "consulter la notice de remplissage" pointe sur "https://pad.incubateur.net/s/nLmDl89Oi#"
@@ -21,7 +21,7 @@ Fonctionnalité: Import de bénéficiaires
 		Alors je vois "Un bénéficiaire existe déjà avec ce nom/prénom/date de naissance sur le territoire." sur la ligne "charlie"
 
 	Scénario: Import de bénéficiaires avec différents formats de date
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Importer des bénéficiaires"
 		Quand je clique sur "Importer des nouveaux bénéficiaires"
 		Quand je téléverse le fichier "/resources/import_beneficiaires_with_all_date_formats.csv"
@@ -30,7 +30,7 @@ Fonctionnalité: Import de bénéficiaires
 		Alors je ne vois pas d'alerte
 
 	Scénario: Import de bénéficiaires avec un fichier partiel (identifiant, nom, prenom, date de naissance et nir)
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Importer des bénéficiaires"
 		Quand je clique sur "Importer des nouveaux bénéficiaires"
  		Quand je téléverse le fichier "/resources/import_beneficiaires_partial.csv"
@@ -40,7 +40,7 @@ Fonctionnalité: Import de bénéficiaires
 		Alors je vois "2 bénéficiaires importés sur 2 demandés."
 
 	Scénario: Ré-Import de bénéficiaires
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Importer des bénéficiaires"
 		Quand je clique sur "Importer des nouveaux bénéficiaires"
 		Quand je téléverse le fichier "/resources/re_import_beneficiaires.csv"
@@ -52,7 +52,7 @@ Fonctionnalité: Import de bénéficiaires
 
 
 	Scénario: Import de nouveaux bénéficiaires
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Importer des bénéficiaires"
 		Quand je clique sur "Importer des nouveaux bénéficiaires"
  		Quand je téléverse le fichier "/resources/import_beneficiaires.csv"

--- a/e2e/features/manager/importOrientationManager.feature
+++ b/e2e/features/manager/importOrientationManager.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Import des chargés d'orientation
 	Je veux pouvoir importer une liste de chargés d'orientation
 
 	Scénario: Import de chargés d'orientation
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Importer une liste de chargés d'orientation"
 		Alors je vois "Importer des chargés d'orientation"
 		Alors le lien "consulter la notice de remplissage" pointe sur "https://pad.incubateur.net/s/EchGdpy8h"

--- a/e2e/features/manager/importStructures.feature
+++ b/e2e/features/manager/importStructures.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Import structures
 	Je veux pouvoir importer une liste de structures
 
 	Scénario: Import de structures
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Alors je vois "État du territoire"
 		Quand je clique sur "Importer des structures"
 		Alors je vois "Importer des structures"

--- a/e2e/features/manager/onboardingManager.feature
+++ b/e2e/features/manager/onboardingManager.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Onboarding manager
 	Je veux pouvoir saisir et valider mes informations personnelles
 
 	Scénario: Première connexion - Mise à jour profil
-		Soit un "administrateur pdi" authentifié pour la première fois avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié pour la première fois avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je vois "Création de mon compte Admin de territoire"
 
 		Alors je vois "Agathe" dans le champ "Prénom"

--- a/e2e/features/manager/rattachement.feature
+++ b/e2e/features/manager/rattachement.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Rattachement pro
 	Je veux pouvoir assigner de nouveaux référents aux bénéficiaires
 
 	Scénario: Modifier le rattachement d'un bénéficiaire
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
 		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Quand je recherche "tif"
@@ -23,7 +23,7 @@ Fonctionnalité: Rattachement pro
 		Alors je vois "Groupe NS" sur la ligne "Tifour"
 
 	Scénario: Ré-orienter des bénéficiaires
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
 		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
 		Alors je choisis "Sélectionner Corinne Cash"

--- a/e2e/features/manager/showListBeneficiairies.feature
+++ b/e2e/features/manager/showListBeneficiairies.feature
@@ -5,14 +5,14 @@ Fonctionnalité: Consultation de la liste des bénéficiaires par un manager
 	Je veux voir la liste des bénéficiaires
 
 	Scénario: Voir la liste
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
 		Quand j'attends que le tableau "Liste des bénéficiaires" apparaisse
 		Alors je vois la colonne "Date de naissance"
 		Alors je vois "22/06/1996" sur la ligne "Lindsay"
 
 	Scénario: Voir la liste des bénéficiaires d'un professionnel
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Professionnels"
 		Quand je clique sur "liste des bénéficiaires de Pierre Chevalier"
 		Alors je vois "pierre.chevalier@livry-gargan.fr"
@@ -20,7 +20,7 @@ Fonctionnalité: Consultation de la liste des bénéficiaires par un manager
 		Alors je vois "Tifour" dans le tableau "Liste des bénéficiaires"
 
 	Scénario: Supprimer le filtre professionnel
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Professionnels"
 		Quand je clique sur "liste des bénéficiaires de Pierre Chevalier"
 		Quand je clique sur "Supprimer le filtre"
@@ -28,7 +28,7 @@ Fonctionnalité: Consultation de la liste des bénéficiaires par un manager
 		Alors je vois "Aguilar" dans le tableau "Liste des bénéficiaires"
 
 	Scénario: rechercher un bénéficiaire par préfixe
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
 		Quand je recherche "gon"
 		Quand je clique sur "Rechercher"
@@ -36,7 +36,7 @@ Fonctionnalité: Consultation de la liste des bénéficiaires par un manager
 		Alors je vois "Gônzalez" sur la ligne "Bolton"
 
 	Scénario: rechercher un bénéficiaire par suffixe
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
 		Quand je recherche "alez"
 		Quand je clique sur "Rechercher"

--- a/e2e/features/manager/updateStructure.feature
+++ b/e2e/features/manager/updateStructure.feature
@@ -10,6 +10,7 @@ Fonctionnalité: Modification d'une structure
 		Quand je clique sur "Structures"
 		Alors je vois "Interlogement 51" dans le tableau "Liste des structures"
 		Quand je clique sur "Éditer la structure Interlogement 51"
+		Alors je suis sur la page "manager/structures/c0b8aee3-c061-4023-b57e-92880627d589"
 		Alors je renseigne "51000" dans le champ "Code postal"
 		Alors je renseigne "Châlons-en-Champagne" dans le champ "Ville"
 		Quand je clique sur "Mettre à jour"

--- a/e2e/features/manager/updateStructure.feature
+++ b/e2e/features/manager/updateStructure.feature
@@ -1,6 +1,6 @@
 #language: fr
 
-Fonctionnalité: Modification d'un structure
+Fonctionnalité: Modification d'une structure
 	Pour pouvoir garder des informations d'une structure à jour
 	En tant que manager
 	Je veux pouvoir modifier à les informations d'une structure

--- a/e2e/features/manager/updateStructure.feature
+++ b/e2e/features/manager/updateStructure.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Modification d'une structure
 	Je veux pouvoir modifier à les informations d'une structure
 
 	Scénario: Mise à jour d'une structure
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd51@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd51@fabrique.social.gouv.fr"
 		Quand je clique sur "Structures"
 		Alors je vois "Interlogement 51" dans le tableau "Liste des structures"
 		Quand je clique sur "Éditer la structure Interlogement 51"

--- a/e2e/features/manager/validateAccount.feature
+++ b/e2e/features/manager/validateAccount.feature
@@ -6,14 +6,14 @@ Fonctionnalité: Gestion de professionnels d'un déploiement
 	Je veux pouvoir voir les professionnels et gérer leur activation
 
 	Scénario: Liste des professionnels
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Professionnels"
 		Quand j'attends que le tableau "Liste des professionnels" apparaisse
 		Alors je vois "1" sur la ligne "Giulia Diaby"
 		Alors je vois "0" sur la ligne "Blaise Alaise"
 
 	Scénario: Validation d'un professionnel
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Professionnels"
 		Quand j'attends que le tableau "Liste des professionnels" apparaisse
 		Quand je clique sur "Activer"

--- a/e2e/features/manager/viewNotebook.feature
+++ b/e2e/features/manager/viewNotebook.feature
@@ -5,7 +5,7 @@ Fonctionnalité: Consultation d'un carnet par un manager
 	Je veux voir le carnet d'un bénéficiaire
 
 	Scénario: voir un carnet par un manager
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
 		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
 		Quand je clique sur "Voir le carnet de Lindsay Aguilar"
@@ -14,7 +14,7 @@ Fonctionnalité: Consultation d'un carnet par un manager
 		Alors je vois "lindsay.aguilar@nisi.fr"
 
 	Scénario: voir l'information RQTH
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
 		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
 		Quand je clique sur "Voir le carnet de Katharine Chandler"
@@ -23,7 +23,7 @@ Fonctionnalité: Consultation d'un carnet par un manager
 		Alors je vois "Usager disposant de la RQTH"
 
 	Scénario: Mettre à jour les informations personnelles
-		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
 		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
 		Quand je clique sur "Voir le carnet de Payne Bennett"

--- a/e2e/step_definitions/fr.js
+++ b/e2e/step_definitions/fr.js
@@ -9,7 +9,7 @@ exports.USER_TYPES = [
 	},
 	{
 		code: 'manager',
-		value: 'administrateur pdi',
+		value: 'administrateur de territoire',
 	},
 	{
 		code: 'admin_structure',


### PR DESCRIPTION
closes #1393

## :wrench: Problème

Lorsqu'un administrateur de territoire ou un administrateur carnet de bord souhaite éditer les informations d'une structure, il doit le faire dans un formulaire assez riche qui s'affiche dans un volet.
Le formulaire est peu pratique à utiliser dans le volet.

## :cake: Solution

Afficher le formulaire dans une page dédiée.
La page est disponible à l'adresse `/manager/structures/[structure_id]`.

## :rotating_light:  Points d'attention / Remarques

On en profite pour renommer toutes les mentions "Admin PDI" en "Administrateur de territoire".

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1418.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->
Se connecter en tant que `manager.cd93`.
Cliquer sur "Structures".
Cliquer sur l'icône "crayon" dans la colonne "Editer" en face d'une structure à modifier.
Vérifier que l'on est redirigé sur une page affichant le formulaire d'édition d'une structure.
Vérifier que l'url est alors `manager/structures/[structure_id]`.
Saisir une modification dans le nom de la structure.
Valider.
Vérifier que l'on est redirigé vers la liste des structures.
Vérifier que la liste affiche le nom de la structure modifié.


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
