### PR TITLE
fix: creation d'un axe de travail sans situation

### DIFF
--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -49,7 +49,7 @@ type alias Creator =
 
 type alias PersonalSituationFlags =
     { theme : String
-    , situations : List String
+    , situations : Maybe (List String)
     , createdAt : Maybe String
     , creator : Account
     }
@@ -105,7 +105,7 @@ init flags =
 extractPersonalSituationFromFlags : PersonalSituationFlags -> PersonalSituationElement
 extractPersonalSituationFromFlags flags =
     { theme = flags.theme
-    , situations = flags.situations
+    , situations = Maybe.withDefault [] flags.situations
     , createdAt = flags.createdAt
     , creator =
         case ( flags.creator.professional, flags.creator.orientation_manager ) of

--- a/e2e/features/pro/carnet/focuses.feature
+++ b/e2e/features/pro/carnet/focuses.feature
@@ -19,6 +19,7 @@ Scénario: Ajout d'un axe de travail par un pro
 	Quand je clique sur "Valider"
 	Quand je clique sur "J'ai compris"
 	Alors je vois "Aucune action" dans la tuile "Numérique"
+	Alors je ne vois pas "J'ai compris"
 
 Scénario: Je peux consulter un axe de travail existant
 	Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Tifour"


### PR DESCRIPTION
## :wrench: Problème

Lors de la création d'un axe de travail, si aucune situation n'est coché, alors l'application plante. cela est du au type des flags Elm qui ne correspondent pas avec ce qui est envoyé. (List String vs Maybe (List string))

## :cake: Solution

On corrige le type et on complete le test pour s'assurer que ca fonctionne correctement


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

- Dans le carnet d'un bénéficiaire, je clique sur ajouter un axe de travail
- Je rentre une thématique pour laquelle il n'y a pas de situation dans le diagnostic, par exemple mobilité alors qu'il n'y a pas d'info sur la mobilité dans le diagnostic
- Je valide
- Le panneau `J'ai compris `disparais


<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Ne pas supprimer ce bloc, qui sera mis à jour [automatiquement](.github/workflows/review-scalingo.yml).
<!-- END ## emplacement de l'URL de la review app ## -->

fix #1562
