### PR TITLE
fix: Ne pas afficher le bouton "Orienter"/"Réorienter" pour les administrateurs de structure.

### DIFF
--- a/app/src/lib/ui/OrientationHeader/OrientationHeader.svelte
+++ b/app/src/lib/ui/OrientationHeader/OrientationHeader.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-	import type {
+	import {
 		GetNotebookByBeneficiaryIdQuery,
 		GetNotebookQuery,
+		RoleEnum,
 	} from '$lib/graphql/_gen/typed-document-nodes';
 	import { Button } from '$lib/ui/base';
-	import { openComponent } from '$lib/stores';
+	import { accountData, openComponent } from '$lib/stores';
 	import ChangeOrientationForm from '../OrientationRequest/ChangeOrientationForm.svelte';
 	import { createEventDispatcher } from 'svelte';
 
@@ -27,8 +28,11 @@
 	}
 </script>
 
-<div class="flex flex-row mb-8 items-center">
-	<div class="flex flex-row flex-none items-center gap-6 h-8">
-		<Button title={buttonTitle} on:click={() => openChangeOrientationForm()}>{buttonTitle}</Button>
+{#if [RoleEnum.Manager, RoleEnum.OrientationManager].includes($accountData.type)}
+	<div class="flex flex-row mb-8 items-center">
+		<div class="flex flex-row flex-none items-center gap-6 h-8">
+			<Button title={buttonTitle} on:click={() => openChangeOrientationForm()}>{buttonTitle}</Button
+			>
+		</div>
 	</div>
-</div>
+{/if}

--- a/app/src/lib/ui/OrientationHeader/OrientationHeader.test.ts
+++ b/app/src/lib/ui/OrientationHeader/OrientationHeader.test.ts
@@ -1,0 +1,181 @@
+import { test } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import OrientationHeader from '../OrientationHeader/OrientationHeader.svelte';
+import { accountData } from '$lib/stores';
+import { GetNotebookByBeneficiaryIdQuery, RoleEnum } from '$lib/graphql/_gen/typed-document-nodes';
+
+const pierreChevalierAccount = {
+	id: 'acc1',
+	type: RoleEnum.Professional,
+	confirmed: true,
+	username: 'pierre.chevalier',
+	professional: {
+		id: 'p1',
+		firstname: 'Pierre',
+		lastname: 'Chevalier',
+		email: 'pierre.chevalier@livry-gargan.fr',
+		structure: {
+			id: 's1',
+			name: 'Centre communal Livry gargan',
+		},
+	},
+};
+
+const sankaAccount = {
+	id: 'acc2',
+	type: RoleEnum.Professional,
+	confirmed: true,
+	username: 'sanka',
+	professional: {
+		id: 'p2',
+		firstname: 'Simon',
+		lastname: 'Anka',
+		email: 'sanka@groupe-ns',
+		structure: {
+			id: 's2',
+			name: 'Groupe NS',
+		},
+	},
+};
+
+const adminStructureAccount = {
+	id: 'admin-structure-account-id',
+	type: RoleEnum.AdminStructure,
+	confirmed: true,
+	username: 'admin.structure',
+	admin_structure: {
+		id: 'admin-structure-id',
+		firstname: 'Admin',
+		lastname: 'Structure',
+		email: 'admin.structure@email.net',
+	},
+};
+
+const orientationManagerAccount = {
+	id: 'orientation-manager-account-id',
+	type: RoleEnum.OrientationManager,
+	confirmed: true,
+	username: 'orientation.manager',
+	orientation_manager: {
+		id: 'orientation-manager-id',
+		firstname: 'Orientation',
+		lastname: 'Manager',
+		email: 'orientation.manager@email.net',
+	},
+};
+
+const managerAccount = {
+	id: 'manager-account-id',
+	type: RoleEnum.Manager,
+	confirmed: true,
+	username: 'manager',
+	manager: {
+		id: 'manager-id',
+		firstname: 'Admin',
+		lastname: 'Territoire',
+		email: 'admin.territoire@email.net',
+	},
+};
+
+const members = [
+	{
+		id: '1',
+		memberType: 'referent',
+		createdAt: '2020-01-01',
+		account: pierreChevalierAccount,
+	},
+	{
+		id: '2',
+		memberType: 'no-referent',
+		createdAt: '2020-01-01',
+		account: sankaAccount,
+	},
+];
+
+const beneficiary = {
+	id: 'beneficiary-id',
+	firstname: 'Béné',
+	lastname: 'Ficiaire',
+	dateOfBirth: '1998-07-12',
+};
+
+const notebook: GetNotebookByBeneficiaryIdQuery['notebook'][number] = {
+	id: 'notebook-id',
+	beneficiary,
+	beneficiaryId: beneficiary.id,
+	members,
+	wantedJobs: [],
+	focuses: [],
+	rightAre: false,
+	rightBonus: false,
+	rightRqth: false,
+	notebookInfo: { needOrientation: false },
+};
+
+test('do not show "Réorienter" button for admin_structure', () => {
+	accountData.set(adminStructureAccount);
+
+	render(OrientationHeader, {
+		props: {
+			notebook,
+		},
+	});
+	expect(screen.queryByText('Orienter')).not.toBeInTheDocument();
+	expect(screen.queryByText('Réorienter')).not.toBeInTheDocument();
+});
+
+describe('when beneficiary needs orientation', () => {
+	const notebookNeedingOrientation = {
+		...notebook,
+		notebookInfo: { needOrientation: true },
+	};
+	test('show "Orienter" button for orientation_manager', () => {
+		accountData.set(orientationManagerAccount);
+
+		render(OrientationHeader, {
+			props: {
+				notebook: notebookNeedingOrientation,
+			},
+		});
+		expect(screen.getByText('Orienter')).toBeInTheDocument();
+		expect(screen.queryByText('Réorienter')).not.toBeInTheDocument();
+	});
+
+	test('show "Orienter" button for manager', () => {
+		accountData.set(managerAccount);
+
+		render(OrientationHeader, {
+			props: {
+				notebook: notebookNeedingOrientation,
+			},
+		});
+		expect(screen.getByText('Orienter')).toBeInTheDocument();
+		expect(screen.queryByText('Réorienter')).not.toBeInTheDocument();
+	});
+});
+
+describe('when beneficiary does not need orientation', () => {
+	test('show "Réorienter" button for orientation_manager', () => {
+		accountData.set(orientationManagerAccount);
+
+		render(OrientationHeader, {
+			props: {
+				notebook,
+			},
+		});
+		expect(screen.getByText('Réorienter')).toBeInTheDocument();
+		expect(screen.queryByText('Orienter')).not.toBeInTheDocument();
+	});
+
+	test('show "Réorienter" button for manager', () => {
+		accountData.set(managerAccount);
+
+		render(OrientationHeader, {
+			props: {
+				notebook,
+			},
+		});
+		expect(screen.getByText('Réorienter')).toBeInTheDocument();
+		expect(screen.queryByText('Orienter')).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## :wrench: Problème

Les administrateurs de structure ne font pas de réorientation, aussi l'API permettant cette réorientation leur interdit l'opération.
Cependant, le bouton `Orienter`/`Réorienter` est toujours affiché pour les administrateurs de structure.

## :cake: Solution

On n'affiche plus le bouton `Orienter`/`Réorienter` pour les administrateurs de structure.

## :rotating_light:  Points d'attention / Remarques

On en profite pour ajouter des tests au niveau composant sur cet affichage, plutôt que des tests end-to-end.

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1495.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->
Je me connecte en tant que jacques.celaire
J'affiche le liste des bénéficiaires de la structure
J'affiche le carnet de Aguilar
Je ne vois pas le bouton "Réorienter" car les admin de structure ne font pas de réorientation

fixes #1492