### PR TITLE
chore: Ajout de la règle eslint `prefer-const`.

### DIFF
--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -14,9 +14,9 @@ module.exports = {
 	settings: {
 		'svelte3/typescript': () => require('typescript'), // pass the TypeScript package to the Svelte plugin
 	},
-	// Temporary hack, current codebase should be checked for this
 	rules: {
 		'no-unused-vars': 'off',
+		'@typescript-eslint/no-unused-vars': 'error',
 		'prefer-const': 'error',
 	},
 	globals: {

--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -17,6 +17,7 @@ module.exports = {
 	// Temporary hack, current codebase should be checked for this
 	rules: {
 		'no-unused-vars': 'off',
+		'prefer-const': 'error',
 	},
 	globals: {
 		__version__: 'readonly',

--- a/app/elm/BeneficiaryApp/Main.elm.d.ts
+++ b/app/elm/BeneficiaryApp/Main.elm.d.ts
@@ -1,4 +1,5 @@
 export namespace BeneficiaryApp.Main {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	function init(options: { node?: HTMLElement | null; flags: Flags }): ElmApp;
 }
 export interface ElmApp {

--- a/app/elm/MainApp/Main.elm.d.ts
+++ b/app/elm/MainApp/Main.elm.d.ts
@@ -1,4 +1,5 @@
 export namespace MainApp.Main {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	function init(options: { node?: HTMLElement | null; flags: Flags }): ElmApp;
 }
 export interface ElmApp {

--- a/app/elm/OrientationHome/Main.elm.d.ts
+++ b/app/elm/OrientationHome/Main.elm.d.ts
@@ -1,4 +1,5 @@
 export namespace OrientationHome.Main {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	function init(options: { node?: HTMLElement | null; flags: Flags }): ElmApp;
 }
 export interface ElmApp {

--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
 		"fix": "npm run fix:prettier && npm run fix:eslint",
 		"fix:prettier": "npm run lint:prettier -- --write",
 		"fix:prettier:all": "npm run lint:prettier:all -- --write",
-		"fix:eslint": "npm run lint:eslint --fix",
+		"fix:eslint": "npm run lint:eslint -- --fix",
 		"fix:eslint:all": "npm run lint:eslint:all -- --fix",
 		"format": "npm run fix:prettier",
 		"codegen": "graphql-codegen --config codegen.cjs",

--- a/app/src/global.d.ts
+++ b/app/src/global.d.ts
@@ -2,9 +2,9 @@
 
 // support for Crisp
 interface Window {
-	$crisp: any;
+	$crisp: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 	CRISP_WEBSITE_ID: string;
-	dsfr: any;
+	dsfr: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 // support for svelecte

--- a/app/src/lib/chat/Crisp.svelte
+++ b/app/src/lib/chat/Crisp.svelte
@@ -12,8 +12,8 @@
 		window.CRISP_WEBSITE_ID = websiteId;
 
 		(function () {
-			let d = document;
-			let s = d.createElement('script');
+			const d = document;
+			const s = d.createElement('script');
 			s.src = 'https://client.crisp.chat/l.js';
 			s.async = true;
 			d.getElementsByTagName('head')[0].appendChild(s);

--- a/app/src/lib/emailing/index.ts
+++ b/app/src/lib/emailing/index.ts
@@ -5,7 +5,7 @@ import type Mail from 'nodemailer/lib/mailer';
 import type { SentMessageInfo } from 'nodemailer/lib/smtp-transport';
 import type { SvelteComponent } from 'svelte/types/runtime';
 
-type Constructor<T> = new (...args: any[]) => T;
+type Constructor<T> = new (...args: any[]) => T; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 export default async function send({
 	options,
@@ -32,7 +32,7 @@ export async function createMail({
 }): Promise<string> {
 	const { Component, formattedParams } = await prepareEmail({ template, params });
 
-	return (Component as any).render(formattedParams).html;
+	return (Component as any).render(formattedParams).html; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export async function prepareEmail({

--- a/app/src/lib/stores/crispData.ts
+++ b/app/src/lib/stores/crispData.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
 import type { Writable } from 'svelte/store';
 
-type CrispData = any;
+type CrispData = any; // eslint-disable-line @typescript-eslint/no-explicit-any
 export const crispData: Writable<null | CrispData> = writable(null);

--- a/app/src/lib/ui/AdminStructure/AccountEdit.svelte
+++ b/app/src/lib/ui/AdminStructure/AccountEdit.svelte
@@ -7,9 +7,9 @@
 	import { Alert, Button } from '$lib/ui/base';
 	import type { AdminStructureAccountInput } from './adminStructure.schema';
 
-	let { id, email, firstname, lastname, phoneNumbers } = $accountData.admin_structure;
+	const { id, email, firstname, lastname, phoneNumbers } = $accountData.admin_structure;
 
-	let initialValues = {
+	const initialValues = {
 		email,
 		firstname,
 		lastname,

--- a/app/src/lib/ui/Beneficiary/NotebookMembers.svelte
+++ b/app/src/lib/ui/Beneficiary/NotebookMembers.svelte
@@ -11,6 +11,7 @@
 	import { trackEvent } from '$lib/tracking/matomo';
 	import { Radio } from '$lib/ui/base';
 	import { createEventDispatcher } from 'svelte';
+	import type { Option } from '$lib/types';
 
 	type Notebook = GetNotebookByBeneficiaryIdQuery['notebook'][0];
 	export let members: Notebook['members'];
@@ -18,7 +19,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	const options = [
+	const options: Option[] = [
 		{ name: 'referent', label: 'Oui' },
 		{ name: 'no_referent', label: 'Non' },
 	];
@@ -41,7 +42,7 @@
 		}
 	}
 
-	function setSelectedMemberType(selected: any) {
+	function setSelectedMemberType(selected: CustomEvent) {
 		memberType = selected.detail.value;
 	}
 </script>

--- a/app/src/lib/ui/BeneficiaryList/AddOrientationForm.svelte
+++ b/app/src/lib/ui/BeneficiaryList/AddOrientationForm.svelte
@@ -19,7 +19,7 @@
 
 	export let onClose: () => void;
 
-	let orientationTypeStore: OperationStore<GetOrientationTypeQuery> = operationStore(
+	const orientationTypeStore: OperationStore<GetOrientationTypeQuery> = operationStore(
 		GetOrientationTypeDocument
 	);
 	query(orientationTypeStore);

--- a/app/src/lib/ui/BeneficiaryList/AddOrientationManagerForm.svelte
+++ b/app/src/lib/ui/BeneficiaryList/AddOrientationManagerForm.svelte
@@ -19,7 +19,7 @@
 
 	export let onClose: () => void;
 
-	let orientationManagerStore: OperationStore<GetOrientationManagerQuery> = operationStore(
+	const orientationManagerStore: OperationStore<GetOrientationManagerQuery> = operationStore(
 		GetOrientationManagerDocument
 	);
 	query(orientationManagerStore);

--- a/app/src/lib/ui/BeneficiaryList/AddProfessionnalForm.svelte
+++ b/app/src/lib/ui/BeneficiaryList/AddProfessionnalForm.svelte
@@ -24,7 +24,7 @@
 	}[];
 	export let onBeneficiaryOrientationChanged: () => void;
 
-	let professionalStore: OperationStore<GetProfessionalsFromStructuresQuery> = operationStore(
+	const professionalStore: OperationStore<GetProfessionalsFromStructuresQuery> = operationStore(
 		GetProfessionalsFromStructuresDocument,
 		{ id: structureId }
 	);

--- a/app/src/lib/ui/BeneficiaryList/FilterOrientation.svelte
+++ b/app/src/lib/ui/BeneficiaryList/FilterOrientation.svelte
@@ -10,12 +10,12 @@
 
 	const dispatch = createEventDispatcher();
 
-	let orientationStatusfilterOptions: { label: string; name: OrientedFilter }[] = [
+	const orientationStatusfilterOptions: { label: string; name: OrientedFilter }[] = [
 		{ label: 'À orienter', name: 'non-oriente' },
 		{ label: 'Orienté', name: 'oriente' },
 	];
 
-	let beneficiaryFromfilterOptions: { label: string; name: BeneficiaryFilter }[] = [
+	const beneficiaryFromfilterOptions: { label: string; name: BeneficiaryFilter }[] = [
 		{ label: 'Bénéficiaires de mon portefeuille', name: 'mes-beneficiaires' },
 		{ label: 'Autres bénéficiaires du territoire', name: 'autres-beneficiaires' },
 	];

--- a/app/src/lib/ui/BeneficiaryList/Filters.svelte
+++ b/app/src/lib/ui/BeneficiaryList/Filters.svelte
@@ -28,7 +28,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	let filterOptions: { label: string; name: MemberFilter }[] = [
+	const filterOptions: { label: string; name: MemberFilter }[] = [
 		{ label: 'Tous', name: 'all' },
 		{ label: 'Suivi', name: 'withMember' },
 		{ label: 'Non suivi', name: 'noMember' },

--- a/app/src/lib/ui/Manager/AccountEdit.svelte
+++ b/app/src/lib/ui/Manager/AccountEdit.svelte
@@ -8,9 +8,9 @@
 	import type { ManagerAccountInput } from './manager.schema';
 	import { accountData } from '$lib/stores/account';
 
-	let { id, email, firstname, lastname } = $accountData.manager;
+	const { id, email, firstname, lastname } = $accountData.manager;
 
-	let initialValues = {
+	const initialValues = {
 		email,
 		firstname,
 		lastname,

--- a/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
+++ b/app/src/lib/ui/Manager/ImportBeneficiaries.svelte
@@ -23,13 +23,13 @@
 	import { translateError } from './errorMessage';
 	import { Spinner } from '$lib/ui/base';
 
-	let queryProfessionals: OperationStore<GetProfessionalsForManagerQuery> = operationStore(
+	const queryProfessionals: OperationStore<GetProfessionalsForManagerQuery> = operationStore(
 		GetProfessionalsForManagerDocument,
 		{}
 	);
 	query(queryProfessionals);
 
-	let queryStructures: OperationStore<GetStructuresForManagerQuery> = operationStore(
+	const queryStructures: OperationStore<GetStructuresForManagerQuery> = operationStore(
 		GetStructuresForManagerDocument,
 		{}
 	);

--- a/app/src/lib/ui/Manager/UpdateNotebookMembers.svelte
+++ b/app/src/lib/ui/Manager/UpdateNotebookMembers.svelte
@@ -82,7 +82,7 @@
 		return proDictEmailToProLight[email];
 	}
 
-	let insertSummary: Record<
+	const insertSummary: Record<
 		string,
 		{
 			beneficiary: BeneficiaryLight;
@@ -309,7 +309,7 @@
 				beneficiaryId: payload.beneficiaryId,
 				structureId: payload.structureId,
 			});
-			let errorMessage = "Une erreur s'est produite, le rattachement n'a pas été fait.";
+			const errorMessage = "Une erreur s'est produite, le rattachement n'a pas été fait.";
 			if (result.error) {
 				captureException(result.error);
 			}

--- a/app/src/lib/ui/OrientationManager/AccountEdit.svelte
+++ b/app/src/lib/ui/OrientationManager/AccountEdit.svelte
@@ -7,9 +7,9 @@
 	import { Alert, Button } from '$lib/ui/base';
 	import type { OrientationManagerAccountInput } from './orientationManager.schema';
 
-	let { id, email, firstname, lastname, phoneNumbers } = $accountData.orientation_manager;
+	const { id, email, firstname, lastname, phoneNumbers } = $accountData.orientation_manager;
 
-	let initialValues = {
+	const initialValues = {
 		email,
 		firstname,
 		lastname,

--- a/app/src/lib/ui/OrientationManager/OrientationForm.svelte
+++ b/app/src/lib/ui/OrientationManager/OrientationForm.svelte
@@ -34,7 +34,7 @@
 	export let structureId: string = null;
 	let selectedStructureId = structureId;
 
-	let orientationTypes: OperationStore<GetOrientationTypeQuery> = operationStore(
+	const orientationTypes: OperationStore<GetOrientationTypeQuery> = operationStore(
 		GetOrientationTypeDocument
 	);
 	query(orientationTypes);
@@ -45,7 +45,7 @@
 			label,
 		})) ?? [];
 
-	let structures: OperationStore<GetStructuresWithProQuery> = operationStore(
+	const structures: OperationStore<GetStructuresWithProQuery> = operationStore(
 		GetStructuresWithProDocument,
 		null,
 		{ requestPolicy: 'network-only' }

--- a/app/src/lib/ui/OrientationRequest/CreateOrientationRequestForm.svelte
+++ b/app/src/lib/ui/OrientationRequest/CreateOrientationRequestForm.svelte
@@ -17,7 +17,7 @@
 
 	const initialValues = {};
 
-	let orientationTypeStore: OperationStore<GetOrientationTypeQuery> = operationStore(
+	const orientationTypeStore: OperationStore<GetOrientationTypeQuery> = operationStore(
 		GetOrientationTypeDocument
 	);
 	query(orientationTypeStore);

--- a/app/src/lib/ui/ProAccount/ProAccountEdit.svelte
+++ b/app/src/lib/ui/ProAccount/ProAccountEdit.svelte
@@ -7,9 +7,9 @@
 	import { Alert, Button } from '$lib/ui/base';
 	import type { ProAccountWithStructureInput } from '$lib/ui/ProCreationForm/pro.schema';
 
-	let { id, email, firstname, lastname, position, mobileNumber } = $accountData.professional;
+	const { id, email, firstname, lastname, position, mobileNumber } = $accountData.professional;
 
-	let initialValues = {
+	const initialValues = {
 		email,
 		firstname,
 		lastname,

--- a/app/src/lib/ui/ProCreationForm/index.svelte
+++ b/app/src/lib/ui/ProCreationForm/index.svelte
@@ -18,7 +18,7 @@
 	export let onCancel: () => void = null;
 	export let hiddenFields: Partial<Record<keyof AccountRequest, boolean>> = {};
 
-	let result: OperationStore<GetStructuresQuery> = operationStore(GetStructuresDocument, {});
+	const result: OperationStore<GetStructuresQuery> = operationStore(GetStructuresDocument, {});
 	query(result);
 
 	$: options = $result?.data?.structure;

--- a/app/src/lib/ui/ProFormIdentifiers/ProFormIdentifierCAF.svelte
+++ b/app/src/lib/ui/ProFormIdentifiers/ProFormIdentifierCAF.svelte
@@ -26,7 +26,7 @@
 
 	let postalCode = '';
 	let idCAF = '';
-	let errors: { postalCode?: string; idCAF?: string } = {};
+	const errors: { postalCode?: string; idCAF?: string } = {};
 
 	export let users: RD.RemoteData<ExternalUser[], string> = RD.notAsked;
 </script>

--- a/app/src/lib/ui/ProFormIdentifiers/ProFormIdentifierPE.svelte
+++ b/app/src/lib/ui/ProFormIdentifiers/ProFormIdentifierPE.svelte
@@ -23,7 +23,7 @@
 	}
 
 	let idPE = '';
-	let errors: { idPE?: string } = {};
+	const errors: { idPE?: string } = {};
 
 	export let users: RD.RemoteData<ExternalUser[], string> = RD.notAsked;
 </script>

--- a/app/src/lib/ui/ProNotebookAction/ProNotebookActionCreate.svelte
+++ b/app/src/lib/ui/ProNotebookAction/ProNotebookActionCreate.svelte
@@ -27,10 +27,10 @@
 			return;
 		}
 
-		let themeActions = store.data.actions
+		const themeActions = store.data.actions
 			.filter((a) => a.theme === theme)
 			.sort((a1, a2) => a1.description.localeCompare(a2.description));
-		let otherActions = store.data.actions
+		const otherActions = store.data.actions
 			.filter((a) => a.theme !== theme)
 			.sort((a1, a2) => a1.description.localeCompare(a2.description));
 

--- a/app/src/lib/ui/ProNotebookContract/ProNotebookContractDetails.svelte
+++ b/app/src/lib/ui/ProNotebookContract/ProNotebookContractDetails.svelte
@@ -15,6 +15,7 @@
 		proNotebookContractSchema,
 	} from './ProNotebookContract.schema';
 	import { Form, Input, Radio } from '$lib/ui/forms';
+	import { captureException } from '$lib/utils/sentry';
 
 	export let notebook: GetNotebookQuery['notebook_public_view'][0]['notebook'];
 
@@ -55,6 +56,7 @@
 
 	function handleContractChange(
 		event: Event,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		updateValidateField: (filed: string, value: any) => void,
 		handleReset: () => void
 	) {
@@ -62,7 +64,22 @@
 		updateValidateField('contractType', target.value);
 		handleReset();
 	}
-	function setContractEndDate(initialDate, monthInterval: number) {
+
+	function setContractEndDate(initialDate: unknown, monthInterval: number) {
+		if (
+			typeof initialDate !== 'string' &&
+			typeof initialDate !== 'number' &&
+			!(initialDate instanceof Date)
+		) {
+			captureException(
+				new Error(
+					`[setContractEndDate] Une date était attendue mais la sélection reçue est ${JSON.stringify(
+						initialDate
+					)}.`
+				)
+			);
+			return initialDate;
+		}
 		if (monthInterval) {
 			return formatDateISO(add(new Date(initialDate), { months: monthInterval }));
 		}

--- a/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusCreate.svelte
+++ b/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusCreate.svelte
@@ -35,7 +35,7 @@
 
 	const formData = initFormData();
 
-	let disabled = !formData.theme && !formData.linkedTo && formData.situations?.length > 0;
+	const disabled = !formData.theme && !formData.linkedTo && formData.situations?.length > 0;
 
 	async function createFocus() {
 		trackEvent('pro', 'notebook', `add focus ${formData.theme}`);

--- a/app/src/lib/ui/ProNotebookMember/ProAppointment.svelte
+++ b/app/src/lib/ui/ProNotebookMember/ProAppointment.svelte
@@ -70,7 +70,7 @@
 				appointments.map((appointment) => {
 					appointment.status = appointment.status.toLowerCase();
 					appointment.fullDate = appointment.date;
-					let d = parseISO(appointment.date);
+					const d = parseISO(appointment.date);
 					appointment.date = appointment.date.split('T')[0];
 					appointment.hours = d.getHours().toString();
 					appointment.minutes = d.getMinutes().toString();

--- a/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
@@ -72,7 +72,7 @@
 			workSituation,
 		} = values;
 
-		let payload = {
+		const payload = {
 			id: notebook.id,
 			educationLevel,
 			geographicalArea,

--- a/app/src/lib/ui/ProfessionalList/Filters.svelte
+++ b/app/src/lib/ui/ProfessionalList/Filters.svelte
@@ -21,7 +21,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	let filterOptions: { label: string; name: BeneficiaryCountFilter }[] = [
+	const filterOptions: { label: string; name: BeneficiaryCountFilter }[] = [
 		{ label: 'Tous', name: 'all' },
 		{ label: 'Avec', name: 'withBeneficiaries' },
 		{ label: 'Sans', name: 'noBeneficiaries' },

--- a/app/src/lib/ui/StructureList/StructureList.svelte
+++ b/app/src/lib/ui/StructureList/StructureList.svelte
@@ -6,7 +6,7 @@
 
 	type Structure = GetStructuresForDeploymentQuery['structure'][0];
 
-	let dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
 	export let structures: Structure[];
 

--- a/app/src/lib/ui/base/Accordion.svelte
+++ b/app/src/lib/ui/base/Accordion.svelte
@@ -4,7 +4,7 @@
 
 	export let title: string;
 	let ref = null;
-	let internalItemKey = {}; // used for identify accordion
+	const internalItemKey = {}; // used for identify accordion
 	const accordionId = `accordion-${$accordionCounter++}`;
 	const { registerAccordionItem, selectedItem } = getContext<AccordionContext>(ACCORDION);
 	registerAccordionItem(internalItemKey);

--- a/app/src/lib/ui/base/Accordions.svelte
+++ b/app/src/lib/ui/base/Accordions.svelte
@@ -4,8 +4,8 @@
 	import type { Writable } from 'svelte/store';
 	import { ACCORDION, type AccordionContext } from './accordion';
 
-	let accordionItems: Writable<Record<never, never>[]> = writable([]);
-	let selectedItem: Writable<Record<never, never>> = writable(null);
+	const accordionItems: Writable<Record<never, never>[]> = writable([]);
+	const selectedItem: Writable<Record<never, never>> = writable(null);
 
 	setContext<AccordionContext>(ACCORDION, {
 		registerAccordionItem: (accordion: Record<never, never>): void => {

--- a/app/src/lib/ui/base/Autocomplete.svelte
+++ b/app/src/lib/ui/base/Autocomplete.svelte
@@ -11,7 +11,7 @@
 	import { createEventDispatcher } from 'svelte';
 
 	counter++;
-	let uniqueId = `select-input-${counter}`;
+	const uniqueId = `select-input-${counter}`;
 	export let id = uniqueId;
 
 	export let label = 'Selectionner un élément';
@@ -42,10 +42,10 @@
 
 	let timeout = null;
 
-	let dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
 	$: internalOptions = options.map((o, i): Suggestion => {
-		let selected = !multiple
+		const selected = !multiple
 			? o.value === selectedItem?.value
 			: selectedItems?.findIndex((item) => item.value === o.value) !== -1;
 
@@ -112,7 +112,7 @@
 	function toggleSelection(suggestionIndex: number, close = true) {
 		if (multiple) {
 			selectedItems = internalOptions.flatMap((o) => {
-				let { value, label } = o;
+				const { value, label } = o;
 				if (o.index === suggestionIndex) {
 					if (o.selected) {
 						return [];
@@ -122,7 +122,7 @@
 				return o.selected ? { label, value } : [];
 			});
 		} else {
-			let { label, value } = internalOptions.find((o) => o.index === suggestionIndex);
+			const { label, value } = internalOptions.find((o) => o.index === suggestionIndex);
 			selectedItem = { label, value };
 		}
 		if (close && open) {

--- a/app/src/lib/ui/base/Button.svelte
+++ b/app/src/lib/ui/base/Button.svelte
@@ -23,7 +23,7 @@
 	export let icon: string | null = '';
 	export let title: string | null = '';
 	export let iconSide: 'left' | 'right' = 'left';
-	let iconSideClass = icon ? `fr-btn--icon-${iconSide}` : '';
+	const iconSideClass = icon ? `fr-btn--icon-${iconSide}` : '';
 </script>
 
 <button

--- a/app/src/lib/ui/base/Footer.svelte
+++ b/app/src/lib/ui/base/Footer.svelte
@@ -42,6 +42,7 @@
 						class="fr-footer__bottom-link"
 						href="https://github.com/gip-inclusion/carnet-de-bord/blob/master/CHANGELOG.md"
 						target="_blank"
+						rel="noreferrer"
 					>
 						Version {appVersion}
 					</a>
@@ -71,7 +72,8 @@
 				<p>
 					Sauf mention contraire, tous les textes de ce site sont sous <a
 						href="https://github.com/etalab/licence-ouverte/blob/master/LO.md"
-						target="_blank">licence etalab-2.0</a
+						target="_blank"
+						rel="noreferrer">licence etalab-2.0</a
 					>
 				</p>
 			</div>

--- a/app/src/lib/ui/base/Link.svelte
+++ b/app/src/lib/ui/base/Link.svelte
@@ -12,7 +12,7 @@
 		goto(href);
 	}
 
-	let ariaCurrent = 'page' as const;
+	const ariaCurrent = 'page' as const;
 	$: additionalProps = isCurrent ? { 'aria-current': ariaCurrent } : {};
 </script>
 

--- a/app/src/lib/ui/base/MenuButton.svelte
+++ b/app/src/lib/ui/base/MenuButton.svelte
@@ -10,12 +10,12 @@
 	export let ref = null;
 	export let icon: string;
 	export let label: string;
-	let menuId = `menu-${counter++}`;
-	let buttonId = `button-${menuId}`;
+	const menuId = `menu-${counter++}`;
+	const buttonId = `button-${menuId}`;
 	let isOpened = false;
 
-	let selectedItem: Writable<Record<never, never>> = writable(null);
-	let focusedItem: Writable<Record<never, never>> = writable(null);
+	const selectedItem: Writable<Record<never, never>> = writable(null);
+	const focusedItem: Writable<Record<never, never>> = writable(null);
 
 	let menuItems: Record<never, never>[] = [];
 

--- a/app/src/lib/ui/base/MenuListItem.svelte
+++ b/app/src/lib/ui/base/MenuListItem.svelte
@@ -6,7 +6,7 @@
 	export let disabled = false;
 	export let href: string = null;
 
-	let internalItemKey = {};
+	const internalItemKey = {};
 
 	let item: HTMLButtonElement | HTMLAnchorElement;
 	export function focus(): void {

--- a/app/src/lib/ui/base/SearchBar.svelte
+++ b/app/src/lib/ui/base/SearchBar.svelte
@@ -4,7 +4,7 @@
 
 <script lang="ts">
 	counter++;
-	let uniqueId = `search-bar-input-${counter}`;
+	const uniqueId = `search-bar-input-${counter}`;
 	export let id: string | null = `search-bar-${counter}`;
 	export let size: string | null = 'lg';
 	export let btnLabel: string | null = '';

--- a/app/src/lib/ui/base/Select.svelte
+++ b/app/src/lib/ui/base/Select.svelte
@@ -10,7 +10,7 @@
 	import { createEventDispatcher } from 'svelte';
 
 	counter++;
-	let uniqueId = `select-input-${counter}`;
+	const uniqueId = `select-input-${counter}`;
 	export let name = uniqueId;
 	export let id: string | null = uniqueId;
 	export let selectHint: string | null = '';

--- a/app/src/lib/ui/forms/SvelecteSFL.svelte
+++ b/app/src/lib/ui/forms/SvelecteSFL.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-	let counter = 0;
+	const counter = 0;
 </script>
 
 <script lang="ts">

--- a/app/src/routes/(auth)/+layout.svelte
+++ b/app/src/routes/(auth)/+layout.svelte
@@ -7,7 +7,7 @@
 	import { accountData } from '$lib/stores';
 
 	export let data: LayoutData;
-	$accountData = data.account;
+	accountData.set(data.account);
 
 	onMount(() => {
 		Matomo.setCustomDimension(Matomo.CustomDimensions.Role, data.user.role);

--- a/app/src/routes/(auth)/manager/beneficiaires/+page.svelte
+++ b/app/src/routes/(auth)/manager/beneficiaires/+page.svelte
@@ -12,7 +12,7 @@
 
 	export let data: PageData;
 
-	let breadcrumbs = [
+	const breadcrumbs = [
 		{
 			name: 'accueil',
 			path: homeForRole(RoleEnum.Manager),

--- a/app/src/routes/(auth)/manager/bienvenue/+page.svelte
+++ b/app/src/routes/(auth)/manager/bienvenue/+page.svelte
@@ -18,9 +18,9 @@
 
 	let error: string;
 
-	let { id, email, firstname, lastname } = $accountData.manager;
+	const { id, email, firstname, lastname } = $accountData.manager;
 
-	let initialValues = {
+	const initialValues = {
 		email,
 		firstname,
 		lastname,

--- a/app/src/routes/(auth)/manager/professionnels/+page.svelte
+++ b/app/src/routes/(auth)/manager/professionnels/+page.svelte
@@ -31,7 +31,7 @@
 		$proStore.reexecute({ requestPolicy: 'network-only' });
 	}
 
-	let emails: Record<string, undefined | 'ToConfirm' | 'Sending' | 'Failed' | 'Sent'> = {};
+	const emails: Record<string, undefined | 'ToConfirm' | 'Sending' | 'Failed' | 'Sent'> = {};
 
 	type AccountSummary = Pick<Professional, 'id' | 'email' | 'firstname' | 'lastname'> & {
 		type: RoleEnum;

--- a/app/src/routes/(auth)/orientation/beneficiaires/+page.svelte
+++ b/app/src/routes/(auth)/orientation/beneficiaires/+page.svelte
@@ -13,7 +13,7 @@
 
 	export let data: PageData;
 
-	let breadcrumbs = [
+	const breadcrumbs = [
 		{
 			name: 'accueil',
 			path: homeForRole(RoleEnum.Manager),

--- a/app/src/routes/(auth)/orientation/bienvenue/+page.svelte
+++ b/app/src/routes/(auth)/orientation/bienvenue/+page.svelte
@@ -17,9 +17,9 @@
 
 	let error: string;
 
-	let { id, email, firstname, lastname, phoneNumbers } = $accountData.orientation_manager;
+	const { id, email, firstname, lastname, phoneNumbers } = $accountData.orientation_manager;
 
-	let initialValues = {
+	const initialValues = {
 		email,
 		firstname,
 		lastname,

--- a/app/src/routes/(auth)/orientation/demandes/+page.svelte
+++ b/app/src/routes/(auth)/orientation/demandes/+page.svelte
@@ -11,7 +11,7 @@
 	import { LoaderIndicator, Text } from '$lib/ui/utils';
 	import Dialog from '$lib/ui/Dialog.svelte';
 
-	let breadcrumbs = [
+	const breadcrumbs = [
 		{
 			name: 'accueil',
 			path: homeForRole(RoleEnum.OrientationManager),

--- a/app/src/routes/(auth)/pro/annuaire/+page.svelte
+++ b/app/src/routes/(auth)/pro/annuaire/+page.svelte
@@ -11,7 +11,7 @@
 
 	export let data: PageData;
 
-	let searching = false;
+	const searching = false;
 	let { search } = data;
 
 	const queryVariables = buildQueryVariables({

--- a/app/src/routes/(auth)/pro/bienvenue/+page.svelte
+++ b/app/src/routes/(auth)/pro/bienvenue/+page.svelte
@@ -17,9 +17,9 @@
 
 	let error: string;
 
-	let { id, email, firstname, lastname, mobileNumber, position } = $accountData.professional;
+	const { id, email, firstname, lastname, mobileNumber, position } = $accountData.professional;
 
-	let initialValues = {
+	const initialValues = {
 		email,
 		firstname,
 		lastname,

--- a/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
@@ -57,7 +57,9 @@
 		status: string,
 		statusValues: { label: string; name: string }[]
 	): string {
-		let status_string: { label: string; name: string } = statusValues.find((v) => v.name == status);
+		const status_string: { label: string; name: string } = statusValues.find(
+			(v) => v.name == status
+		);
 
 		return status_string ? status_string.label : 'Inconnu';
 	}
@@ -110,7 +112,7 @@
 	export let data: PageData;
 
 	const updateVisitDateStore = operationStore(UpdateNotebookVisitDateDocument);
-	let getNotebookEvents: GetNotebookEventsQueryStore = operationStore(
+	const getNotebookEvents: GetNotebookEventsQueryStore = operationStore(
 		GetNotebookEventsDocument,
 		{ notebookId: data.notebookId },
 		{ pause: true }

--- a/app/src/routes/(auth)/structures/bienvenue/+page.svelte
+++ b/app/src/routes/(auth)/structures/bienvenue/+page.svelte
@@ -17,9 +17,9 @@
 
 	let error: string;
 
-	let { id, email, firstname, lastname, phoneNumbers } = $accountData.admin_structure;
+	const { id, email, firstname, lastname, phoneNumbers } = $accountData.admin_structure;
 
-	let initialValues = {
+	const initialValues = {
 		email,
 		firstname,
 		lastname,

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -16,7 +16,7 @@
 	import * as yup from 'yup';
 	import * as yupFrLocale from '$lib/utils/yupFrLocale';
 	import createClient from '$lib/graphql/createClient';
-	import { setClient } from '@urql/svelte';
+	import { Client, setClient } from '@urql/svelte';
 	import LayerCdb from '$lib/ui/LayerCDB.svelte';
 	import { getMatomoUrl, getMatomoSiteId } from '$lib/config/variables/public';
 
@@ -29,7 +29,7 @@
 	backendAPI.set(data.backendAPI);
 	graphqlAPI.set(data.graphqlAPI);
 
-	let client;
+	let client: Client;
 
 	$: {
 		client = createClient(fetch, data.graphqlAPI, data.token);

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -26,8 +26,8 @@
 
 	export let data: PageData;
 
-	$backendAPI = data.backendAPI;
-	$graphqlAPI = data.graphqlAPI;
+	backendAPI.set(data.backendAPI);
+	graphqlAPI.set(data.graphqlAPI);
 
 	let client;
 
@@ -62,7 +62,7 @@
 
 		Matomo.load(getMatomoUrl(), getMatomoSiteId());
 	});
-	let unsubscribe = page.subscribe(({ url }) => {
+	const unsubscribe = page.subscribe(({ url }) => {
 		if (!browser || !url.pathname || !getMatomoUrl() || !getMatomoSiteId()) {
 			return;
 		}


### PR DESCRIPTION
## :wrench: Problème

Dans le code typescript on a beaucoup d'usages de `let` alors que les variables ne sont pas réaffectées.
Dans ce cas, `const` est suffisant permet une meilleure lecture (à la déclaration, on sait que la variable ne changera pas).

## :cake: Solution

On ajoute la règle eslint `prefer-const` avec le niveau `error`.


## :rotating_light:  Points d'attention / Remarques

Au passage, on en profite pour corriger d'autres warnings de linter.

## :desert_island: Comment tester

Dans le répertoire `app`, lancer la commande `npm run lint:eslint:all` et vérifier qu'aucune erreur ni warning ne sont présents.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->


<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
