### PR TITLE
chore: retirer les références à maildev

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -97,9 +97,7 @@ L'équipe privilégie les "squash and merge" avec un message de commit qui suit 
 
 ## Gestion des mails sur les environnements de développement (review / preprod)
 
-Pour les environnements de review les mails envoyés par l'application sont visible sur une instance de [maildev](https://maildev.github.io/maildev/) que l'on déploie lorsqu'on déploie nos environnements de review-branch.
-
-Pour la preprod, nous utilisons [mailtrap](https://mailtrap.io) (demander l'accès)
+Pour les environnements de review et la preprod, les mails envoyés par l'application sont visibles sur une instance de [mailtrap](https://mailtrap.io) (Les accès se trouvent dans bitwarden).
 
 ## Howto
 

--- a/app/src/lib/emailing/send.ts
+++ b/app/src/lib/emailing/send.ts
@@ -14,7 +14,6 @@ const smtpConfig: SMTPTransport.Options = {
 	secure: SMTP_PORT === 465,
 	tls: {
 		minVersion: 'TLSv1.2',
-		...(/maildev/.test(SMTP_HOST) && { rejectUnauthorized: false }),
 	},
 	...(SMTP_PASS &&
 		SMTP_USER && {

--- a/backend/cdb/api/core/sendmail.py
+++ b/backend/cdb/api/core/sendmail.py
@@ -23,8 +23,7 @@ def send_mail(to: str, subject: str, message: str) -> None:
     msg.attach(part1)
     s = smtplib.SMTP(settings.smtp_host, int(settings.smtp_port))
 
-    if "maildev" not in settings.smtp_host:
-        s.starttls()
+    s.starttls()
 
     if settings.smtp_user and settings.smtp_pass:
         s.login(settings.smtp_user, settings.smtp_pass)


### PR DESCRIPTION
## :wrench: Problème

Maildev a été retiré avec db957f984a919b6539672fd33af6a4e242eed071, les environnements hors prod utilisent tous mailtrap

## :cake: Solution

🗑

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1568.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->