### PR TITLE
fix: ne pas modifier la structure de suivi en cas de rattachement en tant que no-referent

### DIFF
--- a/backend/cdb/api/v1/routers/notebooks.py
+++ b/backend/cdb/api/v1/routers/notebooks.py
@@ -97,7 +97,15 @@ async def add_notebook_members(
             mutations = mutations | get_deactivate_notebook_members_mutation(
                 dsl_schema, notebook_id, request.state.account.id
             )
-
+            mutations = mutations | get_deactivate_beneficiary_structure_mutation(
+                dsl_schema,
+                orientation_info.beneficiary["id"],
+            )
+            mutations = mutations | get_insert_beneficiary_structure_mutation(
+                dsl_schema,
+                orientation_info.beneficiary["id"],
+                request.state.account.structure_id,
+            )
             if orientation_info.former_referent_account_id:
                 mutations = (
                     mutations
@@ -113,15 +121,6 @@ async def add_notebook_members(
             notebook_id,
             request.state.account.id,
             data.member_type,
-        )
-        mutations = mutations | get_deactivate_beneficiary_structure_mutation(
-            dsl_schema,
-            orientation_info.beneficiary["id"],
-        )
-        mutations = mutations | get_insert_beneficiary_structure_mutation(
-            dsl_schema,
-            orientation_info.beneficiary["id"],
-            request.state.account.structure_id,
         )
 
         await session.execute(dsl_gql(DSLMutation(**mutations)))

--- a/backend/tests/api/test_notebooks.py
+++ b/backend/tests/api/test_notebooks.py
@@ -77,10 +77,19 @@ async def test_add_notebook_member_as_no_referent(
         db_connection,
         notebook_sophie_tifour.id,
     )
-
+    structures = await get_structures_for_beneficiary(
+        db_connection,
+        notebook_sophie_tifour.beneficiary_id,
+    )
     # Check that a new member was added
     assert_member(members, professional_paul_camara, "no_referent", True)
-    # Check that no email is sent since referent doesn't change
+
+    # Check that beneficiary_structure has not changed
+    assert_structure(
+        structures,
+        beneficiary_status="current",
+        structure_name="Centre Communal d'action social Livry-Gargan",
+    )
     mock_send_email.assert_not_called()
     # Check that former referent is still the referent
     assert_member(members, professional_pierre_chevalier, "referent", True)


### PR DESCRIPTION


## :wrench: Problème
Lorsqu'un pro se rattache à un carnet sans avoir de mandat, on affecte le bénéficiaire à la structure du pro alors que cela ne devrait  être fait que dans le cas ou le pro à un mandat (comme référent) 

## :cake: Solution
Modifer le rattachement à une structure seulement lorsqu'un pro se rattache à un carnet et qu'il à un mandat

## :rotating_light:  Points d'attention / Remarques

ras

## :desert_island: Comment tester
se connecter en tant que `pierre.chevalier`
se rattaché à Buckley Hoffman en tant que pro sans mandat (donc non référent).
Sel connecter en tant `manager.cd93`
Verifier que Buckley Hoffman n'est toujours pas suivi par une structure

fix #1551


<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1552.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
