### PR TITLE
ci: mise à jour de isort pour corriger l'échec pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: [--target-version=py310]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
## :wrench: Problème

Depuis quelques jours, une mise à jour de `poetry-core` entraîne un échec d'installation de l'outil `isort` utilisé par notre configuration de `pre-commit` : https://github.com/PyCQA/isort/issues/2077

## :cake: Solution

Une mise à jour de `isort` a été publiée (5.12.0) qui corrige le problème. Dans cette PR, on met à jour notre configuration `pre-commit` pour utiliser cette version.

## :desert_island: Comment tester

Confirmer que le workflow `Test` passe bien sur cette PR.