### PR TITLE
fix: 

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -12102,8 +12102,6 @@ export type Structure = {
 	beneficiaries: Array<BeneficiaryStructure>;
 	/** An aggregate relationship */
 	beneficiaries_aggregate: BeneficiaryStructureAggregate;
-	/** a computed field, executes function nb_beneficiary_for_structure  */
-	beneficiaryCount?: Maybe<Scalars['bigint']>;
 	city?: Maybe<Scalars['String']>;
 	createdAt?: Maybe<Scalars['timestamptz']>;
 	/** An object relationship */
@@ -12257,7 +12255,6 @@ export type StructureBoolExp = {
 	admins_aggregate?: InputMaybe<AdminStructureStructureAggregateBoolExp>;
 	beneficiaries?: InputMaybe<BeneficiaryStructureBoolExp>;
 	beneficiaries_aggregate?: InputMaybe<BeneficiaryStructureAggregateBoolExp>;
-	beneficiaryCount?: InputMaybe<BigintComparisonExp>;
 	city?: InputMaybe<StringComparisonExp>;
 	createdAt?: InputMaybe<TimestamptzComparisonExp>;
 	deployment?: InputMaybe<DeploymentBoolExp>;
@@ -12411,7 +12408,6 @@ export type StructureOrderBy = {
 	address2?: InputMaybe<OrderBy>;
 	admins_aggregate?: InputMaybe<AdminStructureStructureAggregateOrderBy>;
 	beneficiaries_aggregate?: InputMaybe<BeneficiaryStructureAggregateOrderBy>;
-	beneficiaryCount?: InputMaybe<OrderBy>;
 	city?: InputMaybe<OrderBy>;
 	createdAt?: InputMaybe<OrderBy>;
 	deployment?: InputMaybe<DeploymentOrderBy>;
@@ -16476,10 +16472,6 @@ export type GetStructureQueryVariables = Exact<{
 
 export type GetStructureQuery = {
 	__typename?: 'query_root';
-	beneficiaries: {
-		__typename?: 'notebook_aggregate';
-		aggregate?: { __typename?: 'notebook_aggregate_fields'; count: number } | null;
-	};
 	structure_by_pk?: {
 		__typename?: 'structure';
 		id: string;
@@ -16491,7 +16483,11 @@ export type GetStructureQuery = {
 		postalCode?: string | null;
 		city?: string | null;
 		website?: string | null;
-		beneficiaries: {
+		supportedBeneficiaries: {
+			__typename?: 'beneficiary_structure_aggregate';
+			aggregate?: { __typename?: 'beneficiary_structure_aggregate_fields'; count: number } | null;
+		};
+		unsupportedBeneficiaries: {
 			__typename?: 'beneficiary_structure_aggregate';
 			aggregate?: { __typename?: 'beneficiary_structure_aggregate_fields'; count: number } | null;
 		};
@@ -16556,7 +16552,10 @@ export type GetManagedStructuresQuery = {
 		id: string;
 		city?: string | null;
 		name: string;
-		beneficiaryCount?: any | null;
+		beneficiaries_aggregate: {
+			__typename?: 'beneficiary_structure_aggregate';
+			aggregate?: { __typename?: 'beneficiary_structure_aggregate_fields'; count: number } | null;
+		};
 		professionals_aggregate: {
 			__typename?: 'professional_aggregate';
 			aggregate?: { __typename?: 'professional_aggregate_fields'; count: number } | null;
@@ -27233,93 +27232,6 @@ export const GetStructureDocument = {
 				selections: [
 					{
 						kind: 'Field',
-						alias: { kind: 'Name', value: 'beneficiaries' },
-						name: { kind: 'Name', value: 'notebook_aggregate' },
-						arguments: [
-							{
-								kind: 'Argument',
-								name: { kind: 'Name', value: 'where' },
-								value: {
-									kind: 'ObjectValue',
-									fields: [
-										{
-											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'members' },
-											value: {
-												kind: 'ObjectValue',
-												fields: [
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: 'active' },
-														value: {
-															kind: 'ObjectValue',
-															fields: [
-																{
-																	kind: 'ObjectField',
-																	name: { kind: 'Name', value: '_eq' },
-																	value: { kind: 'BooleanValue', value: true },
-																},
-															],
-														},
-													},
-													{
-														kind: 'ObjectField',
-														name: { kind: 'Name', value: 'account' },
-														value: {
-															kind: 'ObjectValue',
-															fields: [
-																{
-																	kind: 'ObjectField',
-																	name: { kind: 'Name', value: 'professional' },
-																	value: {
-																		kind: 'ObjectValue',
-																		fields: [
-																			{
-																				kind: 'ObjectField',
-																				name: { kind: 'Name', value: 'structureId' },
-																				value: {
-																					kind: 'ObjectValue',
-																					fields: [
-																						{
-																							kind: 'ObjectField',
-																							name: { kind: 'Name', value: '_eq' },
-																							value: {
-																								kind: 'Variable',
-																								name: { kind: 'Name', value: 'structureId' },
-																							},
-																						},
-																					],
-																				},
-																			},
-																		],
-																	},
-																},
-															],
-														},
-													},
-												],
-											},
-										},
-									],
-								},
-							},
-						],
-						selectionSet: {
-							kind: 'SelectionSet',
-							selections: [
-								{
-									kind: 'Field',
-									name: { kind: 'Name', value: 'aggregate' },
-									selectionSet: {
-										kind: 'SelectionSet',
-										selections: [{ kind: 'Field', name: { kind: 'Name', value: 'count' } }],
-									},
-								},
-							],
-						},
-					},
-					{
-						kind: 'Field',
 						name: { kind: 'Name', value: 'structure_by_pk' },
 						arguments: [
 							{
@@ -27342,7 +27254,153 @@ export const GetStructureDocument = {
 								{ kind: 'Field', name: { kind: 'Name', value: 'website' } },
 								{
 									kind: 'Field',
-									alias: { kind: 'Name', value: 'beneficiaries' },
+									alias: { kind: 'Name', value: 'supportedBeneficiaries' },
+									name: { kind: 'Name', value: 'beneficiaries_aggregate' },
+									arguments: [
+										{
+											kind: 'Argument',
+											name: { kind: 'Name', value: 'where' },
+											value: {
+												kind: 'ObjectValue',
+												fields: [
+													{
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: 'status' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: '_neq' },
+																	value: { kind: 'StringValue', value: 'outdated', block: false },
+																},
+															],
+														},
+													},
+													{
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: 'beneficiary' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'notebook' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: 'members' },
+																				value: {
+																					kind: 'ObjectValue',
+																					fields: [
+																						{
+																							kind: 'ObjectField',
+																							name: { kind: 'Name', value: 'active' },
+																							value: {
+																								kind: 'ObjectValue',
+																								fields: [
+																									{
+																										kind: 'ObjectField',
+																										name: { kind: 'Name', value: '_eq' },
+																										value: { kind: 'BooleanValue', value: true },
+																									},
+																								],
+																							},
+																						},
+																						{
+																							kind: 'ObjectField',
+																							name: { kind: 'Name', value: 'memberType' },
+																							value: {
+																								kind: 'ObjectValue',
+																								fields: [
+																									{
+																										kind: 'ObjectField',
+																										name: { kind: 'Name', value: '_eq' },
+																										value: {
+																											kind: 'StringValue',
+																											value: 'referent',
+																											block: false,
+																										},
+																									},
+																								],
+																							},
+																						},
+																						{
+																							kind: 'ObjectField',
+																							name: { kind: 'Name', value: 'account' },
+																							value: {
+																								kind: 'ObjectValue',
+																								fields: [
+																									{
+																										kind: 'ObjectField',
+																										name: { kind: 'Name', value: 'professional' },
+																										value: {
+																											kind: 'ObjectValue',
+																											fields: [
+																												{
+																													kind: 'ObjectField',
+																													name: {
+																														kind: 'Name',
+																														value: 'structureId',
+																													},
+																													value: {
+																														kind: 'ObjectValue',
+																														fields: [
+																															{
+																																kind: 'ObjectField',
+																																name: {
+																																	kind: 'Name',
+																																	value: '_eq',
+																																},
+																																value: {
+																																	kind: 'Variable',
+																																	name: {
+																																		kind: 'Name',
+																																		value: 'structureId',
+																																	},
+																																},
+																															},
+																														],
+																													},
+																												},
+																											],
+																										},
+																									},
+																								],
+																							},
+																						},
+																					],
+																				},
+																			},
+																		],
+																	},
+																},
+															],
+														},
+													},
+												],
+											},
+										},
+									],
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'aggregate' },
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [{ kind: 'Field', name: { kind: 'Name', value: 'count' } }],
+												},
+											},
+										],
+									},
+								},
+								{
+									kind: 'Field',
+									alias: { kind: 'Name', value: 'unsupportedBeneficiaries' },
 									name: { kind: 'Name', value: 'beneficiaries_aggregate' },
 									arguments: [
 										{
@@ -27401,6 +27459,24 @@ export const GetStructureDocument = {
 																													value: {
 																														kind: 'BooleanValue',
 																														value: true,
+																													},
+																												},
+																											],
+																										},
+																									},
+																									{
+																										kind: 'ObjectField',
+																										name: { kind: 'Name', value: 'memberType' },
+																										value: {
+																											kind: 'ObjectValue',
+																											fields: [
+																												{
+																													kind: 'ObjectField',
+																													name: { kind: 'Name', value: '_eq' },
+																													value: {
+																														kind: 'StringValue',
+																														value: 'referent',
+																														block: false,
 																													},
 																												},
 																											],
@@ -27882,7 +27958,48 @@ export const GetManagedStructuresDocument = {
 								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'city' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'beneficiaryCount' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'beneficiaries_aggregate' },
+									arguments: [
+										{
+											kind: 'Argument',
+											name: { kind: 'Name', value: 'where' },
+											value: {
+												kind: 'ObjectValue',
+												fields: [
+													{
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: 'status' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: '_eq' },
+																	value: { kind: 'StringValue', value: 'current', block: false },
+																},
+															],
+														},
+													},
+												],
+											},
+										},
+									],
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'aggregate' },
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [{ kind: 'Field', name: { kind: 'Name', value: 'count' } }],
+												},
+											},
+										],
+									},
+								},
 								{
 									kind: 'Field',
 									name: { kind: 'Name', value: 'professionals_aggregate' },

--- a/app/src/lib/ui/BeneficiaryList/Container.svelte
+++ b/app/src/lib/ui/BeneficiaryList/Container.svelte
@@ -91,53 +91,24 @@
 			},
 		};
 
-		if (filter === 'all' && structureId) {
-			graphqlFilter._or = [
-				{ structures: { status: { _neq: 'outdated' }, structureId: { _eq: structureId } } },
-				{
-					notebook: {
-						members: {
-							active: { _eq: true },
-							account: { professional: { structureId: { _eq: structureId } } },
-						},
-					},
-				},
-			];
+		if (structureId) {
+			graphqlFilter.structures = {
+				status: { _neq: 'outdated' },
+				structureId: { _eq: structureId },
+			};
 		}
 		if (filter === 'noMember') {
-			if (structureId) {
-				graphqlFilter.structures = {
-					status: { _neq: 'outdated' },
-					structureId: { _eq: structureId },
-				};
-				graphqlFilter.notebook = {
-					_not: {
-						members: {
-							active: { _eq: true },
-							account: { professional: { structureId: { _eq: structureId } } },
-						},
-					},
-				};
-			} else {
-				graphqlFilter.notebook = {
-					_not: { members: { active: { _eq: true }, memberType: { _eq: 'referent' } } },
-				};
-			}
+			graphqlFilter.notebook._and.push({
+				_not: { members: { active: { _eq: true }, memberType: { _eq: 'referent' } } },
+			});
 		}
 		if (filter === 'withMember') {
-			if (structureId) {
-				graphqlFilter.notebook = {
-					members: {
-						active: { _eq: true },
-						account: { professional: { structureId: { _eq: structureId } } },
-					},
-				};
-			} else {
-				graphqlFilter.notebook.members = {
+			graphqlFilter.notebook._and.push({
+				members: {
 					active: { _eq: true },
 					memberType: { _eq: 'referent' },
-				};
-			}
+				},
+			});
 		}
 		return graphqlFilter;
 	}

--- a/app/src/routes/(auth)/structures/+page.svelte
+++ b/app/src/routes/(auth)/structures/+page.svelte
@@ -24,7 +24,7 @@
 		name: data.name,
 		city: data.city,
 		nbAdmin: data.admins_aggregate.aggregate.count,
-		beneficiaryCount: data.beneficiaryCount,
+		beneficiaryCount: data.beneficiaries_aggregate.aggregate.count,
 		nbProfessional: data.professionals_aggregate.aggregate.count,
 	}));
 

--- a/app/src/routes/(auth)/structures/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/structures/[uuid]/+page.svelte
@@ -32,8 +32,9 @@
 	function refreshStore() {
 		getStructure.reexecute({ requestPolicy: 'cache-and-network' });
 	}
-	$: beneficiaries = $getStructure.data?.beneficiaries?.aggregate?.count;
 	$: structure = $getStructure.data?.structure_by_pk;
+	$: supportedBeneficiairies = structure?.supportedBeneficiaries.aggregate.count;
+	$: unsupportedBeneficiairies = structure?.unsupportedBeneficiaries.aggregate.count;
 	$: members = structure?.admins_aggregate?.nodes?.map(({ admin_structure }) => admin_structure);
 	$: professionals = structure?.professionals;
 
@@ -56,21 +57,20 @@
 			link: `${data.structureId}/professionnels`,
 		},
 		{
-			label: `${pluralize('Bénéficiaire', beneficiaries)} ${pluralize(
+			label: `${pluralize('Bénéficiaire', supportedBeneficiairies)} ${pluralize(
 				'accompagné',
-				beneficiaries
+				supportedBeneficiairies
 			)}`,
-			amount: beneficiaries,
+			amount: supportedBeneficiairies,
 			link: `${data.structureId}/beneficiaires?filter=withMember`,
 		},
 		{
-			label: `${pluralize(
-				'Bénéficiaire',
-				structure?.beneficiaries?.aggregate?.count ?? 0
-			)} non ${pluralize('accompagné', structure?.beneficiaries?.aggregate?.count ?? 0)}`,
-			amount: structure?.beneficiaries?.aggregate?.count ?? 0,
-			classNames:
-				structure?.beneficiaries?.aggregate?.count > 0 ? 'text-marianne-red' : 'text-success',
+			label: `${pluralize('Bénéficiaire', unsupportedBeneficiairies)} non ${pluralize(
+				'accompagné',
+				unsupportedBeneficiairies
+			)}`,
+			amount: unsupportedBeneficiairies,
+			classNames: unsupportedBeneficiairies ? 'text-marianne-red' : 'text-success',
 			link: `${data.structureId}/beneficiaires?filter=noMember`,
 		},
 	];

--- a/app/src/routes/(auth)/structures/[uuid]/_getStructure.gql
+++ b/app/src/routes/(auth)/structures/[uuid]/_getStructure.gql
@@ -1,16 +1,4 @@
 query GetStructure($structureId: uuid!) {
-  beneficiaries: notebook_aggregate(
-    where: {
-      members: {
-        active: { _eq: true }
-        account: { professional: { structureId: { _eq: $structureId } } }
-      }
-    }
-  ) {
-    aggregate {
-      count
-    }
-  }
   structure_by_pk(id: $structureId) {
     id
     name
@@ -21,7 +9,25 @@ query GetStructure($structureId: uuid!) {
     postalCode
     city
     website
-    beneficiaries: beneficiaries_aggregate(
+    supportedBeneficiaries: beneficiaries_aggregate(
+      where: {
+        status: { _neq: "outdated" }
+        beneficiary: {
+          notebook: {
+            members: {
+              active: { _eq: true }
+              memberType: { _eq: "referent" }
+              account: { professional: { structureId: { _eq: $structureId } } }
+            }
+          }
+        }
+      }
+    ) {
+      aggregate {
+        count
+      }
+    }
+    unsupportedBeneficiaries: beneficiaries_aggregate(
       where: {
         status: { _neq: "outdated" }
         beneficiary: {
@@ -29,6 +35,7 @@ query GetStructure($structureId: uuid!) {
             _not: {
               members: {
                 active: { _eq: true }
+                memberType: { _eq: "referent" }
                 account: { professional: { structureId: { _eq: $structureId } } }
               }
             }

--- a/app/src/routes/(auth)/structures/_getStructures.gql
+++ b/app/src/routes/(auth)/structures/_getStructures.gql
@@ -3,7 +3,11 @@ query GetManagedStructures($adminId: uuid!) {
     id
     city
     name
-    beneficiaryCount
+    beneficiaries_aggregate(where: { status: { _eq: "current" } }) {
+      aggregate {
+        count
+      }
+    }
     professionals_aggregate {
       aggregate {
         count

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_structure.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_structure.yaml
@@ -53,13 +53,6 @@ array_relationships:
         table:
           name: professional
           schema: public
-computed_fields:
-  - name: beneficiaryCount
-    definition:
-      function:
-        name: nb_beneficiary_for_structure
-        schema: public
-    comment: 'a computed field, executes function nb_beneficiary_for_structure '
 insert_permissions:
   - role: admin_cdb
     permission:
@@ -154,8 +147,6 @@ select_permissions:
         - updated_at
         - website
         - deployment_id
-      computed_fields:
-        - beneficiaryCount
       filter:
         deployment_id:
           _eq: X-Hasura-Deployment-Id


### PR DESCRIPTION
## :wrench: Problème

> _Décrivez ici le besoin ou l'intention couvert par cette Pull Request._

Actuellement on remonte et dénombre les bénéficiaires dont un pro de la structure  fait parti du groupe de suivi. 
En tant qu'admin de structure, j'aimerais savoir combien de bénéficiaires de ma structure ont un référent et combien de bénéficiaire on besoin d'un référent.

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés._

On limite l'affichage des bénéficiaires à ceux rattachés à la structure.

## :rotating_light:  Points d'attention / Remarques



## :desert_island: Comment tester

1. Se connecter en tant que lara.pafromage
2. Sélectionner un structure
3. valider que le compte des des bénéficiaires correspond à la somme des bénéficiaires suivi / non suivi (une fois la structure sélectionnée)
4. aller sur la liste des bénéficiaires suivis et valider que le nombre correspond à celui de la tuile
5. afficher la liste des non suivis et valider que le nombre correspond à celui de la tuile
6. afficher tout les bénéficiaires et valider que le nombre correspond à celui de la tuile sur l'accueil

<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Ne pas supprimer ce bloc, qui sera mis à jour [automatiquement](.github/workflows/review-scalingo.yml).
<!-- END ## emplacement de l'URL de la review app ## -->


fix #1436
