### PR TITLE
fix: suppression de l'action de renvoi de mail de connexion

### DIFF
--- a/app/src/routes/auth/login/+page.svelte
+++ b/app/src/routes/auth/login/+page.svelte
@@ -76,7 +76,8 @@
 				Si vous n'avez pas reçu le lien, vous pouvez cliquer sur le bouton ci-dessous.
 			</div>
 			<div>
-				<Button on:click={handleSubmit} outline={true}>Renvoyer le lien</Button>
+				<!-- le bouton devrait être supprimé mais il permet à l'utilisateur de faire une action pour patienter pendant que le courriel est délivré -->
+				<Button outline={true}>Renvoyer le lien</Button>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## :wrench: Problème

Suite à l'ajout de l'action du  bouton "Renvoyer le mail de connexion", on observe un nombre croissant de demande de courriel de connexion dans une labs de temps très court. Cela impacte de plus la délivrabilité des mails en surchargeant anormalement le nombre d'envoi d'email. On observe aussi un nombre croissant de mail dont l'état est "différé" dans tipimail. Cela est du au fait que nous sommes en plus limité dans l'envoi de mail de connexion ayant un nouveau compte sur tipimail.

## :cake: Solution

On désactive la possibilité de renvoyer le mail en attendant de trouver une solution plus perenne.


## :rotating_light:  Points d'attention / Remarques

ras

## :desert_island: Comment tester

- aller sur la page de connexion
- saisir "pierre.chevalier"
- ouvrir les devtools
- cliquer sur renvoyer le lien
- valider qu'aucun appel réseau ne soit fait.

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1483.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->