### PR TITLE
fix: affichage du bouton se détacher uniquement pour les pros

### DIFF
--- a/app/src/lib/ui/ProNotebookMember/ProNotebookMembersView.svelte
+++ b/app/src/lib/ui/ProNotebookMember/ProNotebookMembersView.svelte
@@ -101,7 +101,7 @@
 
 	$: showRemoveButton =
 		members?.find((member: Member) => member.memberType === 'referent')?.account.id !==
-		$accountData.id;
+			$accountData.id && $accountData.type == RoleEnum.Professional;
 </script>
 
 {#if displayMemberManagementButtons}

--- a/app/src/lib/ui/ProNotebookMember/ProNotebookMembersView.test.ts
+++ b/app/src/lib/ui/ProNotebookMember/ProNotebookMembersView.test.ts
@@ -38,61 +38,40 @@ const sankaAccount = {
 	},
 };
 
+const giuiliaDiabyAccount = {
+	id: 'acc3',
+	type: RoleEnum.OrientationManager,
+	confirmed: true,
+	username: 'giuilia.diabby',
+	orientation_manager: {
+		id: 'om1',
+		firstname: 'giuilia',
+		lastname: 'diaby',
+		email: 'orientation.manager@email.net',
+	},
+};
+
 const notebookMembers = [
 	{
 		id: '1',
 		memberType: 'referent',
 		createdAt: '2020-01-01',
-		account: {
-			id: 'acc1',
-			type: RoleEnum.Professional,
-			professional: {
-				id: 'p1',
-				firstname: 'pierre',
-				lastname: 'chevalier',
-				email: 'pierre.chevalier@livry-gargan.fr',
-				structure: {
-					id: 's1',
-					name: 's1',
-				},
-			},
-		},
+		account: pierreChevalierAccount,
 	},
 	{
 		id: '2',
 		memberType: 'no-referent',
 		createdAt: '2020-01-01',
-		account: {
-			id: 'acc2',
-			type: RoleEnum.Professional,
-			professional: {
-				id: 'p2',
-				firstname: 'simon',
-				lastname: 'anka',
-				email: 'sanka@groupe-ns.fr',
-				structure: {
-					id: 's2',
-					name: 's2',
-				},
-			},
-		},
+		account: sankaAccount,
 	},
 	{
 		id: '3',
 		memberType: 'orientation_manager',
 		createdAt: '2020-01-01',
-		account: {
-			id: 'acc3',
-			type: RoleEnum.OrientationManager,
-			orientation_manager: {
-				id: 'om1',
-				firstname: 'giulia',
-				lastname: 'diaby',
-				email: 'giulia.diaby@cd93.fr',
-			},
-		},
+		account: giuiliaDiabyAccount,
 	},
 ];
+
 test('do not show remove button for referent', () => {
 	accountData.set(pierreChevalierAccount);
 
@@ -125,4 +104,21 @@ test('show remove button for no referent', () => {
 	});
 	expect(screen.getByText('Inviter un accompagnateur')).toBeInTheDocument();
 	expect(screen.getByText('Se détacher')).toBeInTheDocument();
+});
+
+test('do not show remove button for orientation managers', () => {
+	accountData.set(giuiliaDiabyAccount);
+
+	render(ProNotebookMembersView, {
+		props: {
+			notebookId: 'id',
+			beneficiaryFirstname: 'leon',
+			beneficiaryLastname: 'leon',
+			appointments: [],
+			displayMemberManagementButtons: true,
+			members: notebookMembers,
+		},
+	});
+	expect(screen.getByText('Inviter un accompagnateur')).toBeInTheDocument();
+	expect(screen.queryByText('Se détacher')).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## :wrench: Problème

Actuellement, sur la page d'un carnet, les chargés d'orientation voient un bouton se « détacher » qui ne fonctionne pas car tout le code de cette page a été prévu pour uniquement détacher les professionnels.

## :cake: Solution

Désactivation du bouton « se détacher » pour chargé d'orientation. Une nouvelle méthode sera mise en place dans une autre PR pour que les CO puissent se détacher directement à partir de la liste des bénéficiaires.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

1. Je me connecte en tant que `samy.rouate`
2. Je vais sur le carnet de `Terry Horn`
3. Je confirme qu'il n'y a plus de bouton « Se détacher » dans la partie « Groupe de suivi »

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1486.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


 fix #1484  
