### PR TITLE
chore: pass Elm styles to tailwindcss

### DIFF
--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -117,23 +117,3 @@
 </div>
 
 <Footer />
-
-<style>
-	:global(.align-text-top
-			.font-normal
-			.grid
-			.grid-cols-3
-			.leading-10
-			.odd:bg-gray-100
-			.p-4
-			.pl-2
-			.pr-4
-			.pr-8
-			.pt-10
-			.pt-4
-			.py-3
-			.py-8
-			.rounded-lg
-			.shadow-dsfr) {
-	}
-</style>

--- a/app/tailwind.config.cjs
+++ b/app/tailwind.config.cjs
@@ -1,5 +1,5 @@
 const config = {
-	content: ['./src/**/*.{html,js,svelte,ts}'],
+	content: ['./src/**/*.{html,js,svelte,ts}', './elm/**/*.elm'],
 	theme: {
 		extend: {
 			boxShadow: { dsfr: '0px 2px 6px rgba(0, 0, 18, 0.16)' },


### PR DESCRIPTION
## :wrench: Problème

Maintenir une liste des classes Tailwind utilisées par Elm dans Svelte est fastidieux, avec un fort risque d’erreur.

## :cake: Solution

Ajouter les fichiers elm dans la liste des fichiers à surveiller par Tailwindcss.

## :desert_island: Comment tester

Naviguer sur la recette, les styles doivent être en place.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1581.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->