### PR TITLE
fix: La pastille du nombre de bénéficiaires suivis est fausse

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -23583,6 +23583,49 @@ export const GetProfessionalsForStructureDocument = {
 											{
 												kind: 'Field',
 												name: { kind: 'Name', value: 'notebooksWhereMember_aggregate' },
+												arguments: [
+													{
+														kind: 'Argument',
+														name: { kind: 'Name', value: 'where' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'active' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: '_eq' },
+																				value: { kind: 'BooleanValue', value: true },
+																			},
+																		],
+																	},
+																},
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'memberType' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: '_eq' },
+																				value: {
+																					kind: 'StringValue',
+																					value: 'referent',
+																					block: false,
+																				},
+																			},
+																		],
+																	},
+																},
+															],
+														},
+													},
+												],
 												selectionSet: {
 													kind: 'SelectionSet',
 													selections: [

--- a/app/src/lib/ui/ProfessionalList/_getProfessionalsForStructure.gql
+++ b/app/src/lib/ui/ProfessionalList/_getProfessionalsForStructure.gql
@@ -12,7 +12,9 @@ query GetProfessionalsForStructure($structureId: uuid!) {
     account {
       id
       onboardingDone
-      notebooksWhereMember_aggregate {
+      notebooksWhereMember_aggregate(
+        where: { active: { _eq: true }, memberType: { _eq: "referent" } }
+      ) {
         aggregate {
           count
         }

--- a/e2e/features/structureAdmin/edit_professional.feature
+++ b/e2e/features/structureAdmin/edit_professional.feature
@@ -28,6 +28,7 @@ Fonctionnalité: Modification d'un professionnel
 		Soit un "administrateur de structures" authentifié avec l'email "jacques.celaire@livry-gargan.fr"
 		Quand je clique sur "Centre Communal d'action social Livry-Gargan"
 		Quand je clique sur "Professionnels"
+		Alors je vois "1" sur la ligne "Pierre Chevalier"
 		Quand je clique sur "Mettre à jour" dans la ligne de "Pierre Chevalier"
 		Quand je décoche "Socio-professionnel"
 		Quand je décoche "PE (Professionnel)"


### PR DESCRIPTION
## :wrench: Problème

Je me connecte en tant que jacques.celaire.
J'affiche la liste de pro de ma structure.
Je vois que pierre chevalier suit 2 personnes alors qu'il n'est référent que d'un seul bénéficiaire.


## :cake: Solution

On ne filtre (referent + actif) pas l'aggregat des notebook_member dans la requete GetProfessionalsForStructure.
On ajoute le même filtre pour le compte que pour l'affichage de la liste des bénéficiaires.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1496.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

Je me connecte en tant que jacques.celaire.
J'affiche la liste de pro de ma structure.
Je vois que pierre chevalier suit 1 personne.

fixes #1493

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
