### PR TITLE
fix: mise à jour de la liste des axes de travail

### DIFF
--- a/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
@@ -119,7 +119,14 @@
 	const getNotebook = operationStore(
 		GetNotebookDocument,
 		buildQueryVariables(variables, selected),
-		{ additionalTypenames: ['notebook_action', 'notebook_appointment', 'orientation_request'] }
+		{
+			additionalTypenames: [
+				'notebook_focus',
+				'notebook_action',
+				'notebook_appointment',
+				'orientation_request',
+			],
+		}
 	);
 
 	query(getNotebook);

--- a/e2e/features/pro/carnet/focuses.feature
+++ b/e2e/features/pro/carnet/focuses.feature
@@ -9,3 +9,15 @@ Scénario: Visibilité du nombre d'actions en cours pour chaque axe de travail
 	Alors je vois "1 action" dans la tuile "Difficultés administratives"
 	Alors je vois "4 actions" dans la tuile "Emploi"
 	Alors je vois "2 actions" dans la tuile "Logement"
+
+Scénario: Ajout d'un axe de travail par un pro
+	Soit le pro "sanka@groupe-ns.fr" sur le carnet de "Gallegos"
+	Quand je clique sur "Ajouter un axe de travail"
+	Alors j'attends que le texte "Axe de travail" apparaisse
+	Quand je choisis "Aucun"
+	Quand je selectionne l'option "Numérique" dans la liste "Thème"
+	Quand je choisis "Absence d'équipement ou de connexion"
+	Quand je choisis "Absence d'adresse de messagerie"
+	Quand je clique sur "Valider"
+	Quand je clique sur "J'ai compris"
+	Alors je vois "Aucune action" dans la tuile "Numérique"


### PR DESCRIPTION
## :wrench: Problème

Lorsque je me connecte en tant que pro (pierre.chevalier) et que je vais sur un carnet sur lequel je suis rattaché. 
Lorsque je crée le premier axe de travail, celui ci ne s'affiche pas (l'affichage n'est pas rechargé).
Cela est du à la manière dont fonctionne urql (la librairie utilisée pour les requete gql) 
ref: https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas

## :cake: Solution

On rajoute `notebook_focus`  dans la liste des `additionnalTypenames`

## :rotating_light:  Points d'attention / Remarques

 

## :desert_island: Comment tester

- Je me connecte en tant que pierre.chevalier
- Je recherche le carnet de kline
- Je clique sur "Se rattacher"
- Je clique sur "Rajouter un axe de travail"
- Je choisis"Numérique"
- Je valide
-  Je vois le nouvel axe de travail


<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1431.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

fix #1430