### PR TITLE
feat: ajout de la date du dernier emploi

### DIFF
--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -20,6 +20,7 @@ type alias Flags =
     , geographicalArea : Maybe String
     , educationLevel : Maybe String
     , wantedJobs : List String
+    , lastJobEndedAt : Maybe String
     }
 
 
@@ -149,6 +150,12 @@ professionalSituation model =
                         (workSituationDateFormat situationPro.workSituationDate situationPro.workSituationEndDate)
                     ]
                 , div [ class "fr-col-6" ]
+                    [ situationElement "Date du dernier emploi"
+                        (Maybe.map (Date.format "dd/MM/yyyy" >> text) situationPro.lastJobEndedAt)
+                        "Non renseigné"
+                        Nothing
+                    ]
+                , div [ class "fr-col-6" ]
                     [ div [ class "fr-col-6" ]
                         [ situationElement "Dispose d'un RQTH"
                             (Just
@@ -229,6 +236,7 @@ extractSituationFromFlags flags =
     , geographicalArea = flags.geographicalArea
     , educationLevel = flags.educationLevel
     , wantedJobs = flags.wantedJobs
+    , lastJobEndedAt = flags.lastJobEndedAt |> Maybe.andThen (fromIsoString >> Result.toMaybe)
     }
 
 

--- a/app/elm/Diagnostic/Main.elm.d.ts
+++ b/app/elm/Diagnostic/Main.elm.d.ts
@@ -10,6 +10,7 @@ export type Flags = {
 	geographicalArea: string | undefined;
 	educationLevel: string | undefined;
 	wantedJobs: string[];
+	lastJobEndedAt: string | undefined;
 };
 
 export type Ports = {};

--- a/app/elm/Domain/SituationPro.elm
+++ b/app/elm/Domain/SituationPro.elm
@@ -15,6 +15,7 @@ type alias SituationPro =
     , geographicalArea : Maybe String
     , educationLevel : Maybe String
     , wantedJobs : List String
+    , lastJobEndedAt : Maybe Date
     }
 
 

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -5564,6 +5564,7 @@ export type Notebook = {
 	focuses_aggregate: NotebookFocusAggregate;
 	geographicalArea?: Maybe<Scalars['String']>;
 	id: Scalars['uuid'];
+	lastJobEndedAt?: Maybe<Scalars['date']>;
 	/** An array relationship */
 	members: Array<NotebookMember>;
 	/** An aggregate relationship */
@@ -6268,6 +6269,7 @@ export type NotebookBoolExp = {
 	focuses_aggregate?: InputMaybe<NotebookFocusAggregateBoolExp>;
 	geographicalArea?: InputMaybe<StringComparisonExp>;
 	id?: InputMaybe<UuidComparisonExp>;
+	lastJobEndedAt?: InputMaybe<DateComparisonExp>;
 	members?: InputMaybe<NotebookMemberBoolExp>;
 	members_aggregate?: InputMaybe<NotebookMemberAggregateBoolExp>;
 	notebookInfo?: InputMaybe<NotebookInfoBoolExp>;
@@ -7290,6 +7292,7 @@ export type NotebookInsertInput = {
 	focuses?: InputMaybe<NotebookFocusArrRelInsertInput>;
 	geographicalArea?: InputMaybe<Scalars['String']>;
 	id?: InputMaybe<Scalars['uuid']>;
+	lastJobEndedAt?: InputMaybe<Scalars['date']>;
 	members?: InputMaybe<NotebookMemberArrRelInsertInput>;
 	notebookInfo?: InputMaybe<NotebookInfoObjRelInsertInput>;
 	rightAre?: InputMaybe<Scalars['Boolean']>;
@@ -7316,6 +7319,7 @@ export type NotebookMaxFields = {
 	educationLevel?: Maybe<Scalars['String']>;
 	geographicalArea?: Maybe<Scalars['String']>;
 	id?: Maybe<Scalars['uuid']>;
+	lastJobEndedAt?: Maybe<Scalars['date']>;
 	rightRsa?: Maybe<Scalars['String']>;
 	updatedAt?: Maybe<Scalars['timestamptz']>;
 	workSituation?: Maybe<Scalars['String']>;
@@ -7673,6 +7677,7 @@ export type NotebookMinFields = {
 	educationLevel?: Maybe<Scalars['String']>;
 	geographicalArea?: Maybe<Scalars['String']>;
 	id?: Maybe<Scalars['uuid']>;
+	lastJobEndedAt?: Maybe<Scalars['date']>;
 	rightRsa?: Maybe<Scalars['String']>;
 	updatedAt?: Maybe<Scalars['timestamptz']>;
 	workSituation?: Maybe<Scalars['String']>;
@@ -7718,6 +7723,7 @@ export type NotebookOrderBy = {
 	focuses_aggregate?: InputMaybe<NotebookFocusAggregateOrderBy>;
 	geographicalArea?: InputMaybe<OrderBy>;
 	id?: InputMaybe<OrderBy>;
+	lastJobEndedAt?: InputMaybe<OrderBy>;
 	members_aggregate?: InputMaybe<NotebookMemberAggregateOrderBy>;
 	notebookInfo?: InputMaybe<NotebookInfoOrderBy>;
 	notebookMemberCount?: InputMaybe<OrderBy>;
@@ -7926,6 +7932,8 @@ export enum NotebookSelectColumn {
 	/** column name */
 	Id = 'id',
 	/** column name */
+	LastJobEndedAt = 'lastJobEndedAt',
+	/** column name */
 	RightAre = 'rightAre',
 	/** column name */
 	RightAss = 'rightAss',
@@ -7956,6 +7964,7 @@ export type NotebookSetInput = {
 	educationLevel?: InputMaybe<Scalars['String']>;
 	geographicalArea?: InputMaybe<Scalars['String']>;
 	id?: InputMaybe<Scalars['uuid']>;
+	lastJobEndedAt?: InputMaybe<Scalars['date']>;
 	rightAre?: InputMaybe<Scalars['Boolean']>;
 	rightAss?: InputMaybe<Scalars['Boolean']>;
 	rightBonus?: InputMaybe<Scalars['Boolean']>;
@@ -7986,6 +7995,7 @@ export type NotebookStreamCursorValueInput = {
 	educationLevel?: InputMaybe<Scalars['String']>;
 	geographicalArea?: InputMaybe<Scalars['String']>;
 	id?: InputMaybe<Scalars['uuid']>;
+	lastJobEndedAt?: InputMaybe<Scalars['date']>;
 	rightAre?: InputMaybe<Scalars['Boolean']>;
 	rightAss?: InputMaybe<Scalars['Boolean']>;
 	rightBonus?: InputMaybe<Scalars['Boolean']>;
@@ -8301,6 +8311,8 @@ export enum NotebookUpdateColumn {
 	GeographicalArea = 'geographicalArea',
 	/** column name */
 	Id = 'id',
+	/** column name */
+	LastJobEndedAt = 'lastJobEndedAt',
 	/** column name */
 	RightAre = 'rightAre',
 	/** column name */
@@ -14864,6 +14876,7 @@ export type UpdateSocioProMutationVariables = Exact<{
 	rightBonus?: InputMaybe<Scalars['Boolean']>;
 	geographicalArea?: InputMaybe<Scalars['String']>;
 	educationLevel?: InputMaybe<Scalars['String']>;
+	lastJobEndedAt?: InputMaybe<Scalars['date']>;
 	wantedJobs: Array<WantedJobInsertInput> | WantedJobInsertInput;
 }>;
 
@@ -15129,6 +15142,7 @@ export type GetNotebookByBeneficiaryIdQuery = {
 		contractStartDate?: string | null;
 		contractEndDate?: string | null;
 		educationLevel?: string | null;
+		lastJobEndedAt?: string | null;
 		geographicalArea?: string | null;
 		wantedJobs: Array<{
 			__typename?: 'wanted_job';
@@ -15288,6 +15302,7 @@ export type GetNotebookByIdQuery = {
 		contractStartDate?: string | null;
 		contractEndDate?: string | null;
 		educationLevel?: string | null;
+		lastJobEndedAt?: string | null;
 		geographicalArea?: string | null;
 		wantedJobs: Array<{
 			__typename?: 'wanted_job';
@@ -15440,6 +15455,7 @@ export type NotebookFragmentFragment = {
 	contractStartDate?: string | null;
 	contractEndDate?: string | null;
 	educationLevel?: string | null;
+	lastJobEndedAt?: string | null;
 	geographicalArea?: string | null;
 	wantedJobs: Array<{
 		__typename?: 'wanted_job';
@@ -16072,6 +16088,7 @@ export type GetNotebookQuery = {
 			contractSignDate?: string | null;
 			contractStartDate?: string | null;
 			contractEndDate?: string | null;
+			lastJobEndedAt?: string | null;
 			notebookInfo?: { __typename?: 'notebook_info'; needOrientation: boolean } | null;
 			wantedJobs: Array<{
 				__typename?: 'wanted_job';
@@ -16699,6 +16716,7 @@ export const NotebookFragmentFragmentDoc = {
 					{ kind: 'Field', name: { kind: 'Name', value: 'contractStartDate' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'contractEndDate' } },
 					{ kind: 'Field', name: { kind: 'Name', value: 'educationLevel' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'lastJobEndedAt' } },
 					{
 						kind: 'Field',
 						name: { kind: 'Name', value: 'wantedJobs' },
@@ -23021,6 +23039,11 @@ export const UpdateSocioProDocument = {
 				},
 				{
 					kind: 'VariableDefinition',
+					variable: { kind: 'Variable', name: { kind: 'Name', value: 'lastJobEndedAt' } },
+					type: { kind: 'NamedType', name: { kind: 'Name', value: 'date' } },
+				},
+				{
+					kind: 'VariableDefinition',
 					variable: { kind: 'Variable', name: { kind: 'Name', value: 'wantedJobs' } },
 					type: {
 						kind: 'NonNullType',
@@ -23123,6 +23146,11 @@ export const UpdateSocioProDocument = {
 											kind: 'ObjectField',
 											name: { kind: 'Name', value: 'educationLevel' },
 											value: { kind: 'Variable', name: { kind: 'Name', value: 'educationLevel' } },
+										},
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: 'lastJobEndedAt' },
+											value: { kind: 'Variable', name: { kind: 'Name', value: 'lastJobEndedAt' } },
 										},
 									],
 								},
@@ -27005,6 +27033,7 @@ export const GetNotebookDocument = {
 											{ kind: 'Field', name: { kind: 'Name', value: 'contractSignDate' } },
 											{ kind: 'Field', name: { kind: 'Name', value: 'contractStartDate' } },
 											{ kind: 'Field', name: { kind: 'Name', value: 'contractEndDate' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'lastJobEndedAt' } },
 											{
 												kind: 'Field',
 												name: { kind: 'Name', value: 'notebookInfo' },

--- a/app/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/app/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -13,6 +13,7 @@
 		| 'rightRsa'
 		| 'geographicalArea'
 		| 'educationLevel'
+		| 'lastJobEndedAt'
 	> & { wantedJobs: { rome_code: { id: string; label: string } }[] };
 </script>
 
@@ -39,6 +40,7 @@
 				geographicalArea: notebook.geographicalArea,
 				educationLevel: notebook.educationLevel,
 				wantedJobs: notebook.wantedJobs.map(({ rome_code }) => rome_code.label),
+				lastJobEndedAt: notebook.lastJobEndedAt,
 			},
 		});
 	});

--- a/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioPro.schema.ts
+++ b/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioPro.schema.ts
@@ -11,6 +11,7 @@ export const proNotebookSocioproSchema = yup.object().shape({
 	rightBonus: yup.boolean(),
 	geographicalArea: yup.string().nullable(),
 	educationLevel: yup.string().nullable(),
+	lastJobEndedAt: yup.date().transform(transformDate).nullable(),
 	workSituationDate: yup.date().transform(transformDate).nullable(),
 	workSituationEndDate: yup
 		.mixed()

--- a/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
@@ -34,6 +34,7 @@
 		| 'rightRqth'
 		| 'educationLevel'
 		| 'geographicalArea'
+		| 'lastJobEndedAt'
 	> & { wantedJobs: string[] };
 
 	const updateSocioProStore = operationStore(UpdateSocioProDocument);
@@ -51,6 +52,7 @@
 		rightBonus: notebook.rightBonus,
 		geographicalArea: notebook.geographicalArea,
 		educationLevel: notebook.educationLevel,
+		lastJobEndedAt: notebook.lastJobEndedAt ?? '',
 	};
 
 	let wantedJobs = notebook.wantedJobs;
@@ -84,6 +86,7 @@
 			workSituation,
 			workSituationDate: values.workSituationDate.toString() || null,
 			workSituationEndDate: values.workSituationEndDate.toString() || null,
+			lastJobEndedAt: values.lastJobEndedAt.toString() || null,
 			wantedJobs: wantedJobs.map((rome_code_id) => ({
 				notebook_id: notebook.id,
 				rome_code_id,
@@ -205,7 +208,9 @@
 				</div>
 			</div>
 		</div>
-
+		<div class="fr-form-group">
+			<Input name="lastJobEndedAt" inputLabel="Date de fin du dernier emploi" type="date" />
+		</div>
 		<div class="pb-4">
 			<Checkbox name="rightRqth" label="RQTH" />
 		</div>

--- a/app/src/lib/ui/ProNotebookSocioPro/_UpdateSocioPro.gql
+++ b/app/src/lib/ui/ProNotebookSocioPro/_UpdateSocioPro.gql
@@ -10,6 +10,7 @@ mutation UpdateSocioPro(
   $rightBonus: Boolean
   $geographicalArea: String
   $educationLevel: String
+  $lastJobEndedAt: date
   $wantedJobs: [wanted_job_insert_input!]!
 ) {
   update: update_notebook_by_pk(
@@ -25,6 +26,7 @@ mutation UpdateSocioPro(
       rightBonus: $rightBonus
       geographicalArea: $geographicalArea
       educationLevel: $educationLevel
+      lastJobEndedAt: $lastJobEndedAt
     }
   ) {
     id

--- a/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
+++ b/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
@@ -26,6 +26,7 @@ fragment notebookFragment on notebook {
   contractStartDate
   contractEndDate
   educationLevel
+  lastJobEndedAt
   wantedJobs {
     rome_code {
       id

--- a/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
+++ b/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
@@ -93,6 +93,7 @@ query GetNotebook(
       contractSignDate
       contractStartDate
       contractEndDate
+      lastJobEndedAt
       notebookInfo {
         needOrientation
       }

--- a/backend/cdb/api/_gen/schema_gql.py
+++ b/backend/cdb/api/_gen/schema_gql.py
@@ -2996,7 +2996,7 @@ type deployment {
   """An array relationship"""
   orientationSystems(
     """distinct select on columns"""
-    distinct_on: [deployment_orientation_system_select_column!]
+    distinct_on: [orientation_system_select_column!]
 
     """limit the number of rows returned"""
     limit: Int
@@ -3005,16 +3005,16 @@ type deployment {
     offset: Int
 
     """sort the rows by one or more columns"""
-    order_by: [deployment_orientation_system_order_by!]
+    order_by: [orientation_system_order_by!]
 
     """filter the rows returned"""
-    where: deployment_orientation_system_bool_exp
-  ): [deployment_orientation_system!]!
+    where: orientation_system_bool_exp
+  ): [orientation_system!]!
 
   """An aggregate relationship"""
   orientationSystems_aggregate(
     """distinct select on columns"""
-    distinct_on: [deployment_orientation_system_select_column!]
+    distinct_on: [orientation_system_select_column!]
 
     """limit the number of rows returned"""
     limit: Int
@@ -3023,11 +3023,11 @@ type deployment {
     offset: Int
 
     """sort the rows by one or more columns"""
-    order_by: [deployment_orientation_system_order_by!]
+    order_by: [orientation_system_order_by!]
 
     """filter the rows returned"""
-    where: deployment_orientation_system_bool_exp
-  ): deployment_orientation_system_aggregate!
+    where: orientation_system_bool_exp
+  ): orientation_system_aggregate!
 
   """An array relationship"""
   orientation_managers(
@@ -3142,8 +3142,8 @@ input deployment_bool_exp {
   label: String_comparison_exp
   managers: manager_bool_exp
   managers_aggregate: manager_aggregate_bool_exp
-  orientationSystems: deployment_orientation_system_bool_exp
-  orientationSystems_aggregate: deployment_orientation_system_aggregate_bool_exp
+  orientationSystems: orientation_system_bool_exp
+  orientationSystems_aggregate: orientation_system_aggregate_bool_exp
   orientation_managers: orientation_manager_bool_exp
   orientation_managers_aggregate: orientation_manager_aggregate_bool_exp
   structures: structure_bool_exp
@@ -3193,7 +3193,7 @@ input deployment_insert_input {
   id: uuid
   label: String
   managers: manager_arr_rel_insert_input
-  orientationSystems: deployment_orientation_system_arr_rel_insert_input
+  orientationSystems: orientation_system_arr_rel_insert_input
   orientation_managers: orientation_manager_arr_rel_insert_input
   structures: structure_arr_rel_insert_input
   updatedAt: timestamptz
@@ -3254,252 +3254,10 @@ input deployment_order_by {
   id: order_by
   label: order_by
   managers_aggregate: manager_aggregate_order_by
-  orientationSystems_aggregate: deployment_orientation_system_aggregate_order_by
+  orientationSystems_aggregate: orientation_system_aggregate_order_by
   orientation_managers_aggregate: orientation_manager_aggregate_order_by
   structures_aggregate: structure_aggregate_order_by
   updatedAt: order_by
-}
-
-"""
-columns and relationships of "deployment_orientation_system"
-"""
-type deployment_orientation_system {
-  createdAt: timestamptz!
-
-  """An object relationship"""
-  deployment: deployment!
-  deploymentId: uuid!
-  id: uuid!
-
-  """An object relationship"""
-  orientationSystem: orientation_system!
-  orientationSystemId: uuid!
-}
-
-"""
-aggregated selection of "deployment_orientation_system"
-"""
-type deployment_orientation_system_aggregate {
-  aggregate: deployment_orientation_system_aggregate_fields
-  nodes: [deployment_orientation_system!]!
-}
-
-input deployment_orientation_system_aggregate_bool_exp {
-  count: deployment_orientation_system_aggregate_bool_exp_count
-}
-
-input deployment_orientation_system_aggregate_bool_exp_count {
-  arguments: [deployment_orientation_system_select_column!]
-  distinct: Boolean
-  filter: deployment_orientation_system_bool_exp
-  predicate: Int_comparison_exp!
-}
-
-"""
-aggregate fields of "deployment_orientation_system"
-"""
-type deployment_orientation_system_aggregate_fields {
-  count(columns: [deployment_orientation_system_select_column!], distinct: Boolean): Int!
-  max: deployment_orientation_system_max_fields
-  min: deployment_orientation_system_min_fields
-}
-
-"""
-order by aggregate values of table "deployment_orientation_system"
-"""
-input deployment_orientation_system_aggregate_order_by {
-  count: order_by
-  max: deployment_orientation_system_max_order_by
-  min: deployment_orientation_system_min_order_by
-}
-
-"""
-input type for inserting array relation for remote table "deployment_orientation_system"
-"""
-input deployment_orientation_system_arr_rel_insert_input {
-  data: [deployment_orientation_system_insert_input!]!
-
-  """upsert condition"""
-  on_conflict: deployment_orientation_system_on_conflict
-}
-
-"""
-Boolean expression to filter rows from the table "deployment_orientation_system". All fields are combined with a logical 'AND'.
-"""
-input deployment_orientation_system_bool_exp {
-  _and: [deployment_orientation_system_bool_exp!]
-  _not: deployment_orientation_system_bool_exp
-  _or: [deployment_orientation_system_bool_exp!]
-  createdAt: timestamptz_comparison_exp
-  deployment: deployment_bool_exp
-  deploymentId: uuid_comparison_exp
-  id: uuid_comparison_exp
-  orientationSystem: orientation_system_bool_exp
-  orientationSystemId: uuid_comparison_exp
-}
-
-"""
-unique or primary key constraints on table "deployment_orientation_system"
-"""
-enum deployment_orientation_system_constraint {
-  """
-  unique or primary key constraint on columns "id"
-  """
-  deployment_orientation_system_pkey
-}
-
-"""
-input type for inserting data into table "deployment_orientation_system"
-"""
-input deployment_orientation_system_insert_input {
-  createdAt: timestamptz
-  deployment: deployment_obj_rel_insert_input
-  deploymentId: uuid
-  id: uuid
-  orientationSystem: orientation_system_obj_rel_insert_input
-  orientationSystemId: uuid
-}
-
-"""aggregate max on columns"""
-type deployment_orientation_system_max_fields {
-  createdAt: timestamptz
-  deploymentId: uuid
-  id: uuid
-  orientationSystemId: uuid
-}
-
-"""
-order by max() on columns of table "deployment_orientation_system"
-"""
-input deployment_orientation_system_max_order_by {
-  createdAt: order_by
-  deploymentId: order_by
-  id: order_by
-  orientationSystemId: order_by
-}
-
-"""aggregate min on columns"""
-type deployment_orientation_system_min_fields {
-  createdAt: timestamptz
-  deploymentId: uuid
-  id: uuid
-  orientationSystemId: uuid
-}
-
-"""
-order by min() on columns of table "deployment_orientation_system"
-"""
-input deployment_orientation_system_min_order_by {
-  createdAt: order_by
-  deploymentId: order_by
-  id: order_by
-  orientationSystemId: order_by
-}
-
-"""
-response of any mutation on the table "deployment_orientation_system"
-"""
-type deployment_orientation_system_mutation_response {
-  """number of rows affected by the mutation"""
-  affected_rows: Int!
-
-  """data from the rows affected by the mutation"""
-  returning: [deployment_orientation_system!]!
-}
-
-"""
-on_conflict condition type for table "deployment_orientation_system"
-"""
-input deployment_orientation_system_on_conflict {
-  constraint: deployment_orientation_system_constraint!
-  update_columns: [deployment_orientation_system_update_column!]! = []
-  where: deployment_orientation_system_bool_exp
-}
-
-"""
-Ordering options when selecting data from "deployment_orientation_system".
-"""
-input deployment_orientation_system_order_by {
-  createdAt: order_by
-  deployment: deployment_order_by
-  deploymentId: order_by
-  id: order_by
-  orientationSystem: orientation_system_order_by
-  orientationSystemId: order_by
-}
-
-"""primary key columns input for table: deployment_orientation_system"""
-input deployment_orientation_system_pk_columns_input {
-  id: uuid!
-}
-
-"""
-select columns of table "deployment_orientation_system"
-"""
-enum deployment_orientation_system_select_column {
-  """column name"""
-  createdAt
-
-  """column name"""
-  deploymentId
-
-  """column name"""
-  id
-
-  """column name"""
-  orientationSystemId
-}
-
-"""
-input type for updating data in table "deployment_orientation_system"
-"""
-input deployment_orientation_system_set_input {
-  createdAt: timestamptz
-  deploymentId: uuid
-  id: uuid
-  orientationSystemId: uuid
-}
-
-"""
-Streaming cursor of the table "deployment_orientation_system"
-"""
-input deployment_orientation_system_stream_cursor_input {
-  """Stream column input with initial value"""
-  initial_value: deployment_orientation_system_stream_cursor_value_input!
-
-  """cursor ordering"""
-  ordering: cursor_ordering
-}
-
-"""Initial value of the column from where the streaming should start"""
-input deployment_orientation_system_stream_cursor_value_input {
-  createdAt: timestamptz
-  deploymentId: uuid
-  id: uuid
-  orientationSystemId: uuid
-}
-
-"""
-update columns of table "deployment_orientation_system"
-"""
-enum deployment_orientation_system_update_column {
-  """column name"""
-  createdAt
-
-  """column name"""
-  deploymentId
-
-  """column name"""
-  id
-
-  """column name"""
-  orientationSystemId
-}
-
-input deployment_orientation_system_updates {
-  """sets the columns of the filtered rows to the given values"""
-  _set: deployment_orientation_system_set_input
-  where: deployment_orientation_system_bool_exp!
 }
 
 """primary key columns input for table: deployment"""
@@ -4769,19 +4527,6 @@ type mutation_root {
   delete_deployment_by_pk(id: uuid!): deployment
 
   """
-  delete data from the table: "deployment_orientation_system"
-  """
-  delete_deployment_orientation_system(
-    """filter the rows which have to be deleted"""
-    where: deployment_orientation_system_bool_exp!
-  ): deployment_orientation_system_mutation_response
-
-  """
-  delete single row from the table: "deployment_orientation_system"
-  """
-  delete_deployment_orientation_system_by_pk(id: uuid!): deployment_orientation_system
-
-  """
   delete data from the table: "external_data"
   """
   delete_external_data(
@@ -5293,28 +5038,6 @@ type mutation_root {
     """upsert condition"""
     on_conflict: deployment_on_conflict
   ): deployment
-
-  """
-  insert data into the table: "deployment_orientation_system"
-  """
-  insert_deployment_orientation_system(
-    """the rows to be inserted"""
-    objects: [deployment_orientation_system_insert_input!]!
-
-    """upsert condition"""
-    on_conflict: deployment_orientation_system_on_conflict
-  ): deployment_orientation_system_mutation_response
-
-  """
-  insert a single row into the table: "deployment_orientation_system"
-  """
-  insert_deployment_orientation_system_one(
-    """the row to be inserted"""
-    object: deployment_orientation_system_insert_input!
-
-    """upsert condition"""
-    on_conflict: deployment_orientation_system_on_conflict
-  ): deployment_orientation_system
 
   """
   insert data into the table: "external_data"
@@ -6205,34 +5928,6 @@ type mutation_root {
     """updates to execute, in order"""
     updates: [deployment_updates!]!
   ): [deployment_mutation_response]
-
-  """
-  update data of the table: "deployment_orientation_system"
-  """
-  update_deployment_orientation_system(
-    """sets the columns of the filtered rows to the given values"""
-    _set: deployment_orientation_system_set_input
-
-    """filter the rows which have to be updated"""
-    where: deployment_orientation_system_bool_exp!
-  ): deployment_orientation_system_mutation_response
-
-  """
-  update single row of the table: "deployment_orientation_system"
-  """
-  update_deployment_orientation_system_by_pk(
-    """sets the columns of the filtered rows to the given values"""
-    _set: deployment_orientation_system_set_input
-    pk_columns: deployment_orientation_system_pk_columns_input!
-  ): deployment_orientation_system
-
-  """
-  update multiples rows of table: "deployment_orientation_system"
-  """
-  update_deployment_orientation_system_many(
-    """updates to execute, in order"""
-    updates: [deployment_orientation_system_updates!]!
-  ): [deployment_orientation_system_mutation_response]
 
   """
   update data of the table: "external_data"
@@ -7259,6 +6954,7 @@ type notebook {
   ): notebook_focus_aggregate!
   geographicalArea: String
   id: uuid!
+  lastJobEndedAt: date
 
   """An array relationship"""
   members(
@@ -8027,6 +7723,7 @@ input notebook_bool_exp {
   focuses_aggregate: notebook_focus_aggregate_bool_exp
   geographicalArea: String_comparison_exp
   id: uuid_comparison_exp
+  lastJobEndedAt: date_comparison_exp
   members: notebook_member_bool_exp
   members_aggregate: notebook_member_aggregate_bool_exp
   notebookInfo: notebook_info_bool_exp
@@ -9251,6 +8948,7 @@ input notebook_insert_input {
   focuses: notebook_focus_arr_rel_insert_input
   geographicalArea: String
   id: uuid
+  lastJobEndedAt: date
   members: notebook_member_arr_rel_insert_input
   notebookInfo: notebook_info_obj_rel_insert_input
   rightAre: Boolean
@@ -9276,6 +8974,7 @@ type notebook_max_fields {
   educationLevel: String
   geographicalArea: String
   id: uuid
+  lastJobEndedAt: date
   rightRsa: String
   updatedAt: timestamptz
   workSituation: String
@@ -9689,6 +9388,7 @@ type notebook_min_fields {
   educationLevel: String
   geographicalArea: String
   id: uuid
+  lastJobEndedAt: date
   rightRsa: String
   updatedAt: timestamptz
   workSituation: String
@@ -9741,6 +9441,7 @@ input notebook_order_by {
   focuses_aggregate: notebook_focus_aggregate_order_by
   geographicalArea: order_by
   id: order_by
+  lastJobEndedAt: order_by
   members_aggregate: notebook_member_aggregate_order_by
   notebookInfo: notebook_info_order_by
   notebookMemberCount: order_by
@@ -9988,6 +9689,9 @@ enum notebook_select_column {
   id
 
   """column name"""
+  lastJobEndedAt
+
+  """column name"""
   rightAre
 
   """column name"""
@@ -10028,6 +9732,7 @@ input notebook_set_input {
   educationLevel: String
   geographicalArea: String
   id: uuid
+  lastJobEndedAt: date
   rightAre: Boolean
   rightAss: Boolean
   rightBonus: Boolean
@@ -10061,6 +9766,7 @@ input notebook_stream_cursor_value_input {
   educationLevel: String
   geographicalArea: String
   id: uuid
+  lastJobEndedAt: date
   rightAre: Boolean
   rightAss: Boolean
   rightBonus: Boolean
@@ -10444,6 +10150,9 @@ enum notebook_update_column {
 
   """column name"""
   id
+
+  """column name"""
+  lastJobEndedAt
 
   """column name"""
   rightAre
@@ -10889,8 +10598,8 @@ type orientation_request {
   reason: String
 
   """An object relationship"""
-  requestedOrientationSystem: orientation_system
-  requestedOrientationSystemId: uuid
+  requestedOrientationSystem: orientation_system!
+  requestedOrientationSystemId: uuid!
 
   """An object relationship"""
   requestor: account
@@ -11223,43 +10932,13 @@ input orientation_request_updates {
 columns and relationships of "orientation_system"
 """
 type orientation_system {
+  """An object relationship"""
+  beneficiaries: notebook_info
   createdAt: timestamptz!
 
-  """An array relationship"""
-  deploymentOrientationSystems(
-    """distinct select on columns"""
-    distinct_on: [deployment_orientation_system_select_column!]
-
-    """limit the number of rows returned"""
-    limit: Int
-
-    """skip the first n rows. Use only with order_by"""
-    offset: Int
-
-    """sort the rows by one or more columns"""
-    order_by: [deployment_orientation_system_order_by!]
-
-    """filter the rows returned"""
-    where: deployment_orientation_system_bool_exp
-  ): [deployment_orientation_system!]!
-
-  """An aggregate relationship"""
-  deploymentOrientationSystems_aggregate(
-    """distinct select on columns"""
-    distinct_on: [deployment_orientation_system_select_column!]
-
-    """limit the number of rows returned"""
-    limit: Int
-
-    """skip the first n rows. Use only with order_by"""
-    offset: Int
-
-    """sort the rows by one or more columns"""
-    order_by: [deployment_orientation_system_order_by!]
-
-    """filter the rows returned"""
-    where: deployment_orientation_system_bool_exp
-  ): deployment_orientation_system_aggregate!
+  """An object relationship"""
+  deployment: deployment!
+  deployment_id: uuid!
   id: uuid!
   name: String!
   orientationType: orientation_type_enum!
@@ -11395,9 +11074,10 @@ input orientation_system_bool_exp {
   _and: [orientation_system_bool_exp!]
   _not: orientation_system_bool_exp
   _or: [orientation_system_bool_exp!]
+  beneficiaries: notebook_info_bool_exp
   createdAt: timestamptz_comparison_exp
-  deploymentOrientationSystems: deployment_orientation_system_bool_exp
-  deploymentOrientationSystems_aggregate: deployment_orientation_system_aggregate_bool_exp
+  deployment: deployment_bool_exp
+  deployment_id: uuid_comparison_exp
   id: uuid_comparison_exp
   name: String_comparison_exp
   orientationType: orientation_type_enum_comparison_exp
@@ -11414,6 +11094,11 @@ unique or primary key constraints on table "orientation_system"
 """
 enum orientation_system_constraint {
   """
+  unique or primary key constraint on columns "deployment_id"
+  """
+  name_deployment_id_unique_idx
+
+  """
   unique or primary key constraint on columns "id"
   """
   orientation_system_pkey
@@ -11423,8 +11108,10 @@ enum orientation_system_constraint {
 input type for inserting data into table "orientation_system"
 """
 input orientation_system_insert_input {
+  beneficiaries: notebook_info_obj_rel_insert_input
   createdAt: timestamptz
-  deploymentOrientationSystems: deployment_orientation_system_arr_rel_insert_input
+  deployment: deployment_obj_rel_insert_input
+  deployment_id: uuid
   id: uuid
   name: String
   orientationType: orientation_type_enum
@@ -11437,6 +11124,7 @@ input orientation_system_insert_input {
 """aggregate max on columns"""
 type orientation_system_max_fields {
   createdAt: timestamptz
+  deployment_id: uuid
   id: uuid
   name: String
   updatedAt: timestamptz
@@ -11447,6 +11135,7 @@ order by max() on columns of table "orientation_system"
 """
 input orientation_system_max_order_by {
   createdAt: order_by
+  deployment_id: order_by
   id: order_by
   name: order_by
   updatedAt: order_by
@@ -11455,6 +11144,7 @@ input orientation_system_max_order_by {
 """aggregate min on columns"""
 type orientation_system_min_fields {
   createdAt: timestamptz
+  deployment_id: uuid
   id: uuid
   name: String
   updatedAt: timestamptz
@@ -11465,6 +11155,7 @@ order by min() on columns of table "orientation_system"
 """
 input orientation_system_min_order_by {
   createdAt: order_by
+  deployment_id: order_by
   id: order_by
   name: order_by
   updatedAt: order_by
@@ -11502,8 +11193,10 @@ input orientation_system_on_conflict {
 
 """Ordering options when selecting data from "orientation_system"."""
 input orientation_system_order_by {
+  beneficiaries: notebook_info_order_by
   createdAt: order_by
-  deploymentOrientationSystems_aggregate: deployment_orientation_system_aggregate_order_by
+  deployment: deployment_order_by
+  deployment_id: order_by
   id: order_by
   name: order_by
   orientationType: order_by
@@ -11526,6 +11219,9 @@ enum orientation_system_select_column {
   createdAt
 
   """column name"""
+  deployment_id
+
+  """column name"""
   id
 
   """column name"""
@@ -11543,6 +11239,7 @@ input type for updating data in table "orientation_system"
 """
 input orientation_system_set_input {
   createdAt: timestamptz
+  deployment_id: uuid
   id: uuid
   name: String
   orientationType: orientation_type_enum
@@ -11563,6 +11260,7 @@ input orientation_system_stream_cursor_input {
 """Initial value of the column from where the streaming should start"""
 input orientation_system_stream_cursor_value_input {
   createdAt: timestamptz
+  deployment_id: uuid
   id: uuid
   name: String
   orientationType: orientation_type_enum
@@ -11575,6 +11273,9 @@ update columns of table "orientation_system"
 enum orientation_system_update_column {
   """column name"""
   createdAt
+
+  """column name"""
+  deployment_id
 
   """column name"""
   id
@@ -12161,6 +11862,11 @@ enum professional_orientation_system_constraint {
   unique or primary key constraint on columns "id"
   """
   professional_orientation_system_pkey
+
+  """
+  unique or primary key constraint on columns "orientation_system_id", "professional_id"
+  """
+  professional_orientation_system_professional_id_orientation_sys
 }
 
 """
@@ -12776,51 +12482,6 @@ type query_root {
 
   """fetch data from the table: "deployment" using primary key columns"""
   deployment_by_pk(id: uuid!): deployment
-
-  """
-  fetch data from the table: "deployment_orientation_system"
-  """
-  deployment_orientation_system(
-    """distinct select on columns"""
-    distinct_on: [deployment_orientation_system_select_column!]
-
-    """limit the number of rows returned"""
-    limit: Int
-
-    """skip the first n rows. Use only with order_by"""
-    offset: Int
-
-    """sort the rows by one or more columns"""
-    order_by: [deployment_orientation_system_order_by!]
-
-    """filter the rows returned"""
-    where: deployment_orientation_system_bool_exp
-  ): [deployment_orientation_system!]!
-
-  """
-  fetch aggregated fields from the table: "deployment_orientation_system"
-  """
-  deployment_orientation_system_aggregate(
-    """distinct select on columns"""
-    distinct_on: [deployment_orientation_system_select_column!]
-
-    """limit the number of rows returned"""
-    limit: Int
-
-    """skip the first n rows. Use only with order_by"""
-    offset: Int
-
-    """sort the rows by one or more columns"""
-    order_by: [deployment_orientation_system_order_by!]
-
-    """filter the rows returned"""
-    where: deployment_orientation_system_bool_exp
-  ): deployment_orientation_system_aggregate!
-
-  """
-  fetch data from the table: "deployment_orientation_system" using primary key columns
-  """
-  deployment_orientation_system_by_pk(id: uuid!): deployment_orientation_system
 
   """An array relationship"""
   external_data(
@@ -15260,9 +14921,6 @@ type structure {
     """filter the rows returned"""
     where: beneficiary_structure_bool_exp
   ): beneficiary_structure_aggregate!
-
-  """a computed field, executes function nb_beneficiary_for_structure """
-  beneficiaryCount: bigint
   city: String
   createdAt: timestamptz
 
@@ -15412,7 +15070,6 @@ input structure_bool_exp {
   admins_aggregate: admin_structure_structure_aggregate_bool_exp
   beneficiaries: beneficiary_structure_bool_exp
   beneficiaries_aggregate: beneficiary_structure_aggregate_bool_exp
-  beneficiaryCount: bigint_comparison_exp
   city: String_comparison_exp
   createdAt: timestamptz_comparison_exp
   deployment: deployment_bool_exp
@@ -15584,7 +15241,6 @@ input structure_order_by {
   address2: order_by
   admins_aggregate: admin_structure_structure_aggregate_order_by
   beneficiaries_aggregate: beneficiary_structure_aggregate_order_by
-  beneficiaryCount: order_by
   city: order_by
   createdAt: order_by
   deployment: deployment_order_by
@@ -15688,6 +15344,11 @@ enum structure_orientation_system_constraint {
   unique or primary key constraint on columns "id"
   """
   structure_orientation_system_pkey
+
+  """
+  unique or primary key constraint on columns "structure_id", "orientation_system_id"
+  """
+  structure_orientation_system_structure_id_orientation_system_id
 }
 
 """
@@ -16441,65 +16102,6 @@ type subscription_root {
 
   """fetch data from the table: "deployment" using primary key columns"""
   deployment_by_pk(id: uuid!): deployment
-
-  """
-  fetch data from the table: "deployment_orientation_system"
-  """
-  deployment_orientation_system(
-    """distinct select on columns"""
-    distinct_on: [deployment_orientation_system_select_column!]
-
-    """limit the number of rows returned"""
-    limit: Int
-
-    """skip the first n rows. Use only with order_by"""
-    offset: Int
-
-    """sort the rows by one or more columns"""
-    order_by: [deployment_orientation_system_order_by!]
-
-    """filter the rows returned"""
-    where: deployment_orientation_system_bool_exp
-  ): [deployment_orientation_system!]!
-
-  """
-  fetch aggregated fields from the table: "deployment_orientation_system"
-  """
-  deployment_orientation_system_aggregate(
-    """distinct select on columns"""
-    distinct_on: [deployment_orientation_system_select_column!]
-
-    """limit the number of rows returned"""
-    limit: Int
-
-    """skip the first n rows. Use only with order_by"""
-    offset: Int
-
-    """sort the rows by one or more columns"""
-    order_by: [deployment_orientation_system_order_by!]
-
-    """filter the rows returned"""
-    where: deployment_orientation_system_bool_exp
-  ): deployment_orientation_system_aggregate!
-
-  """
-  fetch data from the table: "deployment_orientation_system" using primary key columns
-  """
-  deployment_orientation_system_by_pk(id: uuid!): deployment_orientation_system
-
-  """
-  fetch data from the table in a streaming manner: "deployment_orientation_system"
-  """
-  deployment_orientation_system_stream(
-    """maximum number of rows returned in a single batch"""
-    batch_size: Int!
-
-    """cursor to stream the results returned by the query"""
-    cursor: [deployment_orientation_system_stream_cursor_input]!
-
-    """filter the rows returned"""
-    where: deployment_orientation_system_bool_exp
-  ): [deployment_orientation_system!]!
 
   """
   fetch data from the table in a streaming manner: "deployment"

--- a/e2e/features/pro/carnet/sociopro.feature
+++ b/e2e/features/pro/carnet/sociopro.feature
@@ -10,8 +10,10 @@ Fonctionnalité: Informations sur la situation socioprofessionnelle
 		Alors je vois "Situation actuelle"
 		Quand je renseigne la date "20/06/2020" dans le champ "Depuis le"
 		Quand je clique sur le texte "12 mois"
+		Quand je renseigne la date "10/01/2020" dans le champ "Date de fin du dernier emploi"
 		Quand je clique sur "Enregistrer"
 		Alors je vois "Du 20/06/2020 au 20/06/2021 (12 mois)"
+		Alors je vois "10/01/2020"
 
 
 	Scénario: Saisie des informations socioprofessionnelles 2 ans

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook.yaml
@@ -19,6 +19,8 @@ configuration:
       custom_name: educationLevel
     geographical_area:
       custom_name: geographicalArea
+    last_job_ended_at:
+      custom_name: lastJobEndedAt
     right_are:
       custom_name: rightAre
     right_ass:
@@ -46,6 +48,7 @@ configuration:
     created_at: createdAt
     education_level: educationLevel
     geographical_area: geographicalArea
+    last_job_ended_at: lastJobEndedAt
     right_are: rightAre
     right_ass: rightAss
     right_bonus: rightBonus
@@ -140,34 +143,15 @@ insert_permissions:
             _eq: X-Hasura-Deployment-Id
       columns:
         - beneficiary_id
+        - contract_end_date
         - contract_sign_date
         - contract_start_date
-        - contract_end_date
         - contract_type
         - created_at
         - education_level
         - geographical_area
         - id
-        - right_are
-        - right_ass
-        - right_bonus
-        - right_rqth
-        - right_rsa
-        - work_situation
-        - work_situation_date
-        - work_situation_end_date
-  - role: professional
-    permission:
-      check: {}
-      columns:
-        - beneficiary_id
-        - contract_sign_date
-        - contract_start_date
-        - contract_end_date
-        - contract_type
-        - created_at
-        - education_level
-        - geographical_area
+        - last_job_ended_at
         - right_are
         - right_ass
         - right_bonus
@@ -181,14 +165,15 @@ select_permissions:
     permission:
       columns:
         - beneficiary_id
+        - contract_end_date
         - contract_sign_date
         - contract_start_date
-        - contract_end_date
         - contract_type
         - created_at
         - education_level
         - geographical_area
         - id
+        - last_job_ended_at
         - right_are
         - right_ass
         - right_bonus
@@ -206,14 +191,15 @@ select_permissions:
     permission:
       columns:
         - beneficiary_id
+        - contract_end_date
         - contract_sign_date
         - contract_start_date
-        - contract_end_date
         - contract_type
         - created_at
         - education_level
         - geographical_area
         - id
+        - last_job_ended_at
         - right_are
         - right_ass
         - right_bonus
@@ -248,14 +234,15 @@ select_permissions:
     permission:
       columns:
         - beneficiary_id
+        - contract_end_date
         - contract_sign_date
         - contract_start_date
-        - contract_end_date
         - contract_type
         - created_at
         - education_level
         - geographical_area
         - id
+        - last_job_ended_at
         - right_are
         - right_ass
         - right_bonus
@@ -274,14 +261,15 @@ select_permissions:
     permission:
       columns:
         - beneficiary_id
+        - contract_end_date
         - contract_sign_date
         - contract_start_date
-        - contract_end_date
         - contract_type
         - created_at
         - education_level
         - geographical_area
         - id
+        - last_job_ended_at
         - right_are
         - right_ass
         - right_bonus
@@ -301,24 +289,25 @@ select_permissions:
   - role: orientation_manager
     permission:
       columns:
-        - id
         - beneficiary_id
+        - contract_end_date
+        - contract_sign_date
+        - contract_start_date
+        - contract_type
         - created_at
-        - right_rsa
-        - right_rqth
+        - education_level
+        - geographical_area
+        - id
+        - last_job_ended_at
         - right_are
         - right_ass
         - right_bonus
-        - geographical_area
-        - education_level
-        - work_situation_date
-        - contract_type
-        - contract_sign_date
-        - work_situation
+        - right_rqth
+        - right_rsa
         - updated_at
+        - work_situation
+        - work_situation_date
         - work_situation_end_date
-        - contract_start_date
-        - contract_end_date
       computed_fields:
         - notebookMemberCount
       filter:
@@ -330,14 +319,15 @@ select_permissions:
     permission:
       columns:
         - beneficiary_id
+        - contract_end_date
         - contract_sign_date
         - contract_start_date
-        - contract_end_date
         - contract_type
         - created_at
         - education_level
         - geographical_area
         - id
+        - last_job_ended_at
         - right_are
         - right_ass
         - right_bonus
@@ -359,23 +349,24 @@ update_permissions:
   - role: admin_cdb
     permission:
       columns:
+        - beneficiary_id
+        - contract_end_date
+        - contract_sign_date
+        - contract_start_date
+        - contract_type
+        - created_at
+        - education_level
+        - geographical_area
+        - id
+        - last_job_ended_at
         - right_are
         - right_ass
         - right_bonus
         - right_rqth
-        - contract_type
-        - education_level
-        - geographical_area
         - right_rsa
         - work_situation
-        - contract_sign_date
-        - contract_start_date
-        - contract_end_date
         - work_situation_date
         - work_situation_end_date
-        - created_at
-        - beneficiary_id
-        - id
       filter: {}
       check: {}
   - role: orientation_manager
@@ -387,6 +378,7 @@ update_permissions:
         - contract_type
         - education_level
         - geographical_area
+        - last_job_ended_at
         - right_are
         - right_ass
         - right_bonus
@@ -406,13 +398,14 @@ update_permissions:
   - role: professional
     permission:
       columns:
+        - contract_end_date
         - contract_sign_date
         - contract_start_date
-        - contract_end_date
         - contract_type
         - created_at
         - education_level
         - geographical_area
+        - last_job_ended_at
         - right_are
         - right_ass
         - right_bonus

--- a/hasura/migrations/carnet_de_bord/1675941150892_alter_table_public_notebook_add_column_last_job_date/down.sql
+++ b/hasura/migrations/carnet_de_bord/1675941150892_alter_table_public_notebook_add_column_last_job_date/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."notebook" drop column "last_job_ended_at";

--- a/hasura/migrations/carnet_de_bord/1675941150892_alter_table_public_notebook_add_column_last_job_date/up.sql
+++ b/hasura/migrations/carnet_de_bord/1675941150892_alter_table_public_notebook_add_column_last_job_date/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."notebook" add column "last_job_ended_at" date null;


### PR DESCRIPTION
## :wrench: Problème

Actuellement nous n'avons pas la date du dernier emploi dans carnet de bord. On souhaiterait la rajouter comme information dans le bloc du diagnostic socio-professionnel.

## :cake: Solution

On rajoute le champs dans le bloc de diagnostic et dans le formulaire de mise à jour des infos sociopro

## :rotating_light:  Points d'attention / Remarques

la date du dernier emploi est enregistrée dans le champs `last_job_ended_at` dans la table `notebook`

## :desert_island: Comment tester

- Se connecter en tant que pierre.chevalier
- Aller sur le carnet de `sophie.tifour`
- Éditer les infos socio professionnelles
- saisir une date dans le champs date de fin du dernier emploi
- Valider
- S'assurer que la date s'affiche bien dans le bloc `Diagnostic socioprofessionnel` 

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1513.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

fix #1512 
