### PR TITLE
feat: ajout de la situation personnelle

### DIFF
--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -43,15 +43,34 @@ type alias PersonalSituationElement =
 -- TODO: add structure name somewhere
 
 
-type alias Person =
+type alias Structure =
+    { name : String
+    }
+
+
+type alias Professional =
+    { firstname : String
+    , lastname : String
+    , structure : Maybe Structure
+    }
+
+
+type alias OrientationManager =
     { firstname : String
     , lastname : String
     }
 
 
 type alias Account =
-    { professional : Maybe Person
-    , orientation_manager : Maybe Person
+    { professional : Maybe Professional
+    , orientation_manager : Maybe OrientationManager
+    }
+
+
+type alias Creator =
+    { firstname : String
+    , lastname : String
+    , structure : Maybe String
     }
 
 
@@ -118,7 +137,16 @@ extractPersonalSituationFromFlags flags =
         flags.createdAt
             |> fromIsoString
             |> Result.toMaybe
-    , creator = "" -- TODO: build the creator + structureName from received account
+    , creator =
+        case ( flags.creator.professional, flags.creator.orientation_manager ) of
+            ( Just p, _ ) ->
+                p.firstname ++ " " ++ p.lastname ++ Maybe.withDefault "" (Maybe.map (\s -> " (" ++ s.name ++ ")") p.structure)
+
+            ( _, Just o ) ->
+                o.firstname ++ " " ++ o.lastname
+
+            _ ->
+                ""
     }
 
 

--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -414,7 +414,9 @@ personalSituationView { personalSituations } =
                             (\personalSituation ->
                                 tr []
                                     [ td [] [ personalSituation.theme |> themeKeyToString |> text ]
-                                    , td [] [ text <| String.join "," personalSituation.situations ]
+                                    , td []
+                                        [ ul [] (List.map (\situation -> li [] [ text situation ]) personalSituation.situations)
+                                        ]
                                     , td []
                                         [ Maybe.withDefault "-" (Maybe.map (Date.format dateFormat) personalSituation.createdAt)
                                             |> text

--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -2,6 +2,7 @@ module Diagnostic.Main exposing (..)
 
 import Browser
 import Date exposing (Date, fromIsoString)
+import Domain.Account exposing (Account)
 import Domain.PoleEmploi.GeneralData exposing (GeneralData)
 import Domain.ProfessionalProject exposing (ProfessionalProject)
 import Domain.ProfessionalSituation exposing (ProfessionalSituation, educationLevelKeyToString, geographicalAreaKeyToString, workSituationKeyToString)
@@ -36,30 +37,6 @@ type alias PersonalSituationElement =
     , situations : List String
     , createdAt : Maybe String
     , creator : String
-    }
-
-
-type alias Structure =
-    { name : String
-    }
-
-
-type alias Professional =
-    { firstname : String
-    , lastname : String
-    , structure : Maybe Structure
-    }
-
-
-type alias OrientationManager =
-    { firstname : String
-    , lastname : String
-    }
-
-
-type alias Account =
-    { professional : Maybe Professional
-    , orientation_manager : Maybe OrientationManager
     }
 
 

--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -5,6 +5,7 @@ import Date exposing (Date, fromIsoString)
 import Domain.PoleEmploi.GeneralData exposing (GeneralData)
 import Domain.ProfessionalProject exposing (ProfessionalProject)
 import Domain.ProfessionalSituation exposing (ProfessionalSituation, educationLevelKeyToString, geographicalAreaKeyToString, workSituationKeyToString)
+import Domain.Theme exposing (themeKeyToString)
 import Html exposing (..)
 import Html.Attributes exposing (class)
 
@@ -33,7 +34,7 @@ type alias ProfessionalSituationFlags =
 type alias PersonalSituationElement =
     { theme : String
     , situations : List String
-    , createdAt : String
+    , createdAt : Maybe Date
     , creator : String
     }
 
@@ -113,7 +114,10 @@ extractPersonalSituationFromFlags : PersonalSituationFlags -> PersonalSituationE
 extractPersonalSituationFromFlags flags =
     { theme = flags.theme
     , situations = flags.situations
-    , createdAt = flags.createdAt
+    , createdAt =
+        flags.createdAt
+            |> fromIsoString
+            |> Result.toMaybe
     , creator = "" -- TODO: build the creator + structureName from received account
     }
 
@@ -368,11 +372,30 @@ personalSituationView : Model -> Html msg
 personalSituationView { personalSituations } =
     div [ class "pt-10 flex flex-col" ]
         [ h3 [ class "text-xl" ] [ text "Situation personnelle" ]
-        , div [ class "fr-container shadow-dsfr rounded-lg pt-4" ]
-            [ ul []
-                (personalSituations
-                    |> List.map (\personalSituation -> li [] [ text personalSituation.theme ])
-                )
+        , div [ class "fr-table fr-table--layout-fixed shadow-dsfr rounded-lg" ]
+            [ table []
+                [ thead []
+                    [ th [] [ text "Thématique" ]
+                    , th [] [ text "Situation" ]
+                    , th [] [ text "Ajouté le" ]
+                    , th [] [ text "Ajouté par" ]
+                    ]
+                , tbody []
+                    (personalSituations
+                        |> List.map
+                            (\personalSituation ->
+                                tr []
+                                    [ td [] [ personalSituation.theme |> themeKeyToString |> text ]
+                                    , td [] [ text <| String.join "," personalSituation.situations ]
+                                    , td []
+                                        [ Maybe.withDefault "-" (Maybe.map (Date.format dateFormat) personalSituation.createdAt)
+                                            |> text
+                                        ]
+                                    , td [] [ text personalSituation.creator ]
+                                    ]
+                            )
+                    )
+                ]
             ]
         ]
 

--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -34,13 +34,9 @@ type alias ProfessionalSituationFlags =
 type alias PersonalSituationElement =
     { theme : String
     , situations : List String
-    , createdAt : Maybe Date
+    , createdAt : Maybe String
     , creator : String
     }
-
-
-
--- TODO: add structure name somewhere
 
 
 type alias Structure =
@@ -133,9 +129,7 @@ extractPersonalSituationFromFlags : PersonalSituationFlags -> PersonalSituationE
 extractPersonalSituationFromFlags flags =
     { theme = flags.theme
     , situations = flags.situations
-    , createdAt =
-        flags.createdAt
-            |> Maybe.andThen (fromIsoString >> Result.toMaybe)
+    , createdAt = flags.createdAt
     , creator =
         case ( flags.creator.professional, flags.creator.orientation_manager ) of
             ( Just p, _ ) ->
@@ -399,28 +393,28 @@ personalSituationView : Model -> Html msg
 personalSituationView { personalSituations } =
     div [ class "pt-10 flex flex-col" ]
         [ h3 [ class "text-xl" ] [ text "Situation personnelle" ]
-        , div [ class "fr-table fr-table--layout-fixed shadow-dsfr rounded-lg" ]
-            [ table []
-                [ thead []
-                    [ th [] [ text "Thématique" ]
-                    , th [] [ text "Situation" ]
-                    , th [] [ text "Ajouté le" ]
-                    , th [] [ text "Ajouté par" ]
+        , div [ class "fr-container shadow-dsfr rounded-lg py-8" ]
+            [ table [ class "w-full" ]
+                [ thead [ class "text-left pb-4" ]
+                    [ th [ class "font-normal text-sm leading-10 pl-2" ] [ text "Thématique" ]
+                    , th [ class "font-normal text-sm" ] [ text "Situation" ]
+                    , th [ class "font-normal text-sm" ] [ text "Ajouté le" ]
+                    , th [ class "font-normal text-sm" ] [ text "Ajouté par" ]
                     ]
                 , tbody []
                     (personalSituations
                         |> List.map
                             (\personalSituation ->
-                                tr []
-                                    [ td [] [ personalSituation.theme |> themeKeyToString |> text ]
-                                    , td []
-                                        [ ul [] (List.map (\situation -> li [] [ text situation ]) personalSituation.situations)
+                                tr [ class "odd:bg-gray-100 align-text-top" ]
+                                    [ td [ class "font-bold pr-8 pl-2 py-3" ] [ personalSituation.theme |> themeKeyToString |> text ]
+                                    , td [ class "font-bold pr-8 py-3" ]
+                                        [ ul [ class "list-none pl-0" ] (List.map (\situation -> li [] [ text situation ]) personalSituation.situations)
                                         ]
-                                    , td []
-                                        [ Maybe.withDefault "-" (Maybe.map (Date.format dateFormat) personalSituation.createdAt)
+                                    , td [ class "pr-8 py-3" ]
+                                        [ Maybe.withDefault "-" personalSituation.createdAt
                                             |> text
                                         ]
-                                    , td [] [ text personalSituation.creator ]
+                                    , td [ class "py-3" ] [ text personalSituation.creator ]
                                     ]
                             )
                     )

--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -403,6 +403,7 @@ personalSituationView { personalSituations } =
                     ]
                 , tbody []
                     (personalSituations
+                        |> List.filter (\personalSituation -> List.length personalSituation.situations > 0)
                         |> List.map
                             (\personalSituation ->
                                 tr [ class "odd:bg-gray-100 align-text-top" ]

--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -32,7 +32,7 @@ type alias ProfessionalSituationFlags =
 
 type alias PersonalSituationElement =
     { theme : String
-    , situation : String
+    , situations : List String
     , createdAt : String
     , creator : String
     }
@@ -56,7 +56,7 @@ type alias Account =
 
 type alias PersonalSituationFlags =
     { theme : String
-    , situation : String
+    , situations : List String
     , createdAt : String
     , creator : Account
     }
@@ -112,7 +112,7 @@ init flags =
 extractPersonalSituationFromFlags : PersonalSituationFlags -> PersonalSituationElement
 extractPersonalSituationFromFlags flags =
     { theme = flags.theme
-    , situation = flags.situation
+    , situations = flags.situations
     , createdAt = flags.createdAt
     , creator = "" -- TODO: build the creator + structureName from received account
     }

--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -30,9 +30,42 @@ type alias ProfessionalSituationFlags =
     }
 
 
+type alias PersonalSituationElement =
+    { theme : String
+    , situation : String
+    , createdAt : String
+    , creator : String
+    }
+
+
+
+-- TODO: add structure name somewhere
+
+
+type alias Person =
+    { firstname : String
+    , lastname : String
+    }
+
+
+type alias Account =
+    { professional : Maybe Person
+    , orientation_manager : Maybe Person
+    }
+
+
+type alias PersonalSituationFlags =
+    { theme : String
+    , situation : String
+    , createdAt : String
+    , creator : Account
+    }
+
+
 type alias Flags =
     { professionalSituation : ProfessionalSituationFlags
     , peGeneralData : Maybe PeFlags
+    , personalSituations : Maybe (List PersonalSituationFlags)
     }
 
 
@@ -61,6 +94,7 @@ type alias Model =
     { professionalSituation : ProfessionalSituation
     , professionalProjects : List ProfessionalProject
     , peGeneralData : GeneralData
+    , personalSituations : List PersonalSituationElement
     }
 
 
@@ -69,9 +103,24 @@ init flags =
     ( { professionalSituation = extractSituationFromFlags flags
       , professionalProjects = []
       , peGeneralData = extractPeGeneralDataFromFlags flags
+      , personalSituations = extractPersonalSituationsFromFlags flags
       }
     , Cmd.none
     )
+
+
+extractPersonalSituationFromFlags : PersonalSituationFlags -> PersonalSituationElement
+extractPersonalSituationFromFlags flags =
+    { theme = flags.theme
+    , situation = flags.situation
+    , createdAt = flags.createdAt
+    , creator = "" -- TODO: build the creator + structureName from received account
+    }
+
+
+extractPersonalSituationsFromFlags : Flags -> List PersonalSituationElement
+extractPersonalSituationsFromFlags { personalSituations } =
+    List.map extractPersonalSituationFromFlags (Maybe.withDefault [] personalSituations)
 
 
 extractSituationFromFlags : Flags -> ProfessionalSituation
@@ -140,7 +189,7 @@ unfilled genderType =
 
 view : Model -> Html msg
 view model =
-    div [ class "mb-10" ] (socioProDiagFirstRowView model ++ [ professionalProjectView model ])
+    div [ class "mb-10" ] (socioProDiagFirstRowView model ++ [ professionalProjectView model, personalSituationView model ])
 
 
 workSituationDateFormat : Maybe Date -> Maybe Date -> Maybe (Html msg)
@@ -311,6 +360,19 @@ professionalProjectView model =
                         Nothing
                     ]
                 ]
+            ]
+        ]
+
+
+personalSituationView : Model -> Html msg
+personalSituationView { personalSituations } =
+    div [ class "pt-10 flex flex-col" ]
+        [ h3 [ class "text-xl" ] [ text "Situation personnelle" ]
+        , div [ class "fr-container shadow-dsfr rounded-lg pt-4" ]
+            [ ul []
+                (personalSituations
+                    |> List.map (\personalSituation -> li [] [ text personalSituation.theme ])
+                )
             ]
         ]
 

--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -77,7 +77,7 @@ type alias Creator =
 type alias PersonalSituationFlags =
     { theme : String
     , situations : List String
-    , createdAt : String
+    , createdAt : Maybe String
     , creator : Account
     }
 
@@ -135,8 +135,7 @@ extractPersonalSituationFromFlags flags =
     , situations = flags.situations
     , createdAt =
         flags.createdAt
-            |> fromIsoString
-            |> Result.toMaybe
+            |> Maybe.andThen (fromIsoString >> Result.toMaybe)
     , creator =
         case ( flags.creator.professional, flags.creator.orientation_manager ) of
             ( Just p, _ ) ->

--- a/app/elm/Diagnostic/Main.elm.d.ts
+++ b/app/elm/Diagnostic/Main.elm.d.ts
@@ -10,6 +10,15 @@ export type Flags = {
 		lastJobEndedAt: string | undefined;
 	};
 	peGeneralData: { [name: string]: string };
+	personalSituations: {
+		situations?: any;
+		theme: string;
+		createdAt?: string;
+		creator: {
+			professional?: { firstname?: string; lastname?: string; structure: { name: string } };
+			orientation_manager?: { firstname?: string; lastname?: string };
+		};
+	}[];
 };
 
 export type Ports = {};

--- a/app/elm/Domain/Account.elm
+++ b/app/elm/Domain/Account.elm
@@ -1,0 +1,22 @@
+module Domain.Account exposing (Account, OrientationManager, Professional)
+
+import Domain.Structure exposing (Structure)
+
+
+type alias Professional =
+    { firstname : String
+    , lastname : String
+    , structure : Maybe Structure
+    }
+
+
+type alias OrientationManager =
+    { firstname : String
+    , lastname : String
+    }
+
+
+type alias Account =
+    { professional : Maybe Professional
+    , orientation_manager : Maybe OrientationManager
+    }

--- a/app/elm/Domain/Structure.elm
+++ b/app/elm/Domain/Structure.elm
@@ -1,0 +1,6 @@
+module Domain.Structure exposing (Structure)
+
+
+type alias Structure =
+    { name : String
+    }

--- a/app/elm/Domain/Theme.elm
+++ b/app/elm/Domain/Theme.elm
@@ -1,0 +1,38 @@
+module Domain.Theme exposing (..)
+
+
+themeKeyToString : String -> String
+themeKeyToString key =
+    case key of
+        "logement" ->
+            "Logement"
+
+        "emploi" ->
+            "Emploi"
+
+        "formation" ->
+            "Formation"
+
+        "difficulte_administrative" ->
+            "Difficultés administratives"
+
+        "difficulte_financiere" ->
+            "Difficultés financières"
+
+        "mobilite" ->
+            "Mobilité"
+
+        "sante" ->
+            "Santé"
+
+        "contraintes_familiales" ->
+            "Contraintes familiales"
+
+        "maitrise_langue" ->
+            "Maîtrise de la langue française"
+
+        "numerique" ->
+            "Numérique"
+
+        _ ->
+            ""

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -16247,6 +16247,23 @@ export type GetNotebookQuery = {
 				theme: string;
 				situations?: any | null;
 				linkedTo?: string | null;
+				createdAt: string;
+				creator: {
+					__typename?: 'account';
+					id: string;
+					professional?: {
+						__typename?: 'professional';
+						firstname: string;
+						lastname: string;
+						structure: { __typename?: 'structure'; name: string };
+					} | null;
+					orientation_manager?: {
+						__typename?: 'orientation_manager';
+						id: string;
+						lastname?: string | null;
+						firstname?: string | null;
+					} | null;
+				};
 				targets: Array<{
 					__typename?: 'notebook_target';
 					id: string;
@@ -27239,6 +27256,65 @@ export const GetNotebookDocument = {
 														{ kind: 'Field', name: { kind: 'Name', value: 'theme' } },
 														{ kind: 'Field', name: { kind: 'Name', value: 'situations' } },
 														{ kind: 'Field', name: { kind: 'Name', value: 'linkedTo' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+														{
+															kind: 'Field',
+															name: { kind: 'Name', value: 'creator' },
+															selectionSet: {
+																kind: 'SelectionSet',
+																selections: [
+																	{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+																	{
+																		kind: 'Field',
+																		name: { kind: 'Name', value: 'professional' },
+																		selectionSet: {
+																			kind: 'SelectionSet',
+																			selections: [
+																				{
+																					kind: 'Field',
+																					name: { kind: 'Name', value: 'firstname' },
+																				},
+																				{
+																					kind: 'Field',
+																					name: { kind: 'Name', value: 'lastname' },
+																				},
+																				{
+																					kind: 'Field',
+																					name: { kind: 'Name', value: 'structure' },
+																					selectionSet: {
+																						kind: 'SelectionSet',
+																						selections: [
+																							{
+																								kind: 'Field',
+																								name: { kind: 'Name', value: 'name' },
+																							},
+																						],
+																					},
+																				},
+																			],
+																		},
+																	},
+																	{
+																		kind: 'Field',
+																		name: { kind: 'Name', value: 'orientation_manager' },
+																		selectionSet: {
+																			kind: 'SelectionSet',
+																			selections: [
+																				{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+																				{
+																					kind: 'Field',
+																					name: { kind: 'Name', value: 'lastname' },
+																				},
+																				{
+																					kind: 'Field',
+																					name: { kind: 'Name', value: 'firstname' },
+																				},
+																			],
+																		},
+																	},
+																],
+															},
+														},
 														{
 															kind: 'Field',
 															name: { kind: 'Name', value: 'targets' },

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -15353,6 +15353,7 @@ export type GetNotebookByBeneficiaryIdQuery = {
 			__typename?: 'notebook_focus';
 			theme: string;
 			situations?: any | null;
+			createdAt: string;
 			creator: {
 				__typename?: 'account';
 				orientation_manager?: {
@@ -15518,6 +15519,7 @@ export type GetNotebookByIdQuery = {
 			__typename?: 'notebook_focus';
 			theme: string;
 			situations?: any | null;
+			createdAt: string;
 			creator: {
 				__typename?: 'account';
 				orientation_manager?: {
@@ -15676,6 +15678,7 @@ export type NotebookFragmentFragment = {
 		__typename?: 'notebook_focus';
 		theme: string;
 		situations?: any | null;
+		createdAt: string;
 		creator: {
 			__typename?: 'account';
 			orientation_manager?: {
@@ -17162,6 +17165,7 @@ export const NotebookFragmentFragmentDoc = {
 							selections: [
 								{ kind: 'Field', name: { kind: 'Name', value: 'theme' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'situations' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
 								{
 									kind: 'Field',
 									name: { kind: 'Name', value: 'creator' },

--- a/app/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/app/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -46,6 +46,12 @@
 	afterUpdate(() => {
 		if (!elmNode) return;
 
+		const focusesWithDates = focuses.map((focus) => {
+			// @TODO I'm pretty sure there is a better way to convert a date time to a date
+			// in JS, if you've got one, let's do it
+			return { ...focus, createdAt: focus.createdAt.split('T')[0] };
+		});
+
 		DiagnosticElm.Diagnostic.Main.init({
 			node: elmNode,
 			flags: {
@@ -60,7 +66,7 @@
 					lastJobEndedAt: notebook.lastJobEndedAt,
 				},
 				peGeneralData: externalDataDetail?.data?.source || null,
-				personalSituations: focuses || null,
+				personalSituations: focusesWithDates || null,
 			},
 		});
 	});

--- a/app/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/app/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -5,6 +5,8 @@
 		NotebookFocus,
 	} from '$lib/graphql/_gen/typed-document-nodes';
 
+	import { formatDateLocale } from '$lib/utils/date';
+
 	export type SocioProInfo = Pick<
 		Notebook,
 		| 'workSituation'
@@ -47,9 +49,7 @@
 		if (!elmNode) return;
 
 		const focusesWithDates = focuses.map((focus) => {
-			// @TODO I'm pretty sure there is a better way to convert a date time to a date
-			// in JS, if you've got one, let's do it
-			return { ...focus, createdAt: focus.createdAt?.split('T')[0] || null };
+			return { ...focus, createdAt: formatDateLocale(focus.createdAt) };
 		});
 
 		DiagnosticElm.Diagnostic.Main.init({
@@ -77,7 +77,7 @@
   @hack to prevent Svelte from removing CSS classes that we need in Elm and are not used in Svelte
   See https://github.com/sveltejs/svelte/issues/5804 for more details
 
-  shadow-dsfr rounded-lg p-4 pt-10 pt-4
+  shadow-dsfr rounded-lg p-4 pt-10 pt-4 font-normal odd:bg-gray-100 py-8 leading-10 pr-8 pr-4 align-text-top pl-2 py-3
 
   -->
 	<div class="elm-node">

--- a/app/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/app/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -1,6 +1,9 @@
 <script lang="ts" context="module">
-	import type { Notebook } from '$lib/graphql/_gen/typed-document-nodes';
-	import type { ExternalData } from '$lib/graphql/_gen/typed-document-nodes';
+	import type {
+		Notebook,
+		ExternalData,
+		NotebookFocus,
+	} from '$lib/graphql/_gen/typed-document-nodes';
 
 	export type SocioProInfo = Pick<
 		Notebook,
@@ -14,11 +17,27 @@
 	> & { wantedJobs: { rome_code: { id: string; label: string } }[] };
 
 	export type ExternalDataDetail = Pick<ExternalData, 'data' | 'source'>;
+
+	export type Focus = Pick<NotebookFocus, 'situations' | 'theme'> & {
+		createdAt?: string;
+		creator: {
+			professional?: {
+				firstname?: string;
+				lastname?: string;
+				structure: { name: string };
+			};
+			orientation_manager?: {
+				firstname?: string;
+				lastname?: string;
+			};
+		};
+	};
 </script>
 
 <script lang="ts">
 	export let notebook: SocioProInfo;
 	export let externalDataDetail: ExternalDataDetail | null;
+	export let focuses: Focus[] | null;
 
 	import { Elm as DiagnosticElm } from '../../../../elm/Diagnostic/Main.elm';
 	import { afterUpdate } from 'svelte';
@@ -41,6 +60,7 @@
 					lastJobEndedAt: notebook.lastJobEndedAt,
 				},
 				peGeneralData: externalDataDetail?.data?.source || null,
+				personalSituations: focuses || null,
 			},
 		});
 	});

--- a/app/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/app/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -49,7 +49,7 @@
 		const focusesWithDates = focuses.map((focus) => {
 			// @TODO I'm pretty sure there is a better way to convert a date time to a date
 			// in JS, if you've got one, let's do it
-			return { ...focus, createdAt: focus.createdAt.split('T')[0] };
+			return { ...focus, createdAt: focus.createdAt?.split('T')[0] || null };
 		});
 
 		DiagnosticElm.Diagnostic.Main.init({

--- a/app/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/app/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -73,13 +73,6 @@
 </script>
 
 {#key notebook}
-	<!--
-  @hack to prevent Svelte from removing CSS classes that we need in Elm and are not used in Svelte
-  See https://github.com/sveltejs/svelte/issues/5804 for more details
-
-  shadow-dsfr rounded-lg p-4 pt-10 pt-4 font-normal odd:bg-gray-100 py-8 leading-10 pr-8 pr-4 align-text-top pl-2 py-3
-
-  -->
 	<div class="elm-node">
 		<!-- Elm app needs to be wrapped by a div to avoid navigation exceptions when unmounting -->
 		<div bind:this={elmNode} />

--- a/app/src/lib/ui/OrientationManager/NotebookEdit.svelte
+++ b/app/src/lib/ui/OrientationManager/NotebookEdit.svelte
@@ -57,7 +57,11 @@
 			/>
 		</MainSection>
 		<MainSection title="Diagnostic socioprofessionnel">
-			<ProNotebookSocioProView notebook={notebook?.notebook} externalDataDetail={externalData} />
+			<ProNotebookSocioProView
+				notebook={notebook?.notebook}
+				externalDataDetail={externalData}
+				focuses={notebook?.notebook?.focuses}
+			/>
 		</MainSection>
 		<MainSection title="Plan d'action">
 			<ProNotebookFocusView notebook={notebook?.notebook} focuses={notebook?.notebook?.focuses} />

--- a/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProView.svelte
+++ b/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProView.svelte
@@ -5,10 +5,12 @@
 	import SocioProView, {
 		type SocioProInfo,
 		type ExternalDataDetail,
+		type Focus,
 	} from '../Beneficiary/SocioProView.svelte';
 
 	export let notebook: SocioProInfo;
 	export let externalDataDetail: ExternalDataDetail | null;
+	export let focuses: Focus[] | null;
 
 	const editSocioProSituation = () => {
 		openComponent.open({
@@ -25,7 +27,7 @@
 </script>
 
 <div class="flex flex-col space-y-6">
-	<SocioProView {notebook} {externalDataDetail} />
+	<SocioProView {notebook} {externalDataDetail} {focuses} />
 	<Button classNames="self-start" on:click={() => editSocioProSituation()} outline
 		>Mettre à jour</Button
 	>

--- a/app/src/lib/ui/views/NotebookView.svelte
+++ b/app/src/lib/ui/views/NotebookView.svelte
@@ -57,7 +57,7 @@
 			<NotebookMembers members={notebook.members} notebookId={notebook.id} />
 		</MainSection>
 		<MainSection title="Diagnostic socioprofessionnel">
-			<SocioProView {notebook} externalDataDetail={externalData} />
+			<SocioProView {notebook} externalDataDetail={externalData} focuses={notebook?.focuses} />
 		</MainSection>
 		<MainSection title="Plan d'action">
 			{#if notebook.focuses.length === 0}

--- a/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
+++ b/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
@@ -109,6 +109,7 @@ fragment notebookFragment on notebook {
   focuses(order_by: { createdAt: desc_nulls_first }) {
     theme
     situations
+    createdAt
     creator {
       orientation_manager {
         firstname

--- a/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
@@ -245,7 +245,11 @@
 			</MainSection>
 			{#if notebook}
 				<MainSection title="Diagnostic socioprofessionnel">
-					<ProNotebookSocioProView {notebook} externalDataDetail={externalData} />
+					<ProNotebookSocioProView
+						{notebook}
+						externalDataDetail={externalData}
+						focuses={notebook?.focuses}
+					/>
 				</MainSection>
 			{/if}
 

--- a/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
+++ b/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
@@ -115,6 +115,22 @@ query GetNotebook(
         theme
         situations
         linkedTo
+        createdAt
+        creator {
+          id
+          professional {
+            firstname
+            lastname
+            structure {
+              name
+            }
+          }
+          orientation_manager {
+            id
+            lastname
+            firstname
+          }
+        }
         targets {
           id
           target

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -117,3 +117,21 @@
 </div>
 
 <Footer />
+
+<style>
+	:global(.align-text-top
+			.font-normal
+			.leading-10
+			.odd:bg-gray-100
+			.p-4
+			.pl-2
+			.pr-4
+			.pr-8
+			.pt-10
+			.pt-4
+			.py-3
+			.py-8
+			.rounded-lg
+			.shadow-dsfr) {
+	}
+</style>

--- a/e2e/features/orientationManager/carnet/focus.feature
+++ b/e2e/features/orientationManager/carnet/focus.feature
@@ -18,7 +18,7 @@ Scénario: Ajout d'un axe de travail
 
 Scénario: Ajout d'un objectif
 	Soit le chargé d'orientation assigné "giulia.diaby@cd93.fr" sur le carnet de "Aguilar"
-	Alors je clique sur le texte "Formation"
+	Alors je clique sur "Formation" dans la tuile "Formation"
 	Alors j'attends que le texte "Prêt à suivre une formation" apparaisse
 	Quand je clique sur "Ajouter un objectif"
 	Alors j'attends que le texte "Objectif" apparaisse
@@ -28,7 +28,7 @@ Scénario: Ajout d'un objectif
 
 Scénario: Ajout d'une action
 	Soit le chargé d'orientation assigné "giulia.diaby@cd93.fr" sur le carnet de "Aguilar"
-	Alors je clique sur le texte "Formation"
+	Alors je clique sur "Formation" dans la tuile "Formation"
 	Alors j'attends que le texte "Prêt à suivre une formation" apparaisse
 	Quand je clique sur "Se former"
 	Alors j'attends que le texte "Action" apparaisse

--- a/e2e/features/pro/carnet/focuses.feature
+++ b/e2e/features/pro/carnet/focuses.feature
@@ -24,7 +24,7 @@ Scénario: Ajout d'un axe de travail par un pro
 
 Scénario: Je peux consulter un axe de travail existant
 	Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Tifour"
-	Quand je clique sur le texte "Logement"
+	Quand je clique sur "Logement" dans la tuile "Logement"
 	Alors j'attends que le texte "Hébergé chez un tiers" apparaisse
 	Quand je clique sur "Changer de logement"
 	Alors j'attends que le texte "Action" apparaisse


### PR DESCRIPTION
## :wrench: Problème

En tant que chargé d'orientation / professionnel, j'ai besoin de consulter et mettre à jour le diagnostic socioprofessionnel afin d'appréhender la réalité de la situation du bénéficiaire et d'adapter mon accompagnement.

Concerne l'issue #1461 

## :cake: Solution

Ajouter dans "Diagnostic socioprofessionnel" un bloc "Situation personnelle" qui permettra d'afficher « à plat » les informations de la situation personnelle.

![Screenshot from 2023-02-14 08-57-22](https://user-images.githubusercontent.com/154904/218674186-6ee7922f-1fd0-4c83-aa25-7aeb13989290.png)


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester


<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1517.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

Se connecter en tant que `pierre.chevalier`, aller sur le carnet de `Sophie Tifour`, constater l'affichage de ses informations personnelles.

![Screenshot from 2023-02-14 17-39-46](https://user-images.githubusercontent.com/154904/218800792-3a0b318a-35b7-42aa-8361-974bc62388e9.png)


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
fix #1461 
