### PR TITLE
fix: Afficher correctement l'erreur lors de la création d'un compte.

### DIFF
--- a/app/src/lib/ui/AdminStructure/ImportProfessionals.svelte
+++ b/app/src/lib/ui/AdminStructure/ImportProfessionals.svelte
@@ -38,24 +38,24 @@
 	}
 
 	let insertInProgress = false;
-	let insertResult: { pro_: ProAccountInput; error: string | null }[];
+	let insertResults: { pro: ProAccountInput; error: string | null }[];
 
 	async function handleSubmit() {
 		insertInProgress = true;
-		insertResult = [];
-		for (const pro of prosToImport) {
-			const { uid, valid, ...pro_ } = pro;
+		insertResults = [];
+		for (const proToImport of prosToImport) {
+			const { uid, valid, ...pro } = proToImport;
 			let error: string;
 			try {
 				await post('/inscription/request', {
-					accountRequest: pro_,
+					accountRequest: pro,
 					structureId,
 					autoConfirm: true,
 				});
 			} catch (e) {
 				error = e.message;
 			}
-			insertResult = [...insertResult, { pro_, error }];
+			insertResults = [...insertResults, { pro, error }];
 		}
 		insertInProgress = false;
 	}
@@ -73,11 +73,11 @@
 		parseErrors = [];
 	}
 
-	$: successfulImports = (insertResult || []).filter(({ error }) => !error).length;
+	$: successfulImports = (insertResults || []).filter(({ error }) => !error).length;
 </script>
 
 <div class="flex flex-col gap-6">
-	{#if insertResult === undefined}
+	{#if insertResults === undefined}
 		{#if pros.length > 0}
 			<p>
 				Vous allez importer les professionnels suivants. Veuillez vérifier que les données sont
@@ -185,7 +185,7 @@
 					${pluralize('demandé', uidToImport.length)}`}
 				/>
 			{/if}
-			{#key insertResult}
+			{#key insertResults}
 				<div class="border-b border-gray-200 shadow">
 					<table class="w-full divide-y divide-gray-300">
 						<thead class="px-2 py-2">
@@ -194,22 +194,22 @@
 							<th>Nom</th>
 						</thead>
 						<tbody class="bg-white divide-y divide-gray-300">
-							{#each insertResult as pro}
+							{#each insertResults as insertResult}
 								<tr>
 									<td class="px-2 py-2 ">
-										<Text value={pro.pro_.email} />
+										<Text value={insertResult.pro.email} />
 									</td>
 									<td class="px-2 py-2 ">
-										<Text value={pro.pro_.firstname} />
+										<Text value={insertResult.pro.firstname} />
 									</td>
 									<td class="px-2 py-2 ">
-										<Text value={pro.pro_.lastname} />
+										<Text value={insertResult.pro.lastname} />
 									</td>
 									<td class="px-2 py-2 ">
-										{#if pro.error}
+										{#if insertResult.error}
 											<Text
 												classNames="text-error"
-												value={`Une erreur s'est produite, le professionnel n'a pas été importé. (${pro.error})`}
+												value={`Une erreur s'est produite, le professionnel n'a pas été importé. (${insertResult.error})`}
 											/>
 										{:else}
 											<span

--- a/app/src/lib/ui/AdminStructure/ImportProfessionals.svelte
+++ b/app/src/lib/ui/AdminStructure/ImportProfessionals.svelte
@@ -53,7 +53,7 @@
 					autoConfirm: true,
 				});
 			} catch (e) {
-				error = e;
+				error = e.message;
 			}
 			insertResult = [...insertResult, { pro_, error }];
 		}
@@ -209,7 +209,7 @@
 										{#if pro.error}
 											<Text
 												classNames="text-error"
-												value={"Une erreur s'est produite, le professionnel n'a pas été importé."}
+												value={`Une erreur s'est produite, le professionnel n'a pas été importé. (${pro.error})`}
 											/>
 										{:else}
 											<span

--- a/app/src/lib/utils/sentry.ts
+++ b/app/src/lib/utils/sentry.ts
@@ -3,9 +3,10 @@ import type { Options } from '@sentry/types';
 
 type SentryInterface = {
 	init: (options: Options) => void;
+	captureException: (error: Error) => void;
 };
 
-let sentry;
+let sentry: SentryInterface;
 
 export function initSentry(Sentry: SentryInterface) {
 	if (!env.PUBLIC_SENTRY_DSN) {


### PR DESCRIPTION
## :wrench: Problème

Lorsqu'un administrateur de structure essaie d'importer un utilisateur déjà existant (avec le bouton `Importer une liste de professionnels` via un fichier csv) il n'a pas d'erreur explicite.
Le message d'erreur affiché est très générique et ne permet pas de comprendre que le compte existé déjà.

## :cake: Solution

En analysant le bogue, on se rend compte que l'erreur lancée est une 500.
Dès lors, la question se pose sur la raison pour laquelle aucune erreur Sentry n'est reçue pour ce cas précis.
De plus, l'erreur qui est sensée être lancée est une 400 avec un log explicite.
cf. fichier [inscription/routes/+server.ts](https://github.com/gip-inclusion/carnet-de-bord/blob/dd7769dc27ee179d0940835112fc4b82cdcf6522/app/src/routes/(public)/inscription/request/%2Bserver.ts#L91).

La raison pour laquelle on ne reçoit aucun erreur Sentry est que `Sentry.captureException` n'est pas appelé en cas de 500.
Comme on utilise la fonction `error` de `SvelteKit` on ne passe pas dans `handleError` qui envoie toutes les erreurs à Sentry.

La raison pour laquelle on n'a aucun log est le fait qu'on ne log pas le bon objet dans ce catch : https://github.com/gip-inclusion/carnet-de-bord/blob/dd7769dc27ee179d0940835112fc4b82cdcf6522/app/src/routes/(public)/inscription/request/%2Bserver.ts#LL131C3-L131C3.
En effet on log l'objet `error` qui est une fonction de `SvelteKit`, au lieu de `insertResult.error`.

La raison pour laquelle on n'a pas de 400 avec un log explicite est qu'on passe le username à la requête qui cherche les comptes existants, au lieu de l'email : https://github.com/gip-inclusion/carnet-de-bord/blob/dd7769dc27ee179d0940835112fc4b82cdcf6522/app/src/routes/(public)/inscription/request/%2Bserver.ts#L75.

Enfin, le message d'erreur renvoyé par cette route n'est pas affiché par l'interface, on ajoute donc ce message d'erreur dans la UI.

## :rotating_light:  Points d'attention / Remarques

On en profite pour faire un peu de renommage au passage.

## :desert_island: Comment tester


<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Se rendre sur la [review app](https://cdb-app-review-pr1434.osc-fr1.scalingo.io).
<!-- END ## emplacement de l'URL de la review app ## -->

Se connecter en tant que `vincent.timaitre`.
Sélectionner la structure `Groupe NS`.
Cliquer que `Importer une liste de professionnels`.
Choisir un fichier contenant un professionnel déjà existant.
Vérifier que le message d'erreur indique qu'un compte associé à cet email existe déjà.

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
