### PR TITLE
feat: Historiser les changements de situations d'un bénéficiaire

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -15403,7 +15403,7 @@ export type UpdateSocioProMutation = {
 		__typename?: 'professional_project_mutation_response';
 		affected_rows: number;
 	} | null;
-	delete_notebook_situation?: {
+	update_notebook_situation?: {
 		__typename?: 'notebook_situation_mutation_response';
 		affected_rows: number;
 	} | null;
@@ -17646,6 +17646,29 @@ export const NotebookFragmentFragmentDoc = {
 						kind: 'Field',
 						name: { kind: 'Name', value: 'situations' },
 						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'where' },
+								value: {
+									kind: 'ObjectValue',
+									fields: [
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: 'deletedAt' },
+											value: {
+												kind: 'ObjectValue',
+												fields: [
+													{
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: '_is_null' },
+														value: { kind: 'BooleanValue', value: true },
+													},
+												],
+											},
+										},
+									],
+								},
+							},
 							{
 								kind: 'Argument',
 								name: { kind: 'Name', value: 'order_by' },
@@ -23845,7 +23868,7 @@ export const UpdateSocioProDocument = {
 					},
 					{
 						kind: 'Field',
-						name: { kind: 'Name', value: 'delete_notebook_situation' },
+						name: { kind: 'Name', value: 'update_notebook_situation' },
 						arguments: [
 							{
 								kind: 'Argument',
@@ -23897,6 +23920,25 @@ export const UpdateSocioProDocument = {
 																				kind: 'Variable',
 																				name: { kind: 'Name', value: 'situationIdsToDelete' },
 																			},
+																		},
+																	],
+																},
+															},
+														],
+													},
+													{
+														kind: 'ObjectValue',
+														fields: [
+															{
+																kind: 'ObjectField',
+																name: { kind: 'Name', value: 'deletedAt' },
+																value: {
+																	kind: 'ObjectValue',
+																	fields: [
+																		{
+																			kind: 'ObjectField',
+																			name: { kind: 'Name', value: '_is_null' },
+																			value: { kind: 'BooleanValue', value: true },
 																		},
 																	],
 																},
@@ -27871,6 +27913,29 @@ export const GetNotebookDocument = {
 												kind: 'Field',
 												name: { kind: 'Name', value: 'situations' },
 												arguments: [
+													{
+														kind: 'Argument',
+														name: { kind: 'Name', value: 'where' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'deletedAt' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: '_is_null' },
+																				value: { kind: 'BooleanValue', value: true },
+																			},
+																		],
+																	},
+																},
+															],
+														},
+													},
 													{
 														kind: 'Argument',
 														name: { kind: 'Name', value: 'order_by' },

--- a/app/src/lib/ui/ProNotebookSocioPro/_UpdateSocioPro.gql
+++ b/app/src/lib/ui/ProNotebookSocioPro/_UpdateSocioPro.gql
@@ -31,8 +31,14 @@ mutation UpdateSocioPro(
   insert_professional_project(objects: $professionalProjects) {
     affected_rows
   }
-  delete_notebook_situation(
-    where: { _and: [{ notebookId: { _eq: $id } }, { situationId: { _in: $situationIdsToDelete } }] }
+  update_notebook_situation(
+    where: {
+      _and: [
+        { notebookId: { _eq: $id } }
+        { situationId: { _in: $situationIdsToDelete } }
+        { deletedAt: { _is_null: true } }
+      ]
+    }
   ) {
     affected_rows
   }

--- a/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
+++ b/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
@@ -106,7 +106,7 @@ fragment notebookFragment on notebook {
       }
     }
   }
-  situations(order_by: { createdAt: desc }) {
+  situations(where: { deletedAt: { _is_null: true } }, order_by: { createdAt: desc }) {
     id
     refSituation {
       id

--- a/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
+++ b/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
@@ -115,7 +115,7 @@ query GetNotebook(
           label
         }
       }
-      situations(order_by: { createdAt: desc }) {
+      situations(where: { deletedAt: { _is_null: true } }, order_by: { createdAt: desc }) {
         id
         refSituation {
           id

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_situation.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_situation.yaml
@@ -7,6 +7,10 @@ configuration:
       custom_name: createdAt
     created_by:
       custom_name: createdBy
+    deleted_at:
+      custom_name: deletedAt
+    deleted_by:
+      custom_name: deletedBy
     notebook_id:
       custom_name: notebookId
     situation_id:
@@ -14,6 +18,8 @@ configuration:
   custom_column_names:
     created_at: createdAt
     created_by: createdBy
+    deleted_at: deletedAt
+    deleted_by: deletedBy
     notebook_id: notebookId
     situation_id: situationId
   custom_root_fields: {}
@@ -23,6 +29,15 @@ object_relationships:
       manual_configuration:
         column_mapping:
           created_by: id
+        insertion_order: null
+        remote_table:
+          name: account
+          schema: public
+  - name: deletor
+    using:
+      manual_configuration:
+        column_mapping:
+          deleted_by: id
         insertion_order: null
         remote_table:
           name: account
@@ -82,6 +97,8 @@ select_permissions:
       columns:
         - created_at
         - created_by
+        - deleted_at
+        - deleted_by
         - id
         - notebook_id
         - situation_id
@@ -91,6 +108,8 @@ select_permissions:
       columns:
         - created_at
         - created_by
+        - deleted_at
+        - deleted_by
         - id
         - notebook_id
         - situation_id
@@ -114,7 +133,9 @@ select_permissions:
     permission:
       columns:
         - created_at
+        - deleted_at
         - created_by
+        - deleted_by
         - id
         - notebook_id
         - situation_id
@@ -126,7 +147,9 @@ select_permissions:
     permission:
       columns:
         - created_at
+        - deleted_at
         - created_by
+        - deleted_by
         - id
         - notebook_id
         - situation_id
@@ -139,7 +162,9 @@ select_permissions:
     permission:
       columns:
         - created_at
+        - deleted_at
         - created_by
+        - deleted_by
         - id
         - notebook_id
         - situation_id
@@ -152,7 +177,9 @@ select_permissions:
     permission:
       columns:
         - created_at
+        - deleted_at
         - created_by
+        - deleted_by
         - id
         - notebook_id
         - situation_id
@@ -161,18 +188,32 @@ select_permissions:
           members:
             account_id:
               _eq: X-Hasura-User-Id
-delete_permissions:
+update_permissions:
   - role: orientation_manager
     permission:
+      columns:
+        - deleted_at
+        - deleted_by
       filter:
         notebook:
           members:
             account_id:
               _eq: X-Hasura-User-Id
+      check: null
+      set:
+        deleted_at: now
+        deleted_by: x-hasura-User-Id
   - role: professional
     permission:
+      columns:
+        - deleted_at
+        - deleted_by
       filter:
         notebook:
           members:
             account_id:
               _eq: X-Hasura-User-Id
+      check: null
+      set:
+        deleted_at: now
+        deleted_by: x-hasura-User-Id

--- a/hasura/migrations/carnet_de_bord/1677550512224_add-deleted-columns-on-notebook-situation/down.sql
+++ b/hasura/migrations/carnet_de_bord/1677550512224_add-deleted-columns-on-notebook-situation/down.sql
@@ -1,0 +1,5 @@
+alter table "public"."notebook_situation" drop constraint "notebook_situation_notebook_id_situation_id_deleted_at_key";
+alter table "public"."notebook_situation" add constraint "notebook_situation_notebook_id_situation_id_key" unique ("notebook_id", "situation_id");
+
+alter table "public"."notebook_situation" drop column "deleted_by";
+alter table "public"."notebook_situation" drop column "deleted_at";

--- a/hasura/migrations/carnet_de_bord/1677550512224_add-deleted-columns-on-notebook-situation/down.sql
+++ b/hasura/migrations/carnet_de_bord/1677550512224_add-deleted-columns-on-notebook-situation/down.sql
@@ -1,5 +1,6 @@
 alter table "public"."notebook_situation" drop constraint "notebook_situation_notebook_id_situation_id_deleted_at_key";
 alter table "public"."notebook_situation" add constraint "notebook_situation_notebook_id_situation_id_key" unique ("notebook_id", "situation_id");
 
+alter table "public"."notebook_situation" drop constraint "notebook_situation_deleted_by_fkey";
 alter table "public"."notebook_situation" drop column "deleted_by";
 alter table "public"."notebook_situation" drop column "deleted_at";

--- a/hasura/migrations/carnet_de_bord/1677550512224_add-deleted-columns-on-notebook-situation/up.sql
+++ b/hasura/migrations/carnet_de_bord/1677550512224_add-deleted-columns-on-notebook-situation/up.sql
@@ -1,0 +1,8 @@
+alter table "public"."notebook_situation" add column "deleted_at" timestamptz
+ null;
+
+alter table "public"."notebook_situation" add column "deleted_by" uuid
+ null;
+
+alter table "public"."notebook_situation" drop constraint "notebook_situation_notebook_id_situation_id_key";
+alter table "public"."notebook_situation" add constraint "notebook_situation_notebook_id_situation_id_deleted_at_key" unique ("notebook_id", "situation_id", "deleted_at");

--- a/hasura/migrations/carnet_de_bord/1677550512224_add-deleted-columns-on-notebook-situation/up.sql
+++ b/hasura/migrations/carnet_de_bord/1677550512224_add-deleted-columns-on-notebook-situation/up.sql
@@ -4,5 +4,11 @@ alter table "public"."notebook_situation" add column "deleted_at" timestamptz
 alter table "public"."notebook_situation" add column "deleted_by" uuid
  null;
 
+alter table "public"."notebook_situation"
+  add constraint "notebook_situation_deleted_by_fkey"
+  foreign key ("deleted_by")
+  references "public"."account"
+  ("id") on update restrict on delete restrict;
+
 alter table "public"."notebook_situation" drop constraint "notebook_situation_notebook_id_situation_id_key";
 alter table "public"."notebook_situation" add constraint "notebook_situation_notebook_id_situation_id_deleted_at_key" unique ("notebook_id", "situation_id", "deleted_at");


### PR DESCRIPTION
## :wrench: Problème

En tant que professionnel, j'ai besoin de conserver l'évolution de la situation personnelle du bénéficiaire afin d'adapter son accompagnement.

## :cake: Solution

Historiser la suppression des situations personnelles lors de la mise à jour du diagnostic
Pour cela, on ajoute les colonnes `deleted_at` et `deleted_by` à la table `notebook_situation`.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester


<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1570.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

Se connecter en tant que `pierre.chevalier`.
Se rendre sur le carnet de Sophie Tifour.
Supprimer une situation existante.
Rétablir la situation précédemment supprimée.
Vérifier que la situation est bien ajoutée et que la date de création correspond à la date du jour.


closes #1523