### PR TITLE
fix: Ne pas afficher le bouton "Demander une réorientation" si une demande et déjà en cours.

### DIFF
--- a/e2e/features/pro/carnet/reorientation.feature
+++ b/e2e/features/pro/carnet/reorientation.feature
@@ -14,6 +14,7 @@ Fonctionnalité: Demande de réorientation
 		Quand je clique sur le bouton "Envoyer ma demande"
 		Alors je vois "Demande de réorientation envoyée"
 		Alors je vois "Orientation recommandée : Social"
+		Alors je ne vois pas "Demander une réorientation"
 
 	Scénario: Affichage d'un bénéficiaire pour lequel la demande de réorientation a été refusée
 		Soit le pro "pcamara@seinesaintdenis.fr" sur le carnet de "Rose"

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_orientation_request.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_orientation_request.yaml
@@ -64,7 +64,6 @@ insert_permissions:
                     _eq: referent
       set:
         requestor_account_id: x-hasura-User-Id
-        status: current
       columns:
         - beneficiary_id
         - reason

--- a/hasura/migrations/carnet_de_bord/1675255129484_alter_table_public_orientation_request_alter_column_status/down.sql
+++ b/hasura/migrations/carnet_de_bord/1675255129484_alter_table_public_orientation_request_alter_column_status/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."orientation_request" ALTER COLUMN "status" drop default;

--- a/hasura/migrations/carnet_de_bord/1675255129484_alter_table_public_orientation_request_alter_column_status/up.sql
+++ b/hasura/migrations/carnet_de_bord/1675255129484_alter_table_public_orientation_request_alter_column_status/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."orientation_request" alter column "status" set default 'pending';
+
+UPDATE orientation_request
+SET status = 'pending'
+WHERE status = 'current';


### PR DESCRIPTION
## :wrench: Problème

Aujourd'hui quand une demande de réorientation est cours, le professionnel peut toujours faire une demande réorientation via le bouton "demander une réorientation".

## :cake: Solution

Le bouton est affiché car on vérifie que la demande n'est pas dans l'état `pending`. Cependant, la valeur par défaut lors de l'insertion (configuré par Hasura) est `current`.
On décide donc de supprimer cette configuration Hasura.
On la remplace par une valeur par défaut lors de l'insert SQL, qui vaut `pending`.
On ajoute une migration de données qui change tous les statuts `current` en `pending`.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1487.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->
Se connecter en tant que `pierre.chevalier`.
Se rendre sur le carnet de Sophie Tifour.
Faire une demande de réorientation.
Vérifier que le bouton `Demander une réorientation` n'est plus affiché.

fixes #1477
