### PR TITLE
fix(manager): mise à jour de la liste bénéficiaires et du dashboard

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -24933,6 +24933,22 @@ export const GetDeploymentInfosDocument = {
 						kind: 'Field',
 						alias: { kind: 'Name', value: 'beneficiaries' },
 						name: { kind: 'Name', value: 'beneficiary_aggregate' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'where' },
+								value: {
+									kind: 'ObjectValue',
+									fields: [
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: 'notebook' },
+											value: { kind: 'ObjectValue', fields: [] },
+										},
+									],
+								},
+							},
+						],
 						selectionSet: {
 							kind: 'SelectionSet',
 							selections: [
@@ -24960,77 +24976,41 @@ export const GetDeploymentInfosDocument = {
 									fields: [
 										{
 											kind: 'ObjectField',
-											name: { kind: 'Name', value: '_or' },
+											name: { kind: 'Name', value: 'notebook' },
+											value: { kind: 'ObjectValue', fields: [] },
+										},
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: '_not' },
 											value: {
-												kind: 'ListValue',
-												values: [
+												kind: 'ObjectValue',
+												fields: [
 													{
-														kind: 'ObjectValue',
-														fields: [
-															{
-																kind: 'ObjectField',
-																name: { kind: 'Name', value: '_not' },
-																value: {
-																	kind: 'ObjectValue',
-																	fields: [
-																		{
-																			kind: 'ObjectField',
-																			name: { kind: 'Name', value: 'structures' },
-																			value: { kind: 'ObjectValue', fields: [] },
-																		},
-																	],
-																},
-															},
-														],
-													},
-													{
-														kind: 'ObjectValue',
-														fields: [
-															{
-																kind: 'ObjectField',
-																name: { kind: 'Name', value: 'notebook' },
-																value: {
-																	kind: 'ObjectValue',
-																	fields: [
-																		{
-																			kind: 'ObjectField',
-																			name: { kind: 'Name', value: 'members' },
-																			value: {
-																				kind: 'ObjectValue',
-																				fields: [
-																					{
-																						kind: 'ObjectField',
-																						name: { kind: 'Name', value: '_not' },
-																						value: {
-																							kind: 'ObjectValue',
-																							fields: [
-																								{
-																									kind: 'ObjectField',
-																									name: { kind: 'Name', value: 'active' },
-																									value: {
-																										kind: 'ObjectValue',
-																										fields: [
-																											{
-																												kind: 'ObjectField',
-																												name: { kind: 'Name', value: '_eq' },
-																												value: {
-																													kind: 'BooleanValue',
-																													value: true,
-																												},
-																											},
-																										],
-																									},
-																								},
-																							],
-																						},
-																					},
-																				],
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: 'structures' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'status' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: '_eq' },
+																				value: {
+																					kind: 'StringValue',
+																					value: 'current',
+																					block: false,
+																				},
 																			},
-																		},
-																	],
+																		],
+																	},
 																},
-															},
-														],
+															],
+														},
 													},
 												],
 											},

--- a/app/src/lib/ui/BeneficiaryList/SupportFilters.svelte
+++ b/app/src/lib/ui/BeneficiaryList/SupportFilters.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+
+	import { Button } from '$lib/ui/base';
+	import type { OrientedFilter } from './OrientationFilter';
+	import { Form, Select, Input } from '$lib/ui/forms';
+	import { supportFilterSchema, SupportFilterValues } from './supportFilter.schema';
+
+	export let filter: string;
+	export let search: string;
+	export let member: string;
+
+	$: initialValues = { filter, search };
+
+	const dispatch = createEventDispatcher();
+
+	const orientationStatusfilterOptions: { label: string; name: OrientedFilter }[] = [
+		{ label: 'Tous', name: 'tous' },
+		{ label: 'Accompagné', name: 'referent' },
+		{ label: "En attente d'un référent", name: 'sans-referent' },
+		{ label: 'Non accompagné', name: 'sans-structure' },
+	];
+
+	function onSubmit(values: SupportFilterValues) {
+		dispatch('filter-update', { filter: 'tous', search: values.search.trim() });
+	}
+
+	function updateFilters(event: CustomEvent<{ selected: OrientedFilter }>) {
+		dispatch('filter-update', { filter: event.detail.selected, search: '' });
+	}
+	function removeMemberFilter() {
+		dispatch('filter-update', { resetMember: true, filter, search });
+	}
+</script>
+
+<Form {initialValues} {onSubmit} validationSchema={supportFilterSchema}>
+	<div class="flex items-end justify-between">
+		<Select
+			selectLabel="Rattachement"
+			name="filter"
+			options={orientationStatusfilterOptions}
+			on:select={updateFilters}
+		/>
+
+		<div class="fr-search-bar" role="search">
+			<Input name="search" inputLabel="Rechercher des beneficiaire" placeholder="Nom de famille" />
+			<button class="fr-btn"> Rechercher </button>
+		</div>
+	</div>
+	{#if member}
+		<p class="flex items-center gap-4 font-medium fr-mt-2w">
+			<span>
+				{member}
+			</span>
+			<Button
+				icon="fr-icon-close-line"
+				on:click={removeMemberFilter}
+				classNames="fr-btn fr-btn--tertiary-no-outline fr-btn--sm">Supprimer le filtre</Button
+			>
+		</p>
+	{/if}
+</Form>

--- a/app/src/lib/ui/BeneficiaryList/supportFilter.schema.ts
+++ b/app/src/lib/ui/BeneficiaryList/supportFilter.schema.ts
@@ -1,0 +1,7 @@
+import * as yup from 'yup';
+export const supportFilterSchema = yup.object().shape({
+	filter: yup.string().nullable(),
+	search: yup.string().nullable(),
+});
+
+export type SupportFilterValues = yup.InferType<typeof supportFilterSchema>;

--- a/app/src/routes/(auth)/manager/_getDeploymentInfo.gql
+++ b/app/src/routes/(auth)/manager/_getDeploymentInfo.gql
@@ -2,18 +2,13 @@ query GetDeploymentInfos($id: uuid!) {
   deployment: deployment_by_pk(id: $id) {
     label
   }
-  beneficiaries: beneficiary_aggregate {
+  beneficiaries: beneficiary_aggregate(where: { notebook: {} }) {
     aggregate {
       count
     }
   }
   beneficiariesWithNoStructure: beneficiary_aggregate(
-    where: {
-      _or: [
-        { _not: { structures: {} } }
-        { notebook: { members: { _not: { active: { _eq: true } } } } }
-      ]
-    }
+    where: { notebook: {}, _not: { structures: { status: { _eq: "current" } } } }
   ) {
     aggregate {
       count

--- a/app/src/routes/(auth)/manager/beneficiaires/+page.ts
+++ b/app/src/routes/(auth)/manager/beneficiaires/+page.ts
@@ -1,11 +1,11 @@
-import { getFilter } from '$lib/ui/BeneficiaryList/Filters.svelte';
+import { getOrientedFilter } from '$lib/ui/BeneficiaryList/OrientationFilter';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ url }) => {
 	const params = url.searchParams;
 	return {
 		currentPage: parseInt(params.get('page') || '1', 10),
-		filter: getFilter(params.get('filter')),
+		filter: getOrientedFilter(params.get('filter')),
 		search: params.get('search') || '',
 		member: params.get('member'),
 	};

--- a/e2e/features/manager/home.feature
+++ b/e2e/features/manager/home.feature
@@ -1,22 +1,13 @@
 #language: fr
 
-Fonctionnalité: Rattachement à une structure
-	Pour pouvoir gérer les réorientations
+Fonctionnalité: Tableau de bord du manager
+	Pour pouvoir gérer l'état du territoire
 	En tant que manager d'un déploiement
-	Je veux pouvoir assigner une nouvelle structure à un bénéficiaire
+	Je veux pouvoir consulter les chiffres clés du déploiement
 
-	Scénario: Modifier la structure de rattachement d'un bénéficiaire
+	Scénario: Affichage des tuiles
 		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
-		Alors je vois "5"
-		Quand je clique sur "Bénéficiaires"
-		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
-		Alors je vois "Centre Communal d'action social Livry-Gargan" sur la ligne "Aguilar"
-		Quand je clique sur "Non rattaché"
-		Alors je vois "Réorienter" dans le volet
-		Alors je vois "Veuillez sélectionner le dispositif d'accompagnement ainsi que la nouvelle structure et le nouveau référent." dans le volet
-		Alors je selectionne l'option "Professionnel" dans la liste "Dispositif d'accompagnement"
-		Alors je selectionne l'option "AFPA (0)" dans la liste "Nom de la structure"
-		Quand je clique sur "Valider"
-		Alors je vois "AFPA" sur la ligne "Aguilar"
-		Quand je clique sur "Accueil"
-		Alors je vois "4"
+		Alors je vois "56" dans la tuile "Bénéficiaires sur le territoire"
+ 		Alors je vois "2" dans la tuile "Bénéficiaires non accompagné"
+		Alors je vois "9" dans la tuile "Structures sur le territoire"
+		Alors je vois "5" dans la tuile "Structures sans bénéficiaire"


### PR DESCRIPTION
## :wrench: Problème

 la home affiche un nombre de bénéficiaires qu'on ne retrouve pas lorsqu'on affiche la liste des bénéficiaires. Le dénombrement de l'accueil etait faux (nombre de bénéficiaire sans structure ou sans membre actif dans le groupe de suivi et le filtre de la liste bénéficiaire qui filtrer les bénéficiaires avec ou sans référent.

## :cake: Solution
On met à jour les filtres avec  accompagnés, non accompagnés, et en attente de référent à la liste des bénéficiaires

## :rotating_light:  Points d'attention / Remarques

On en profite pour mettre à jour le dashboard manager (et ses test e2e)

## :desert_island: Comment tester

Se connecter en tant que `manager.cd93`
Suivre les liens   `bénéficiaires non accompagnés` depuis l'accueil du dashboard
Constater qu'on a bien 2 bénéficiaires

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1537.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

fix #1489 