### PR TITLE
feat: permettre la configuration des rappels par une variable

### DIFF
--- a/backend/bin/post_compile
+++ b/backend/bin/post_compile
@@ -1,1 +1,12 @@
 pip install --quiet --disable-pip-version-check --progress-bar off .
+
+cat > cron.json <<EOF
+{
+  "jobs": [
+    {
+      "command": "${REMINDER_EMAIL_SCHEDULE:-0 22 * * 0-4} python cdb/scripts/notify_admin_structures/main.py",
+      "size": "S"
+    }
+  ]
+}
+EOF

--- a/backend/cron.json
+++ b/backend/cron.json
@@ -1,8 +1,0 @@
-{
-  "jobs": [
-    {
-      "command": "0 7 * * 1-5 python cdb/scripts/notify_admin_structures/main.py",
-      "size": "S"
-    }
-  ]
-}


### PR DESCRIPTION
## :wrench: Problème

La fréquence des emails de rappel est trop élevée, et l'heure d'envoi ne convient pas nécessairement.

## :cake: Solution

Permettre de définir la programmation des envois via une variable d'environnement.

## :rotating_light:  Points d'attention / Remarques

La variable d'environnement utilisée est `REMINDER_EMAIL_SCHEDULE`. Si elle n'est pas définie on utilise une programmation par défaut. Si cette variable est modifiée il faudra bien penser à redéployer l'application pour que le changement soit pris en compte.

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1485.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

