### PR TITLE
chore: retirer une div en doublon sur NotebookMembers

### DIFF
--- a/app/src/lib/ui/Beneficiary/NotebookMembers.svelte
+++ b/app/src/lib/ui/Beneficiary/NotebookMembers.svelte
@@ -92,15 +92,13 @@
 				label="Se rattacher"
 				on:confirm={addCurrentAccountToNotebookMembers}
 			>
-				<div class="fr-form-group">
-					<Radio
-						caption="Bénéficiez-vous d'un mandat d'orientation en la qualité de référent ?"
-						name="memberType"
-						{options}
-						selected={memberType}
-						on:input={setSelectedMemberType}
-					/>
-				</div>
+				<Radio
+					caption="Bénéficiez-vous d'un mandat d'orientation en la qualité de référent ?"
+					name="memberType"
+					{options}
+					selected={memberType}
+					on:input={setSelectedMemberType}
+				/>
 			</Dialog>
 		</div>
 	{/if}


### PR DESCRIPTION
## :wrench: Problème

Le composant Radio installe déjà une `div.fr-form-group`.

## :cake: Solution

Retirer la div en doublon.

## :desert_island: Comment tester

Vérifier le comportement de la modale “Se rattacher” lorsqu’un pro décide de se rattacher à un bénéficiaire.

![image](https://user-images.githubusercontent.com/2758243/225359565-5c696588-6608-4c42-b462-e026dd88f3c5.png)


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->