### PR TITLE
feat: afficher un placeholder quand la situation personnelle est vide

### DIFF
--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -404,45 +404,49 @@ personalSituationView { personalSituations } =
     div [ class "pt-10 flex flex-col" ]
         [ h3 [ class "text-xl" ] [ text "Situation personnelle" ]
         , div [ class "fr-container shadow-dsfr rounded-lg py-8" ]
-            [ table [ class "w-full" ]
-                [ thead [ class "text-left pb-4" ]
-                    [ th [ class "font-normal text-sm leading-10 pl-2" ] [ text "Thématique" ]
-                    , th [ class "font-normal text-sm" ] [ text "Situation" ]
-                    , th [ class "font-normal text-sm" ] [ text "Ajouté le" ]
-                    , th [ class "font-normal text-sm" ] [ text "Ajouté par" ]
+            [ if List.isEmpty personalSituations then
+                span [] [ text "Aucune situation renseignée" ]
+
+              else
+                table [ class "w-full" ]
+                    [ thead [ class "text-left pb-4" ]
+                        [ th [ class "font-normal text-sm leading-10 pl-2" ] [ text "Thématique" ]
+                        , th [ class "font-normal text-sm" ] [ text "Situation" ]
+                        , th [ class "font-normal text-sm" ] [ text "Ajouté le" ]
+                        , th [ class "font-normal text-sm" ] [ text "Ajouté par" ]
+                        ]
+                    , tbody []
+                        (personalSituations
+                            |> List.indexedMap
+                                (\personalIndex personalSituation ->
+                                    personalSituation.situations
+                                        |> List.indexedMap
+                                            (\index situation ->
+                                                tr
+                                                    [ if modBy 2 personalIndex == 0 then
+                                                        class "bg-gray-100 align-text-top text-left"
+
+                                                      else
+                                                        class "align-text-top text-left"
+                                                    ]
+                                                    [ if index == 0 then
+                                                        th [ class "font-bold pr-8 pl-2 py-3", rowspan (List.length personalSituation.situations) ]
+                                                            [ personalSituation.theme |> themeKeyStringToString |> text ]
+
+                                                      else
+                                                        text ""
+                                                    , td [ class "font-bold pr-8 py-3" ]
+                                                        [ text situation.description ]
+                                                    , td [ class "pr-8 py-3" ]
+                                                        [ text situation.createdAt ]
+                                                    , td [ class "py-3" ]
+                                                        [ text situation.creator ]
+                                                    ]
+                                            )
+                                )
+                            |> List.concat
+                        )
                     ]
-                , tbody []
-                    (personalSituations
-                        |> List.indexedMap
-                            (\personalIndex personalSituation ->
-                                personalSituation.situations
-                                    |> List.indexedMap
-                                        (\index situation ->
-                                            tr
-                                                [ if modBy 2 personalIndex == 0 then
-                                                    class "bg-gray-100 align-text-top text-left"
-
-                                                  else
-                                                    class "align-text-top text-left"
-                                                ]
-                                                [ if index == 0 then
-                                                    th [ class "font-bold pr-8 pl-2 py-3", rowspan (List.length personalSituation.situations) ]
-                                                        [ personalSituation.theme |> themeKeyStringToString |> text ]
-
-                                                  else
-                                                    text ""
-                                                , td [ class "font-bold pr-8 py-3" ]
-                                                    [ text situation.description ]
-                                                , td [ class "pr-8 py-3" ]
-                                                    [ text situation.createdAt ]
-                                                , td [ class "py-3" ]
-                                                    [ text situation.creator ]
-                                                ]
-                                        )
-                            )
-                        |> List.concat
-                    )
-                ]
             ]
         ]
 


### PR DESCRIPTION
## :wrench: Problème

Actuellement, lorsque aucune situation personnelle n'est renseignée, le système affiche un tableau vide mais ne permet pas de comprendre de manière explicite qu'il n'y a pas encore de situation identifiée.

## :desert_island: Comment tester

Utiliser la review app :
- en tant que pierre.chevalier
- aller dans le [CdB de Sophie Tifour](http://localhost:3000/pro/carnet/9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d)
- mettre à jour la situation personnelle en décochant tous les éléments
- Enregistrer

<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Ne pas supprimer ce bloc, qui sera mis à jour [automatiquement](.github/workflows/review-scalingo.yml).
<!-- END ## emplacement de l'URL de la review app ## -->

![image](https://user-images.githubusercontent.com/2758243/221815212-7b33889b-a0d1-4c7f-99f5-2123e4125ae8.png)


Closes #1534

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->