### PR TITLE
chore(tests): réutiliser le serveur web pendant les tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -36,7 +36,7 @@ def test_directory() -> str:
     return test_dir
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 @pytest.mark.asyncio
 async def fastapi_app(seed_filepath: str):
     # @TODO: read it from the root .env file


### PR DESCRIPTION
## :wrench: Problème

Les tests sont assez lents.

## :cake: Solution

La configuration du serveur est la même pour tous les tests, autant
utiliser la même instance plutôt que de reconfigurer le serveur pour
chaque test.
Les requêtes HTTP fournissent l’état, le serveur n’a pas besoin d’être
remis à zéro entre deux tests.

## :rotating_light:  Points d'attention / Remarques

Ce changement augmente la vitesse d’exécution des tests, `poetry run
pytest` passe de de 206s sur _master_ à 50s après ce commit.

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->