### PR TITLE
chore: add name in docker project

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,4 +1,14 @@
 # Guide de développement
+## Docker
+
+Les fichiers `docker-compose*.yaml` sont nommés pour faciliter le démarrage et l'arrêt des environnement de développement ou de test en local.
+
+```sh
+# démarrer l'environnement de test en local
+docker compose -f docker-compose-test.yaml up
+# arrêter l'environnement de test en local
+docker compose -f docker-compose-test.yaml down
+```
 
 ## Données, GraphQL et Hasura
 

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,8 +1,9 @@
 version: '3.8'
+name: cdb-test
 
 services:
   db_test:
-    image: postgres:11
+    image: postgres:13
     environment:
       - POSTGRES_DB=carnet_de_bord
       - POSTGRES_USER=cdb
@@ -13,7 +14,6 @@ services:
       - '5433:5432'
     volumes:
       - cdb-pgdata-test:/var/lib/postgresql/data
-    restart: always
 
   hasura_test:
     image: cdb_hasura
@@ -29,7 +29,7 @@ services:
       - '5001:8080'
     depends_on:
       - 'db_test'
-    restart: always
+    stop_signal: SIGKILL
     env_file:
       - .env.test
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   db:
-    image: postgres:11
+    image: postgres:13
     environment:
       - POSTGRES_DB=carnet_de_bord
       - POSTGRES_USER=cdb
@@ -11,7 +11,6 @@ services:
       - '5432:5432'
     volumes:
       - cdb-pgdata:/var/lib/postgresql/data
-    restart: always
 
   hasura:
     image: cdb_hasura
@@ -27,7 +26,7 @@ services:
       - '${HASURA_ENDPOINT_PORT:-5000}:8080'
     depends_on:
       - 'db'
-    restart: always
+    stop_signal: SIGKILL
     env_file:
       - .env
     environment:

--- a/scripts/launch_tests.sh
+++ b/scripts/launch_tests.sh
@@ -41,7 +41,7 @@ then
 fi
 
 # Load the env variables from .env file
-if [ -f ".env.test" ]
+if [ -f "$ROOT_DIR/.env.test" ]
 then
   # See https://github.com/ko1nksm/shdotenv
   eval "$($SCRIPT_DIR/shdotenv --env .env.test)"
@@ -69,17 +69,15 @@ if [ ! "$(docker ps -q -f name=db_test)" ] && [ ! "$(docker ps -q -f name=hasura
 
     # Clean existing volume
     if [ "$(docker volume ls | grep cdb-pgdata-test)" ]; then
-        echo "-> Clean existing volume carnet-de-bord_cdb-pgdata-test"
-        docker volume rm carnet-de-bord_cdb-pgdata-test
+        echo "-> Clean existing volume cdb-test_cdb-pgdata-test"
+        docker volume rm cdb-test_cdb-pgdata-test
     fi
     echo "-> Starting docker"
     docker compose -f docker-compose-test.yaml up --build -d
 else
     echo "Docker test env already started. Use: "
     echo ""
-    echo "    docker compose -f docker-compose-test.yaml stop"
-    echo ""
-    echo "in $ROOT_DIR if you want to stop it."
+    echo "    docker compose --project-name cdb-test down"
     echo ""
 fi
 

--- a/scripts/launch_tests.sh
+++ b/scripts/launch_tests.sh
@@ -77,7 +77,7 @@ if [ ! "$(docker ps -q -f name=db_test)" ] && [ ! "$(docker ps -q -f name=hasura
 else
     echo "Docker test env already started. Use: "
     echo ""
-    echo "    docker compose --project-name cdb-test down"
+    echo "    docker compose -f docker-compose-test.yaml down -v"
     echo ""
 fi
 

--- a/scripts/launch_tests.sh
+++ b/scripts/launch_tests.sh
@@ -70,7 +70,7 @@ if [ ! "$(docker ps -q -f name=db_test)" ] && [ ! "$(docker ps -q -f name=hasura
     # Clean existing volume
     if [ "$(docker volume ls | grep cdb-pgdata-test)" ]; then
         echo "-> Clean existing volume cdb-test_cdb-pgdata-test"
-        docker volume rm cdb-test_cdb-pgdata-test
+        docker compose -f docker-compose-test.yaml down -v
     fi
     echo "-> Starting docker"
     docker compose -f docker-compose-test.yaml up --build -d


### PR DESCRIPTION
## :wrench: Problème

Actuellement nous ne n'utilisons la propriété `name` dans nos fichiers docker compose. cela empêche de pouvoir arrêter / relancer les environnements de développement ou de test indépendamment via la commande  `docker compose`

## :cake: Solution

On ajoute la propriété name dans le docker compose de test


## :rotating_light:  Points d'attention / Remarques

On profite de la pr pour permettre de lancer le script `launch_test.sh` d'autres part que la racine du projet.
On supprime aussi les `restart: always` qui relance les container au demarrage de la machine si ces derniers était lancés.
On ajoute `stop_signal: SIGKILL` pour stopper les container hasura vu que l'app est immutable
On profite d'aligner les versions de pg avec celle de prod 

## :desert_island: Comment tester

- lancer le script launch_test.sh
- lancer la commande  `docker compose --project-name cdb-test down`
- vérifier que les services sont bien arrêtés avec la commande `docker ps ` 
- 
<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1510.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
