### PR TITLE
feat: un référent ne peut pas se détacher du groupe de suivi

### DIFF
--- a/app/__tests__/triggers/notebookEvent.test.ts
+++ b/app/__tests__/triggers/notebookEvent.test.ts
@@ -73,7 +73,6 @@ describe('notebook_event trigger', () => {
 			delete_notebook_event_by_pk(id: "${id}") { id }
 			delete_notebook_action_by_pk(id: "${addActionPayload.data.insert_notebook_action_one.id}") { id }
 	}`;
-		console.log({ mutation });
 		await graphqlAdmin(mutation);
 	});
 });

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2366,18 +2366,39 @@
 			}
 		},
 		"node_modules/@graphql-tools/batch-execute": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.6.tgz",
-			"integrity": "sha512-33vMvVDLBKsNJVNhcySVXF+zkcRL/GRs1Lt+MxygrYCypcAPpFm+amE2y9vOCFufuaKExIX7Lonnmxu19vPzaQ==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.15.tgz",
+			"integrity": "sha512-qb12M8XCK6SBJmZDS8Lzd4PVJFsIwNUkYmFuqcTiBqOI/WsoDlQDZI++ghRpGcusLkL9uzcIOTT/61OeHhsaLg==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/utils": "8.12.0",
+				"@graphql-tools/utils": "9.1.4",
 				"dataloader": "2.1.0",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "1.0.12"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/batch-execute/node_modules/@graphql-tools/utils": {
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+			"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/batch-execute/node_modules/value-or-promise": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+			"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@graphql-tools/code-file-loader": {
@@ -2397,20 +2418,222 @@
 			}
 		},
 		"node_modules/@graphql-tools/delegate": {
-			"version": "9.0.8",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.8.tgz",
-			"integrity": "sha512-h+Uce0Np0eKj7wILOvlffRQ9jEQ4KelNXfqG8A2w+2sO2P6CbKsR7bJ4ch9lcUdCBbZ4Wg6L/K+1C4NRFfzbNw==",
+			"version": "9.0.22",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.22.tgz",
+			"integrity": "sha512-dWJGMN8V7KORtbI8eDAjHYTWiMyis/md27M6pPhrlYVlcsDk3U0jbNdgkswBBUEBvqumPRCv8pVOxKcLS4caKA==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/batch-execute": "8.5.6",
-				"@graphql-tools/schema": "9.0.4",
-				"@graphql-tools/utils": "8.12.0",
+				"@graphql-tools/batch-execute": "8.5.15",
+				"@graphql-tools/executor": "0.0.12",
+				"@graphql-tools/schema": "9.0.13",
+				"@graphql-tools/utils": "9.1.4",
 				"dataloader": "2.1.0",
 				"tslib": "~2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "1.0.12"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/merge": {
+			"version": "8.3.15",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.15.tgz",
+			"integrity": "sha512-hYYOlsqkUlL6oOo7zzuk6hIv7xQzy+x21sgK84d5FWaiWYkLYh9As8myuDd9SD5xovWWQ9m/iRhIOVDEMSyEKA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "9.1.4",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/schema": {
+			"version": "9.0.13",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.13.tgz",
+			"integrity": "sha512-guRA3fwAtv+M1Kh930P4ydH9aKJTWscIkhVFcWpj/cnjYYxj88jkEJ15ZNiJX/2breNY+sbVgmlgLKb6aXi/Jg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/merge": "8.3.15",
+				"@graphql-tools/utils": "9.1.4",
+				"tslib": "^2.4.0",
+				"value-or-promise": "1.0.12"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/utils": {
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+			"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/delegate/node_modules/value-or-promise": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+			"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@graphql-tools/executor": {
+			"version": "0.0.12",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-0.0.12.tgz",
+			"integrity": "sha512-bWpZcYRo81jDoTVONTnxS9dDHhEkNVjxzvFCH4CRpuyzD3uL+5w3MhtxIh24QyWm4LvQ4f+Bz3eMV2xU2I5+FA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "9.1.4",
+				"@graphql-typed-document-node/core": "3.1.1",
+				"@repeaterjs/repeater": "3.0.4",
+				"tslib": "^2.4.0",
+				"value-or-promise": "1.0.12"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-graphql-ws": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-0.0.6.tgz",
+			"integrity": "sha512-n6JvIviYO8iiasV/baclimQqNkYGP7JRlkNSnphNG5LULmVpQ2WsyvbgJHV7wtlTZ8ZQ3+dILgQF83PFyLsfdA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "9.1.4",
+				"@repeaterjs/repeater": "3.0.4",
+				"@types/ws": "^8.0.0",
+				"graphql-ws": "5.11.2",
+				"isomorphic-ws": "5.0.0",
+				"tslib": "^2.4.0",
+				"ws": "8.12.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-graphql-ws/node_modules/@graphql-tools/utils": {
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+			"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-http": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.1.0.tgz",
+			"integrity": "sha512-HUas+3EIqbw/reNH3NaO8/5Cc61ZxsoIArES55kR6Nq8lS8VWiEpnuXLXBq2THYemmthVdK3eDCKTJLmUFuKdA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "9.1.4",
+				"@repeaterjs/repeater": "3.0.4",
+				"@whatwg-node/fetch": "0.6.1",
+				"dset": "3.1.2",
+				"extract-files": "^11.0.0",
+				"meros": "1.2.1",
+				"tslib": "^2.4.0",
+				"value-or-promise": "1.0.12"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-http/node_modules/@graphql-tools/utils": {
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+			"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-http/node_modules/@whatwg-node/fetch": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.6.1.tgz",
+			"integrity": "sha512-sG39WLvcJxGZ+gDstnLSXR2IcnuvIOB51KxCFo0mEhFW0q2u8fZgolr0HPkL+zXwOJsnmT+9V3IRcqLnTXdqVQ==",
+			"dev": true,
+			"dependencies": {
+				"@peculiar/webcrypto": "^1.4.0",
+				"abort-controller": "^3.0.0",
+				"busboy": "^1.6.0",
+				"form-data-encoder": "^1.7.1",
+				"formdata-node": "^4.3.1",
+				"node-fetch": "^2.6.7",
+				"undici": "^5.12.0",
+				"urlpattern-polyfill": "^6.0.2",
+				"web-streams-polyfill": "^3.2.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-http/node_modules/value-or-promise": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+			"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@graphql-tools/executor-legacy-ws": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-0.0.6.tgz",
+			"integrity": "sha512-L1hRuSvBUCNerYDhfeSZXFeqliDlnNXa3fDHTp7efI3Newpbevqa19Fm0mVzsCL7gqIKOwzrPORwh7kOVE/vew==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "9.1.4",
+				"@types/ws": "^8.0.0",
+				"isomorphic-ws": "5.0.0",
+				"tslib": "^2.4.0",
+				"ws": "8.12.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-legacy-ws/node_modules/@graphql-tools/utils": {
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+			"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+			"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor/node_modules/value-or-promise": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+			"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@graphql-tools/git-loader": {
@@ -2564,16 +2787,16 @@
 			}
 		},
 		"node_modules/@graphql-tools/prisma-loader": {
-			"version": "7.2.24",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.24.tgz",
-			"integrity": "sha512-CRQvoraCIcQa44RMSF3EpzLedouR9SSLC6ylFEHCFf2b8r1EfbK5NOdLL1V9znOjjapI6/oJURlFWdldcAaMgg==",
+			"version": "7.2.52",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.52.tgz",
+			"integrity": "sha512-xA0p5wJQouyqDL8I1g1lolnJ8zV73+OIln5ObSSTcC8de7zZjqCAvtXR8X9MPeco0FGHnSJo/qdSaGbbc1kXyA==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/url-loader": "7.16.4",
-				"@graphql-tools/utils": "8.12.0",
+				"@graphql-tools/url-loader": "7.17.1",
+				"@graphql-tools/utils": "9.1.4",
 				"@types/js-yaml": "^4.0.0",
 				"@types/json-stable-stringify": "^1.0.32",
-				"@types/jsonwebtoken": "^8.5.0",
+				"@types/jsonwebtoken": "^9.0.0",
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
 				"dotenv": "^16.0.0",
@@ -2583,7 +2806,7 @@
 				"isomorphic-fetch": "^3.0.0",
 				"js-yaml": "^4.0.0",
 				"json-stable-stringify": "^1.0.1",
-				"jsonwebtoken": "^8.5.1",
+				"jsonwebtoken": "^9.0.0",
 				"lodash": "^4.17.20",
 				"scuid": "^1.1.0",
 				"tslib": "^2.4.0",
@@ -2591,6 +2814,27 @@
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/prisma-loader/node_modules/@graphql-tools/utils": {
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+			"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/prisma-loader/node_modules/@types/jsonwebtoken": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+			"integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@graphql-tools/prisma-loader/node_modules/ansi-styles": {
@@ -2651,37 +2895,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@graphql-tools/prisma-loader/node_modules/jsonwebtoken": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-			"dev": true,
-			"dependencies": {
-				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^5.6.0"
-			},
-			"engines": {
-				"node": ">=4",
-				"npm": ">=1.4.28"
-			}
-		},
-		"node_modules/@graphql-tools/prisma-loader/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
 		"node_modules/@graphql-tools/prisma-loader/node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2724,34 +2937,45 @@
 			}
 		},
 		"node_modules/@graphql-tools/url-loader": {
-			"version": "7.16.4",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.16.4.tgz",
-			"integrity": "sha512-7yGrJJNcqVQIplCyVLk7tW2mAgYyZ06FRmCBnzw3B61+aIjFavrm6YlnKkhdqYSYyFmIbVcigdP3vkoYIu23TA==",
+			"version": "7.17.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.17.1.tgz",
+			"integrity": "sha512-+WZXkg1ZG4fjAB+SkCHLSr7VFZqZAkA/PILcpoPqwAL/wSsrhCHYwbzuWuKn1SGToxJRt7cc+4P0lfR7fq+xhQ==",
 			"dev": true,
 			"dependencies": {
 				"@ardatan/sync-fetch": "0.0.1",
-				"@graphql-tools/delegate": "9.0.8",
-				"@graphql-tools/utils": "8.12.0",
-				"@graphql-tools/wrap": "9.2.3",
+				"@graphql-tools/delegate": "9.0.22",
+				"@graphql-tools/executor-graphql-ws": "0.0.6",
+				"@graphql-tools/executor-http": "0.1.0",
+				"@graphql-tools/executor-legacy-ws": "0.0.6",
+				"@graphql-tools/utils": "9.1.4",
+				"@graphql-tools/wrap": "9.3.0",
 				"@types/ws": "^8.0.0",
-				"@whatwg-node/fetch": "^0.4.0",
-				"dset": "^3.1.2",
-				"extract-files": "^11.0.0",
-				"graphql-ws": "^5.4.1",
-				"isomorphic-ws": "^5.0.0",
-				"meros": "^1.1.4",
+				"@whatwg-node/fetch": "^0.6.0",
+				"isomorphic-ws": "5.0.0",
 				"tslib": "^2.4.0",
 				"value-or-promise": "^1.0.11",
-				"ws": "^8.3.0"
+				"ws": "8.12.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/url-loader/node_modules/@graphql-tools/utils": {
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+			"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 			}
 		},
 		"node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/fetch": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.7.tgz",
-			"integrity": "sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.6.2.tgz",
+			"integrity": "sha512-fCUycF1W+bI6XzwJFnbdDuxIldfKM3w8+AzVCLGlucm0D+AQ8ZMm2j84hdcIhfV6ZdE4Y1HFVrHosAxdDZ+nPw==",
 			"dev": true,
 			"dependencies": {
 				"@peculiar/webcrypto": "^1.4.0",
@@ -2760,7 +2984,8 @@
 				"form-data-encoder": "^1.7.1",
 				"formdata-node": "^4.3.1",
 				"node-fetch": "^2.6.7",
-				"undici": "^5.10.0",
+				"undici": "^5.12.0",
+				"urlpattern-polyfill": "^6.0.2",
 				"web-streams-polyfill": "^3.2.0"
 			}
 		},
@@ -2777,19 +3002,68 @@
 			}
 		},
 		"node_modules/@graphql-tools/wrap": {
-			"version": "9.2.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.2.3.tgz",
-			"integrity": "sha512-aiLjcAuUwcvA1mF25c7KFDPXEdQDpo6bTDyAMCSlFXpF4T01hoxLERmfmbRmsmy/dP80ZB31a+t70aspVdqZSA==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.3.0.tgz",
+			"integrity": "sha512-QOEg04kzFJ1WrlA2t/qjw85C20qPDJwIU/d+bDgDd1+cjTQcVrEt9bq9NilZZg9m9AAgZbeyDwut0oQvNMCGhw==",
 			"dev": true,
 			"dependencies": {
-				"@graphql-tools/delegate": "9.0.8",
-				"@graphql-tools/schema": "9.0.4",
-				"@graphql-tools/utils": "8.12.0",
+				"@graphql-tools/delegate": "9.0.22",
+				"@graphql-tools/schema": "9.0.13",
+				"@graphql-tools/utils": "9.1.4",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "1.0.12"
 			},
 			"peerDependencies": {
 				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/merge": {
+			"version": "8.3.15",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.15.tgz",
+			"integrity": "sha512-hYYOlsqkUlL6oOo7zzuk6hIv7xQzy+x21sgK84d5FWaiWYkLYh9As8myuDd9SD5xovWWQ9m/iRhIOVDEMSyEKA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "9.1.4",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/schema": {
+			"version": "9.0.13",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.13.tgz",
+			"integrity": "sha512-guRA3fwAtv+M1Kh930P4ydH9aKJTWscIkhVFcWpj/cnjYYxj88jkEJ15ZNiJX/2breNY+sbVgmlgLKb6aXi/Jg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/merge": "8.3.15",
+				"@graphql-tools/utils": "9.1.4",
+				"tslib": "^2.4.0",
+				"value-or-promise": "1.0.12"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/utils": {
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+			"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/wrap/node_modules/value-or-promise": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+			"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@graphql-typed-document-node/core": {
@@ -3075,6 +3349,12 @@
 			"version": "1.0.0-next.21",
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
 			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
+			"dev": true
+		},
+		"node_modules/@repeaterjs/repeater": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
+			"integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
 			"dev": true
 		},
 		"node_modules/@rollup/plugin-commonjs": {
@@ -9187,40 +9467,10 @@
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
 		},
-		"node_modules/lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"node_modules/lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"node_modules/lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"node_modules/lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
 		"node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"node_modules/lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
 			"dev": true
 		},
 		"node_modules/lodash.memoize": {
@@ -9233,12 +9483,6 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"node_modules/lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"node_modules/lodash.uniq": {
@@ -12932,9 +13176,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.11.0.tgz",
-			"integrity": "sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.15.0.tgz",
+			"integrity": "sha512-wCAZJDyjw9Myv+Ay62LAoB+hZLPW9SmKbQkbHIhMw/acKSlpn7WohdMUc/Vd4j1iSMBO0hWwU8mjB7a5p5bl8g==",
 			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
@@ -13080,6 +13324,15 @@
 			"dependencies": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
+			}
+		},
+		"node_modules/urlpattern-polyfill": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-6.0.2.tgz",
+			"integrity": "sha512-5vZjFlH9ofROmuWmXM9yj2wljYKgWstGwe8YTyiqM7hVum/g9LyCizPZtb3UqsuppVwety9QJmfc42VggLpTgg==",
+			"dev": true,
+			"dependencies": {
+				"braces": "^3.0.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -13525,16 +13778,16 @@
 			"dev": true
 		},
 		"node_modules/ws": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-			"integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+			"integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
+				"utf-8-validate": ">=5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {
@@ -15318,15 +15571,32 @@
 			}
 		},
 		"@graphql-tools/batch-execute": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.6.tgz",
-			"integrity": "sha512-33vMvVDLBKsNJVNhcySVXF+zkcRL/GRs1Lt+MxygrYCypcAPpFm+amE2y9vOCFufuaKExIX7Lonnmxu19vPzaQ==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.15.tgz",
+			"integrity": "sha512-qb12M8XCK6SBJmZDS8Lzd4PVJFsIwNUkYmFuqcTiBqOI/WsoDlQDZI++ghRpGcusLkL9uzcIOTT/61OeHhsaLg==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/utils": "8.12.0",
+				"@graphql-tools/utils": "9.1.4",
 				"dataloader": "2.1.0",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "1.0.12"
+			},
+			"dependencies": {
+				"@graphql-tools/utils": {
+					"version": "9.1.4",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+					"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				},
+				"value-or-promise": {
+					"version": "1.0.12",
+					"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+					"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+					"dev": true
+				}
 			}
 		},
 		"@graphql-tools/code-file-loader": {
@@ -15343,17 +15613,187 @@
 			}
 		},
 		"@graphql-tools/delegate": {
-			"version": "9.0.8",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.8.tgz",
-			"integrity": "sha512-h+Uce0Np0eKj7wILOvlffRQ9jEQ4KelNXfqG8A2w+2sO2P6CbKsR7bJ4ch9lcUdCBbZ4Wg6L/K+1C4NRFfzbNw==",
+			"version": "9.0.22",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.22.tgz",
+			"integrity": "sha512-dWJGMN8V7KORtbI8eDAjHYTWiMyis/md27M6pPhrlYVlcsDk3U0jbNdgkswBBUEBvqumPRCv8pVOxKcLS4caKA==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/batch-execute": "8.5.6",
-				"@graphql-tools/schema": "9.0.4",
-				"@graphql-tools/utils": "8.12.0",
+				"@graphql-tools/batch-execute": "8.5.15",
+				"@graphql-tools/executor": "0.0.12",
+				"@graphql-tools/schema": "9.0.13",
+				"@graphql-tools/utils": "9.1.4",
 				"dataloader": "2.1.0",
 				"tslib": "~2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "1.0.12"
+			},
+			"dependencies": {
+				"@graphql-tools/merge": {
+					"version": "8.3.15",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.15.tgz",
+					"integrity": "sha512-hYYOlsqkUlL6oOo7zzuk6hIv7xQzy+x21sgK84d5FWaiWYkLYh9As8myuDd9SD5xovWWQ9m/iRhIOVDEMSyEKA==",
+					"dev": true,
+					"requires": {
+						"@graphql-tools/utils": "9.1.4",
+						"tslib": "^2.4.0"
+					}
+				},
+				"@graphql-tools/schema": {
+					"version": "9.0.13",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.13.tgz",
+					"integrity": "sha512-guRA3fwAtv+M1Kh930P4ydH9aKJTWscIkhVFcWpj/cnjYYxj88jkEJ15ZNiJX/2breNY+sbVgmlgLKb6aXi/Jg==",
+					"dev": true,
+					"requires": {
+						"@graphql-tools/merge": "8.3.15",
+						"@graphql-tools/utils": "9.1.4",
+						"tslib": "^2.4.0",
+						"value-or-promise": "1.0.12"
+					}
+				},
+				"@graphql-tools/utils": {
+					"version": "9.1.4",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+					"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				},
+				"value-or-promise": {
+					"version": "1.0.12",
+					"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+					"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+					"dev": true
+				}
+			}
+		},
+		"@graphql-tools/executor": {
+			"version": "0.0.12",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-0.0.12.tgz",
+			"integrity": "sha512-bWpZcYRo81jDoTVONTnxS9dDHhEkNVjxzvFCH4CRpuyzD3uL+5w3MhtxIh24QyWm4LvQ4f+Bz3eMV2xU2I5+FA==",
+			"dev": true,
+			"requires": {
+				"@graphql-tools/utils": "9.1.4",
+				"@graphql-typed-document-node/core": "3.1.1",
+				"@repeaterjs/repeater": "3.0.4",
+				"tslib": "^2.4.0",
+				"value-or-promise": "1.0.12"
+			},
+			"dependencies": {
+				"@graphql-tools/utils": {
+					"version": "9.1.4",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+					"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				},
+				"value-or-promise": {
+					"version": "1.0.12",
+					"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+					"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+					"dev": true
+				}
+			}
+		},
+		"@graphql-tools/executor-graphql-ws": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-0.0.6.tgz",
+			"integrity": "sha512-n6JvIviYO8iiasV/baclimQqNkYGP7JRlkNSnphNG5LULmVpQ2WsyvbgJHV7wtlTZ8ZQ3+dILgQF83PFyLsfdA==",
+			"dev": true,
+			"requires": {
+				"@graphql-tools/utils": "9.1.4",
+				"@repeaterjs/repeater": "3.0.4",
+				"@types/ws": "^8.0.0",
+				"graphql-ws": "5.11.2",
+				"isomorphic-ws": "5.0.0",
+				"tslib": "^2.4.0",
+				"ws": "8.12.0"
+			},
+			"dependencies": {
+				"@graphql-tools/utils": {
+					"version": "9.1.4",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+					"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				}
+			}
+		},
+		"@graphql-tools/executor-http": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.1.0.tgz",
+			"integrity": "sha512-HUas+3EIqbw/reNH3NaO8/5Cc61ZxsoIArES55kR6Nq8lS8VWiEpnuXLXBq2THYemmthVdK3eDCKTJLmUFuKdA==",
+			"dev": true,
+			"requires": {
+				"@graphql-tools/utils": "9.1.4",
+				"@repeaterjs/repeater": "3.0.4",
+				"@whatwg-node/fetch": "0.6.1",
+				"dset": "3.1.2",
+				"extract-files": "^11.0.0",
+				"meros": "1.2.1",
+				"tslib": "^2.4.0",
+				"value-or-promise": "1.0.12"
+			},
+			"dependencies": {
+				"@graphql-tools/utils": {
+					"version": "9.1.4",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+					"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				},
+				"@whatwg-node/fetch": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.6.1.tgz",
+					"integrity": "sha512-sG39WLvcJxGZ+gDstnLSXR2IcnuvIOB51KxCFo0mEhFW0q2u8fZgolr0HPkL+zXwOJsnmT+9V3IRcqLnTXdqVQ==",
+					"dev": true,
+					"requires": {
+						"@peculiar/webcrypto": "^1.4.0",
+						"abort-controller": "^3.0.0",
+						"busboy": "^1.6.0",
+						"form-data-encoder": "^1.7.1",
+						"formdata-node": "^4.3.1",
+						"node-fetch": "^2.6.7",
+						"undici": "^5.12.0",
+						"urlpattern-polyfill": "^6.0.2",
+						"web-streams-polyfill": "^3.2.0"
+					}
+				},
+				"value-or-promise": {
+					"version": "1.0.12",
+					"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+					"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+					"dev": true
+				}
+			}
+		},
+		"@graphql-tools/executor-legacy-ws": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-0.0.6.tgz",
+			"integrity": "sha512-L1hRuSvBUCNerYDhfeSZXFeqliDlnNXa3fDHTp7efI3Newpbevqa19Fm0mVzsCL7gqIKOwzrPORwh7kOVE/vew==",
+			"dev": true,
+			"requires": {
+				"@graphql-tools/utils": "9.1.4",
+				"@types/ws": "^8.0.0",
+				"isomorphic-ws": "5.0.0",
+				"tslib": "^2.4.0",
+				"ws": "8.12.0"
+			},
+			"dependencies": {
+				"@graphql-tools/utils": {
+					"version": "9.1.4",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+					"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				}
 			}
 		},
 		"@graphql-tools/git-loader": {
@@ -15482,16 +15922,16 @@
 			}
 		},
 		"@graphql-tools/prisma-loader": {
-			"version": "7.2.24",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.24.tgz",
-			"integrity": "sha512-CRQvoraCIcQa44RMSF3EpzLedouR9SSLC6ylFEHCFf2b8r1EfbK5NOdLL1V9znOjjapI6/oJURlFWdldcAaMgg==",
+			"version": "7.2.52",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.52.tgz",
+			"integrity": "sha512-xA0p5wJQouyqDL8I1g1lolnJ8zV73+OIln5ObSSTcC8de7zZjqCAvtXR8X9MPeco0FGHnSJo/qdSaGbbc1kXyA==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/url-loader": "7.16.4",
-				"@graphql-tools/utils": "8.12.0",
+				"@graphql-tools/url-loader": "7.17.1",
+				"@graphql-tools/utils": "9.1.4",
 				"@types/js-yaml": "^4.0.0",
 				"@types/json-stable-stringify": "^1.0.32",
-				"@types/jsonwebtoken": "^8.5.0",
+				"@types/jsonwebtoken": "^9.0.0",
 				"chalk": "^4.1.0",
 				"debug": "^4.3.1",
 				"dotenv": "^16.0.0",
@@ -15501,13 +15941,31 @@
 				"isomorphic-fetch": "^3.0.0",
 				"js-yaml": "^4.0.0",
 				"json-stable-stringify": "^1.0.1",
-				"jsonwebtoken": "^8.5.1",
+				"jsonwebtoken": "^9.0.0",
 				"lodash": "^4.17.20",
 				"scuid": "^1.1.0",
 				"tslib": "^2.4.0",
 				"yaml-ast-parser": "^0.0.43"
 			},
 			"dependencies": {
+				"@graphql-tools/utils": {
+					"version": "9.1.4",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+					"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				},
+				"@types/jsonwebtoken": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+					"integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*"
+					}
+				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -15548,30 +16006,6 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"jsonwebtoken": {
-					"version": "8.5.1",
-					"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-					"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-					"dev": true,
-					"requires": {
-						"jws": "^3.2.2",
-						"lodash.includes": "^4.3.0",
-						"lodash.isboolean": "^3.0.3",
-						"lodash.isinteger": "^4.0.4",
-						"lodash.isnumber": "^3.0.3",
-						"lodash.isplainobject": "^4.0.6",
-						"lodash.isstring": "^4.0.1",
-						"lodash.once": "^4.0.0",
-						"ms": "^2.1.1",
-						"semver": "^5.6.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15607,31 +16041,39 @@
 			}
 		},
 		"@graphql-tools/url-loader": {
-			"version": "7.16.4",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.16.4.tgz",
-			"integrity": "sha512-7yGrJJNcqVQIplCyVLk7tW2mAgYyZ06FRmCBnzw3B61+aIjFavrm6YlnKkhdqYSYyFmIbVcigdP3vkoYIu23TA==",
+			"version": "7.17.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.17.1.tgz",
+			"integrity": "sha512-+WZXkg1ZG4fjAB+SkCHLSr7VFZqZAkA/PILcpoPqwAL/wSsrhCHYwbzuWuKn1SGToxJRt7cc+4P0lfR7fq+xhQ==",
 			"dev": true,
 			"requires": {
 				"@ardatan/sync-fetch": "0.0.1",
-				"@graphql-tools/delegate": "9.0.8",
-				"@graphql-tools/utils": "8.12.0",
-				"@graphql-tools/wrap": "9.2.3",
+				"@graphql-tools/delegate": "9.0.22",
+				"@graphql-tools/executor-graphql-ws": "0.0.6",
+				"@graphql-tools/executor-http": "0.1.0",
+				"@graphql-tools/executor-legacy-ws": "0.0.6",
+				"@graphql-tools/utils": "9.1.4",
+				"@graphql-tools/wrap": "9.3.0",
 				"@types/ws": "^8.0.0",
-				"@whatwg-node/fetch": "^0.4.0",
-				"dset": "^3.1.2",
-				"extract-files": "^11.0.0",
-				"graphql-ws": "^5.4.1",
-				"isomorphic-ws": "^5.0.0",
-				"meros": "^1.1.4",
+				"@whatwg-node/fetch": "^0.6.0",
+				"isomorphic-ws": "5.0.0",
 				"tslib": "^2.4.0",
 				"value-or-promise": "^1.0.11",
-				"ws": "^8.3.0"
+				"ws": "8.12.0"
 			},
 			"dependencies": {
+				"@graphql-tools/utils": {
+					"version": "9.1.4",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+					"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				},
 				"@whatwg-node/fetch": {
-					"version": "0.4.7",
-					"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.4.7.tgz",
-					"integrity": "sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==",
+					"version": "0.6.2",
+					"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.6.2.tgz",
+					"integrity": "sha512-fCUycF1W+bI6XzwJFnbdDuxIldfKM3w8+AzVCLGlucm0D+AQ8ZMm2j84hdcIhfV6ZdE4Y1HFVrHosAxdDZ+nPw==",
 					"dev": true,
 					"requires": {
 						"@peculiar/webcrypto": "^1.4.0",
@@ -15640,7 +16082,8 @@
 						"form-data-encoder": "^1.7.1",
 						"formdata-node": "^4.3.1",
 						"node-fetch": "^2.6.7",
-						"undici": "^5.10.0",
+						"undici": "^5.12.0",
+						"urlpattern-polyfill": "^6.0.2",
 						"web-streams-polyfill": "^3.2.0"
 					}
 				}
@@ -15656,16 +16099,55 @@
 			}
 		},
 		"@graphql-tools/wrap": {
-			"version": "9.2.3",
-			"resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.2.3.tgz",
-			"integrity": "sha512-aiLjcAuUwcvA1mF25c7KFDPXEdQDpo6bTDyAMCSlFXpF4T01hoxLERmfmbRmsmy/dP80ZB31a+t70aspVdqZSA==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.3.0.tgz",
+			"integrity": "sha512-QOEg04kzFJ1WrlA2t/qjw85C20qPDJwIU/d+bDgDd1+cjTQcVrEt9bq9NilZZg9m9AAgZbeyDwut0oQvNMCGhw==",
 			"dev": true,
 			"requires": {
-				"@graphql-tools/delegate": "9.0.8",
-				"@graphql-tools/schema": "9.0.4",
-				"@graphql-tools/utils": "8.12.0",
+				"@graphql-tools/delegate": "9.0.22",
+				"@graphql-tools/schema": "9.0.13",
+				"@graphql-tools/utils": "9.1.4",
 				"tslib": "^2.4.0",
-				"value-or-promise": "1.0.11"
+				"value-or-promise": "1.0.12"
+			},
+			"dependencies": {
+				"@graphql-tools/merge": {
+					"version": "8.3.15",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.15.tgz",
+					"integrity": "sha512-hYYOlsqkUlL6oOo7zzuk6hIv7xQzy+x21sgK84d5FWaiWYkLYh9As8myuDd9SD5xovWWQ9m/iRhIOVDEMSyEKA==",
+					"dev": true,
+					"requires": {
+						"@graphql-tools/utils": "9.1.4",
+						"tslib": "^2.4.0"
+					}
+				},
+				"@graphql-tools/schema": {
+					"version": "9.0.13",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.13.tgz",
+					"integrity": "sha512-guRA3fwAtv+M1Kh930P4ydH9aKJTWscIkhVFcWpj/cnjYYxj88jkEJ15ZNiJX/2breNY+sbVgmlgLKb6aXi/Jg==",
+					"dev": true,
+					"requires": {
+						"@graphql-tools/merge": "8.3.15",
+						"@graphql-tools/utils": "9.1.4",
+						"tslib": "^2.4.0",
+						"value-or-promise": "1.0.12"
+					}
+				},
+				"@graphql-tools/utils": {
+					"version": "9.1.4",
+					"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.1.4.tgz",
+					"integrity": "sha512-hgIeLt95h9nQgQuzbbdhuZmh+8WV7RZ/6GbTj6t3IU4Zd2zs9yYJ2jgW/krO587GMOY8zCwrjNOMzD40u3l7Vg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				},
+				"value-or-promise": {
+					"version": "1.0.12",
+					"resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+					"integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+					"dev": true
+				}
 			}
 		},
 		"@graphql-typed-document-node/core": {
@@ -15887,6 +16369,12 @@
 			"version": "1.0.0-next.21",
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
 			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
+			"dev": true
+		},
+		"@repeaterjs/repeater": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
+			"integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
 			"dev": true
 		},
 		"@rollup/plugin-commonjs": {
@@ -20480,40 +20968,10 @@
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
 		},
-		"lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-			"dev": true
-		},
-		"lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-			"dev": true
-		},
-		"lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"dev": true
-		},
-		"lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-			"dev": true
-		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
-		"lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
 			"dev": true
 		},
 		"lodash.memoize": {
@@ -20526,12 +20984,6 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"dev": true
 		},
 		"lodash.uniq": {
@@ -23176,9 +23628,9 @@
 			"dev": true
 		},
 		"undici": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.11.0.tgz",
-			"integrity": "sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.15.0.tgz",
+			"integrity": "sha512-wCAZJDyjw9Myv+Ay62LAoB+hZLPW9SmKbQkbHIhMw/acKSlpn7WohdMUc/Vd4j1iSMBO0hWwU8mjB7a5p5bl8g==",
 			"dev": true,
 			"requires": {
 				"busboy": "^1.6.0"
@@ -23286,6 +23738,15 @@
 			"requires": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
+			}
+		},
+		"urlpattern-polyfill": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-6.0.2.tgz",
+			"integrity": "sha512-5vZjFlH9ofROmuWmXM9yj2wljYKgWstGwe8YTyiqM7hVum/g9LyCizPZtb3UqsuppVwety9QJmfc42VggLpTgg==",
+			"dev": true,
+			"requires": {
+				"braces": "^3.0.2"
 			}
 		},
 		"util-deprecate": {
@@ -23595,9 +24056,9 @@
 			"dev": true
 		},
 		"ws": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-			"integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+			"integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
 			"dev": true,
 			"requires": {}
 		},

--- a/app/setupTest.ts
+++ b/app/setupTest.ts
@@ -1,13 +1,15 @@
 // setupTest.ts
 /* eslint-disable @typescript-eslint/no-empty-function */
 import 'isomorphic-fetch';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/extend-expect';
 import matchers from '@testing-library/jest-dom/matchers';
 import { expect, vi } from 'vitest';
 import type { Navigation, Page } from '@sveltejs/kit';
 import { readable } from 'svelte/store';
-import * as environment from '$app/environment';
-import * as navigation from '$app/navigation';
-import * as stores from '$app/stores';
+import type * as environment from '$app/environment';
+import type * as navigation from '$app/navigation';
+import type * as stores from '$app/stores';
 
 // Add custom jest matchers
 expect.extend(matchers);
@@ -15,7 +17,6 @@ expect.extend(matchers);
 // Mock SvelteKit runtime module $app/environment
 vi.mock('$app/environment', (): typeof environment => ({
 	browser: false,
-	silent: false,
 	dev: true,
 	prerendering: false,
 }));

--- a/app/src/lib/ui/ProNotebookMember/ProNotebookMembersView.svelte
+++ b/app/src/lib/ui/ProNotebookMember/ProNotebookMembersView.svelte
@@ -72,6 +72,10 @@
 
 		return proAppointment ? formatDateTimeLocale(proAppointment.date) : '';
 	}
+
+	$: showRemoveButton =
+		members?.find((member: Member) => member.memberType === 'referent')?.account.id !==
+		$accountData.id;
 </script>
 
 {#if displayMemberManagementButtons}
@@ -81,18 +85,20 @@
 				openInviteMember();
 			}}>Inviter un accompagnateur</Button
 		>
-		<Dialog
-			buttonFullWidth={true}
-			outlineButton={false}
-			title="Se détacher"
-			label="Se détacher"
-			confirmLabel="Oui"
-			on:confirm={() => removeMember()}
-		>
-			<p>
-				Souhaitez-vous être détaché du carnet de bord et ne plus accéder en écriture à celui-ci ?
-			</p>
-		</Dialog>
+		{#if showRemoveButton}
+			<Dialog
+				buttonFullWidth={true}
+				outlineButton={false}
+				title="Se détacher"
+				label="Se détacher"
+				confirmLabel="Oui"
+				on:confirm={() => removeMember()}
+			>
+				<p>
+					Souhaitez-vous être détaché du carnet de bord et ne plus accéder en écriture à celui-ci ?
+				</p>
+			</Dialog>
+		{/if}
 	</div>
 {/if}
 <div class="fr-table fr-table--layout-fixed !mb-0">

--- a/app/src/lib/ui/ProNotebookMember/ProNotebookMembersView.test.ts
+++ b/app/src/lib/ui/ProNotebookMember/ProNotebookMembersView.test.ts
@@ -106,8 +106,8 @@ test('do not show remove button for referent', () => {
 			members: notebookMembers,
 		},
 	});
-	expect(screen.getByText('Inviter un accompagnateur')).toBeDefined();
-	expect(screen.queryByText('Se détacher')).toBe(null);
+	expect(screen.getByText('Inviter un accompagnateur')).toBeInTheDocument();
+	expect(screen.queryByText('Se détacher')).not.toBeInTheDocument();
 });
 
 test('show remove button for no referent', () => {
@@ -123,6 +123,6 @@ test('show remove button for no referent', () => {
 			members: notebookMembers,
 		},
 	});
-	expect(screen.getByText('Inviter un accompagnateur')).toBeDefined();
-	expect(screen.getByText('Se détacher')).toBeDefined();
+	expect(screen.getByText('Inviter un accompagnateur')).toBeInTheDocument();
+	expect(screen.getByText('Se détacher')).toBeInTheDocument();
 });

--- a/app/src/lib/ui/ProNotebookMember/ProNotebookMembersView.test.ts
+++ b/app/src/lib/ui/ProNotebookMember/ProNotebookMembersView.test.ts
@@ -1,0 +1,128 @@
+import { test } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ProNotebookMembersView from './ProNotebookMembersView.svelte';
+import { accountData } from '$lib/stores';
+import { RoleEnum } from '$lib/graphql/_gen/typed-document-nodes';
+
+const pierreChevalierAccount = {
+	id: 'acc1',
+	type: RoleEnum.Professional,
+	confirmed: true,
+	username: 'pierre.chevalier',
+	professional: {
+		id: 'p1',
+		firstname: 'Pierre',
+		lastname: 'Chevalier',
+		email: 'pierre.chevalier@livry-gargan.fr',
+		structure: {
+			id: 's1',
+			name: 'Centre communal Livry gargan',
+		},
+	},
+};
+
+const sankaAccount = {
+	id: 'acc2',
+	type: RoleEnum.Professional,
+	confirmed: true,
+	username: 'sanka',
+	professional: {
+		id: 'p2',
+		firstname: 'Simon',
+		lastname: 'Anka',
+		email: 'sanka@groupe-ns',
+		structure: {
+			id: 's2',
+			name: 'Groupe NS',
+		},
+	},
+};
+
+const notebookMembers = [
+	{
+		id: '1',
+		memberType: 'referent',
+		createdAt: '2020-01-01',
+		account: {
+			id: 'acc1',
+			type: RoleEnum.Professional,
+			professional: {
+				id: 'p1',
+				firstname: 'pierre',
+				lastname: 'chevalier',
+				email: 'pierre.chevalier@livry-gargan.fr',
+				structure: {
+					id: 's1',
+					name: 's1',
+				},
+			},
+		},
+	},
+	{
+		id: '2',
+		memberType: 'no-referent',
+		createdAt: '2020-01-01',
+		account: {
+			id: 'acc2',
+			type: RoleEnum.Professional,
+			professional: {
+				id: 'p2',
+				firstname: 'simon',
+				lastname: 'anka',
+				email: 'sanka@groupe-ns.fr',
+				structure: {
+					id: 's2',
+					name: 's2',
+				},
+			},
+		},
+	},
+	{
+		id: '3',
+		memberType: 'orientation_manager',
+		createdAt: '2020-01-01',
+		account: {
+			id: 'acc3',
+			type: RoleEnum.OrientationManager,
+			orientation_manager: {
+				id: 'om1',
+				firstname: 'giulia',
+				lastname: 'diaby',
+				email: 'giulia.diaby@cd93.fr',
+			},
+		},
+	},
+];
+test('do not show remove button for referent', () => {
+	accountData.set(pierreChevalierAccount);
+
+	render(ProNotebookMembersView, {
+		props: {
+			notebookId: 'id',
+			beneficiaryFirstname: 'leon',
+			beneficiaryLastname: 'leon',
+			appointments: [],
+			displayMemberManagementButtons: true,
+			members: notebookMembers,
+		},
+	});
+	expect(screen.getByText('Inviter un accompagnateur')).toBeDefined();
+	expect(screen.queryByText('Se détacher')).toBe(null);
+});
+
+test('show remove button for no referent', () => {
+	accountData.set(sankaAccount);
+
+	render(ProNotebookMembersView, {
+		props: {
+			notebookId: 'id',
+			beneficiaryFirstname: 'leon',
+			beneficiaryLastname: 'leon',
+			appointments: [],
+			displayMemberManagementButtons: true,
+			members: notebookMembers,
+		},
+	});
+	expect(screen.getByText('Inviter un accompagnateur')).toBeDefined();
+	expect(screen.getByText('Se détacher')).toBeDefined();
+});

--- a/app/src/routes/actions/matomo_dashboard/+server.ts
+++ b/app/src/routes/actions/matomo_dashboard/+server.ts
@@ -43,8 +43,7 @@ export const POST: RequestHandler = async ({ request }) => {
 	try {
 		actionsGuard(request.headers);
 	} catch (e) {
-		console.error(e);
-		return new Response('matomo_dashboard: unauthorized action', { status: 401 });
+		logAndThrow(e, 401, 'matomo_dashboard: unauthorized action');
 	}
 
 	const deploymentResult = await client.query(ListDeploymentIdDocument).toPromise();

--- a/app/src/routes/actions/matomo_dashboard/_matomo_dashboard.test.ts
+++ b/app/src/routes/actions/matomo_dashboard/_matomo_dashboard.test.ts
@@ -48,9 +48,18 @@ Matomo.track = vi.fn();
 
 describe('matomo_dashboard', () => {
 	test('should return 401 if action does not have secret token', async () => {
-		const response = await request(POST);
-		expect(String(response.body)).toEqual('matomo_dashboard: unauthorized action');
-		expect(response.status).toEqual(401);
+		try {
+			await request(POST);
+		} catch (error) {
+			expect(error).toMatchInlineSnapshot(`
+				HttpError {
+				  "body": {
+				    "message": "matomo_dashboard: unauthorized action",
+				  },
+				  "status": 401,
+				}
+			`);
+		}
 	});
 	test('should return 200', async () => {
 		const response = await request(POST, {

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -10,7 +10,9 @@
 		"sourceMap": true,
 		"target": "ES2019",
 		"preserveValueImports": false,
-		"types": ["vitest/globals"]
+		"types": [
+			"vitest/globals"
+		]
 	},
 	"include": [
 		".svelte-kit/ambient.d.ts",
@@ -25,6 +27,7 @@
 		"__tests__/**/*.js",
 		"__tests__/**/*.ts",
 		"__tests__/**/*.svelte",
-		"elm/**/*.d.ts"
+		"elm/**/*.d.ts",
+		"./setupTest.ts"
 	]
 }

--- a/app/tsconfig.test.json
+++ b/app/tsconfig.test.json
@@ -9,5 +9,21 @@
 		"sourceMap": true,
 		"target": "ES2019",
 		"preserveValueImports": false
-	}
+	},
+	"include": [
+		".svelte-kit/ambient.d.ts",
+		".svelte-kit/types/**/$types.d.ts",
+		"vite.config.ts",
+		"src/**/*.js",
+		"src/**/*.ts",
+		"src/**/*.svelte",
+		"src/**/*.js",
+		"src/**/*.ts",
+		"src/**/*.svelte",
+		"__tests__/**/*.js",
+		"__tests__/**/*.ts",
+		"__tests__/**/*.svelte",
+		"elm/**/*.d.ts",
+		"./setupTest.ts"
+	]
 }

--- a/e2e/features/pro/carnet/members.feature
+++ b/e2e/features/pro/carnet/members.feature
@@ -21,7 +21,7 @@ Scénario: Inviter un membre dans le groupe de suivi
 	Alors je vois "Camara" dans le tableau "Liste des membres du groupe de suivi"
 
 Scénario: Se retirer du groupe de suivi et de la structure
-	Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Tifour"
+	Soit le pro "sanka@groupe-ns.fr" sur le carnet de "Tifour"
 	Quand j'attends que le tableau "Liste des membres du groupe de suivi" apparaisse
 	Quand je clique sur "Se détacher"
 	Alors je vois "Souhaitez-vous être détaché du carnet de bord et ne plus accéder en écriture à celui-ci ?"
@@ -29,9 +29,5 @@ Scénario: Se retirer du groupe de suivi et de la structure
 	Alors je vois "Sophie Tifour"
 	Alors je vois "Informations personnelles"
 	Alors je vois "Groupe de suivi"
-	Alors je ne vois pas "Pierre Chevalier"
+	Alors je ne vois pas "Simon Anka"
 	Alors je ne vois pas "Informations socioprofessionnelles"
-  Quand un "chargé d'orientation" authentifié avec l'email "giulia.diaby@cd93.fr"
-  Quand je clique sur "Bénéficiaires"
-	Quand je selectionne l'option "Orienté" dans la liste "Statut"
-	Alors je vois "Non rattaché" sur la ligne "Tifour"


### PR DESCRIPTION
## :wrench: Problème

Actuellement lorsqu'un référent se détache de lui même du groupe de suivi, alors la personne n'est plus suivi et l'information ne parvient pas au Chargé d'orientation ce qui génère une rupture de parcours et bloque la réorientation

## :cake: Solution

Pour éviter cela le détachement d'un pro "référent" doit se faire par une demande de réorientation. Il faut donc cacher le bouton se détacher pour les référents


## :rotating_light:  Points d'attention / Remarques

Mise en place d'un test unitaire pour le composant NotebookMembersView.
On profite de l'ajout du test pour supprimer quelque message de log dans la sortie standart.

## :desert_island: Comment tester
- Se connecter en tant que `pierre.chevalier` sur le carnet de sophie tifour et valider qu'on ne voit pas le bouton `Se détacher`
- Se connecter en tant que `sanka` sur le carnet de sophie tifour et valider qu'on voit bien le bouton `Se détacher`

fix #1424
<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1428.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->