### PR TITLE
chore: notifier la création de la review app par un commentaire

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,11 +15,6 @@
 
 > _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
 
-<!-- BEGIN ## emplacement de l'URL de la review app ## -->
-Ne pas supprimer ce bloc, qui sera mis à jour [automatiquement](.github/workflows/review-scalingo.yml).
-<!-- END ## emplacement de l'URL de la review app ## -->
-
-
 <!--
 Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
 ex: fix #42

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -33,9 +33,9 @@ jobs:
     needs: [scalingo-link]
     steps:
       - name: Add review app URL
-        uses: blablacar/action-sticky-description@df5650c838f2bbc860ab8edd059b6e255fd7bb82
+        uses: thollander/actions-comment-pull-request@a78d1ddb11c87ee75a43e5c7697e2feeabc32718
         with:
-          issue_number: ${{ github.event.number }}
-          marker: "## emplacement de l'URL de la review app ##"
+          pr_number: ${{ github.event.number }}
           message: |
-            Se rendre sur la [review app](https://cdb-app-review-pr${{ github.event.number }}.osc-fr1.scalingo.io).
+            La _review app_ a été déployée : https://cdb-app-review-pr${{ github.event.number }}.osc-fr1.scalingo.io.
+          comment_tag: reviewapp


### PR DESCRIPTION
## :wrench: Problème

L’action blablacar est dépréciée (runs on Node 12).

## :cake: Solution

Utiliser une autre action, le but est simplement d’avoir un lien vers la recette.

## :rotating_light:  Points d'attention / Remarques

Le lien vers la recette est maintenant fourni par un commentaire.

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->