### PR TITLE
feat: Afficher le statut de chaque compte (supprimé / confirmé / non-confirmé) pour l'administrateur de territoire.

### DIFF
--- a/app/src/routes/(auth)/manager/professionnels/+page.svelte
+++ b/app/src/routes/(auth)/manager/professionnels/+page.svelte
@@ -40,6 +40,7 @@
 		onboardingDone: boolean;
 		phoneNumber: string;
 		nbBeneficiaries: number;
+		deletedAt: string;
 	};
 
 	function toList(account: GetAccountsSummaryQuery['accounts'][0]): AccountSummary {
@@ -54,6 +55,7 @@
 				phoneNumber: mobileNumber,
 				type: account.type,
 				confirmed: account.confirmed,
+				deletedAt: account.deletedAt,
 				onboardingDone: account.onboardingDone,
 				nbBeneficiaries: account.notebookCount.aggregate.count,
 			};
@@ -68,6 +70,7 @@
 				phoneNumber: phoneNumbers,
 				type: account.type,
 				confirmed: account.confirmed,
+				deletedAt: account.deletedAt,
 				onboardingDone: account.onboardingDone,
 				nbBeneficiaries: account.notebookCount.aggregate.count,
 			};
@@ -160,10 +163,12 @@
 						<td class="text-center">
 							{#if !account.confirmed}
 								<Button classNames="fr-btn--sm" on:click={() => confirmAccount(account.id)}
-									>Activer</Button
+									>Valider</Button
 								>
+							{:else if account.deletedAt}
+								<p class="fr-badge fr-badge--warning fr-badge--no-icon fr-badge--sm">désactivé</p>
 							{:else}
-								Actif
+								<p class="fr-badge fr-badge--new fr-badge--no-icon fr-badge--sm">validé</p>
 							{/if}
 						</td>
 						<td class="text-center">

--- a/e2e/features/manager/validateAccount.feature
+++ b/e2e/features/manager/validateAccount.feature
@@ -11,11 +11,12 @@ Fonctionnalité: Gestion de professionnels d'un déploiement
 		Quand j'attends que le tableau "Liste des professionnels" apparaisse
 		Alors je vois "1" sur la ligne "Giulia Diaby"
 		Alors je vois "0" sur la ligne "Blaise Alaise"
+		Alors je vois "DÉSACTIVÉ" sur la ligne "Sarah Vigote"
 
 	Scénario: Validation d'un professionnel
 		Soit un "administrateur de territoire" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Professionnels"
 		Quand j'attends que le tableau "Liste des professionnels" apparaisse
-		Quand je clique sur "Activer"
+		Quand je clique sur "Valider"
 		Quand j'attends 1 secondes
-		Alors je vois "Actif" sur la ligne "Lejeune Bienvenu"
+		Alors je vois "VALIDÉ" sur la ligne "Lejeune Bienvenu"


### PR DESCRIPTION
## :wrench: Problème

Actuellement lorsqu'un admin de structure supprime un pro, celui disparait bien de la structure mais reste affiché pour le manager. Il n'y a pas de moyen de distingué l'état du compte du pro (non confirmé, confirmé , supprimé) 

## :cake: Solution

On rajoute l'information de suppression de compte sous forme d'un badge dans la liste des pro

## :rotating_light:  Points d'attention / Remarques

 

## :desert_island: Comment tester

se connecter avec `manager.cd93`
cliquer sur `professionnels`
Voir que sarah.vigote et bien supprimé.
