### PR TITLE
chore: ajouter de la documentation pour les tests

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,6 +28,7 @@ cd carnet-de-bord
 
 ```sh
 cp .env.sample .env
+cp .env.test.sample .env.test
 ````
 
 **3/** Récupérer les dépendances du projet

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,34 @@
+# Vérifier l’application
+
+L’application bénéficie de tests frontend, backend et d’intégration (end-to-end). L’utilisation de chaque suite de test est documenté dans le dossier associé :
+
+## Backend
+
+Dans le répertoire racine du projet, lancez `./scripts/launch_tests.sh` pour lancer les dockers de test en local. PostgreSQL devrait alors écouter sur 5433. Pour s'y connecter :
+
+    psql -U cdb -h localhost -p 5433 postgres;
+
+Lancez dans le répertoire `backend` les tests pytest avec poetry :
+
+    ENV_FILE=../.env.test poetry run pytest -s tests
+
+Pour lancer les tests en mode watch :
+```
+ENV_FILE=../.env.test poetry run ptw --runner "pytest --testmon"
+```
+
+## Frontend
+
+Deux suites de tests peuvent être exécutées avec `npm` :
+
+- Elm : `npm run test:elm`
+- Svelte : `npm run test:svelte`
+
+## End-to-end
+
+Le fonctionnement des tests est décrit dans [e2e/README.md](e2e/README.md).
+Cheatsheet :
+```bash
+$ docker compose -f docker-compose-test.yaml up
+$ npm --prefix e2e test
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -36,19 +36,3 @@ docker run --rm -p 4000:4000 --name cdb_backend cdb_backend:local
 ## Scripts
 
     HASURA_GRAPHQL_DATABASE_URL=postgres://cdb:test@localhost:5432/carnet_de_bord poetry run python scripts/connect_to_db.py
-
-## Tests
-
-Dans le répertoire racine du projet, lancez `./scripts/launch_tests.sh` pour lancer les dockers de test en local. PostgreSQL devrait alors écouter sur 5433. Pour s'y connecter :
-
-    psql -U cdb -h localhost -p 5433 postgres;
-
-Copiez le fichier `.env.test.sample` vers `.env.test`. Ensuite, lancez dans le répertoire `backend` les tests pytest avec poetry :
-
-    ENV_FILE=../.env.test poetry run pytest -s tests
-
-
-Pour lancer les tests en mode watch :
-```
-ENV_FILE=../.env.test poetry run ptw --runner "pytest --testmon"
-```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -33,7 +33,7 @@ Pour lancer les tests e2e sur sa machine :
 
 ```sh
 cd e2e
-npm && npm test
+npm ci && npm test
 ```
 
 Par défaut, les tests se lancent en mode _headless_ mais on peut aussi les lancer avec l'interface de Codecept - CodeceptUI - grâce à la commande :


### PR DESCRIPTION
## :wrench: Problème

Communiquer les différentes suites de tests de l’application aux développeurs.

## :cake: Solution

S’assurer que l’installation de l’environnement permette immédiatement de lancer les tests.
Documenter `npm run test:{elm,svelte}`.
Offrir un aperçu des tests disponible depuis la racine du projet.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1573.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->