### PR TITLE
feat: Affichage des informations de mise à jour des projets professionnels.

### DIFF
--- a/app/elm.json
+++ b/app/elm.json
@@ -9,6 +9,7 @@
             "Confidenceman02/elm-select": "8.2.0",
             "Gizra/elm-debouncer": "2.0.0",
             "austinshenk/elm-w3": "4.0.0",
+            "danhandrea/elm-date-format": "2.0.2",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
@@ -18,8 +19,10 @@
             "elm-community/json-extra": "4.3.0",
             "elm-community/list-extra": "8.7.0",
             "justinmimbs/date": "4.0.1",
+            "justinmimbs/timezone-data": "9.0.0",
             "prikhi/decimal": "2.0.0",
-            "rtfeldman/elm-css": "17.1.1"
+            "rtfeldman/elm-css": "17.1.1",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
             "cmditch/elm-bigint": "1.0.1",
@@ -31,8 +34,7 @@
             "elm/virtual-dom": "1.0.3",
             "elm-community/maybe-extra": "5.3.0",
             "robinheghan/murmur3": "1.0.0",
-            "rtfeldman/elm-hex": "1.0.0",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
+            "rtfeldman/elm-hex": "1.0.0"
         }
     },
     "test-dependencies": {

--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -2,6 +2,7 @@ module Diagnostic.Main exposing (..)
 
 import Browser
 import Date exposing (Date, fromIsoString)
+import DateFormat
 import Decimal
 import Domain.Account exposing (Account)
 import Domain.PoleEmploi.GeneralData exposing (GeneralData)
@@ -10,7 +11,10 @@ import Domain.ProfessionalSituation exposing (ProfessionalSituation, educationLe
 import Domain.Theme exposing (themeKeyStringToString)
 import Html exposing (..)
 import Html.Attributes exposing (class, rowspan)
+import Iso8601
 import List.Extra
+import Time
+import TimeZone
 
 
 type alias Flags =
@@ -30,6 +34,7 @@ type alias ProfessionalProjectFlags =
     , hourlyRate : Maybe Int
     , createdAt : String
     , updatedAt : String
+    , updater : Maybe Account
     }
 
 
@@ -136,22 +141,26 @@ extractPersonalSituationFromFlags flags =
     { theme = flags.refSituation.theme
     , description = flags.refSituation.description
     , createdAt = flags.createdAt
-    , creator =
-        flags.creator
-            |> Maybe.map
-                (\creator ->
-                    case ( creator.professional, creator.orientation_manager ) of
-                        ( Just p, _ ) ->
-                            p.firstname ++ " " ++ p.lastname ++ Maybe.withDefault "" (Maybe.map (\s -> " (" ++ s.name ++ ")") p.structure)
-
-                        ( _, Just o ) ->
-                            o.firstname ++ " " ++ o.lastname
-
-                        _ ->
-                            ""
-                )
-            |> Maybe.withDefault ""
+    , creator = formatAccount flags.creator
     }
+
+
+formatAccount : Maybe Account -> String
+formatAccount account =
+    account
+        |> Maybe.map
+            (\creator ->
+                case ( creator.professional, creator.orientation_manager ) of
+                    ( Just p, _ ) ->
+                        p.firstname ++ " " ++ p.lastname ++ Maybe.withDefault "" (Maybe.map (\s -> " (" ++ s.name ++ ")") p.structure)
+
+                    ( _, Just o ) ->
+                        o.firstname ++ " " ++ o.lastname
+
+                    _ ->
+                        ""
+            )
+        |> Maybe.withDefault ""
 
 
 extractPersonalSituationsToPersonalSituationsByTheme : ( PersonalSituation, List PersonalSituation ) -> PersonalSituationsByTheme
@@ -220,8 +229,9 @@ extractProfessionalProjectFromFlags flags =
             |> Maybe.map (Decimal.mul (Decimal.fromIntWithExponent 1 -2))
     , contractType = extractContractType flags.contractType
     , workingTimeType = extractWorkingTimeType flags.employmentType
-    , updatedAt = fromIsoString flags.updatedAt |> Result.toMaybe
-    , createdAt = fromIsoString flags.createdAt |> Result.toMaybe
+    , updatedAt = Iso8601.toTime flags.updatedAt |> Result.toMaybe
+    , createdAt = Iso8601.toTime flags.createdAt |> Result.toMaybe
+    , updater = formatAccount flags.updater
     }
 
 
@@ -242,6 +252,11 @@ extractWorkingTimeType workingTimeFlag =
 dateFormat : String
 dateFormat =
     "dd/MM/yyyy"
+
+
+parisZone : Time.Zone
+parisZone =
+    TimeZone.europe__paris ()
 
 
 unfilled : GenderType -> String
@@ -401,6 +416,27 @@ peInformationsView peGeneralData =
         ]
 
 
+formatLastUpdateInformation : ProfessionalProject -> String
+formatLastUpdateInformation professionalProject =
+    let
+        updater =
+            if professionalProject.updater == "" then
+                ""
+
+            else
+                " par " ++ professionalProject.updater
+
+        updatedAt =
+            case professionalProject.updatedAt |> Maybe.map (DateFormat.format "dd/MM/yyyy" parisZone) of
+                Nothing ->
+                    ""
+
+                Just date ->
+                    " le " ++ date
+    in
+    "Mis à jour" ++ updater ++ updatedAt
+
+
 professionalProjectView : Model -> Html msg
 professionalProjectView { professionalProjects } =
     div [ class "pt-10 flex flex-col" ]
@@ -416,8 +452,11 @@ professionalProjectView { professionalProjects } =
                     |> List.map
                         (\professionalProject ->
                             div [ class "fr-container shadow-dsfr rounded-lg" ]
-                                [ h4 [ class "text-france-bleu pt-8" ]
-                                    [ text (Maybe.withDefault "Projet en construction" (Maybe.map .label professionalProject.rome)) ]
+                                [ div [ class "pt-8 mb-8" ]
+                                    [ h4 [ class "text-france-bleu mb-0" ]
+                                        [ text (Maybe.withDefault "Projet en construction" (Maybe.map .label professionalProject.rome)) ]
+                                    , div [ class "text-sm" ] [ professionalProject |> formatLastUpdateInformation |> text ]
+                                    ]
                                 , div
                                     [ class "fr-grid-row fr-grid-row--gutters" ]
                                     [ div [ class "fr-col-4" ]

--- a/app/elm/Diagnostic/Main.elm.d.ts
+++ b/app/elm/Diagnostic/Main.elm.d.ts
@@ -18,6 +18,7 @@ export type ProfessionalProjectElm = Pick<
 	| 'employment_type'
 > & {
 	rome?: Pick<RomeCode, 'id' | 'label'>;
+	updater?: Creator;
 };
 
 export type Flags = {

--- a/app/elm/Domain/ProfessionalProject.elm
+++ b/app/elm/Domain/ProfessionalProject.elm
@@ -1,7 +1,7 @@
 module Domain.ProfessionalProject exposing (..)
 
-import Date exposing (Date)
 import Decimal exposing (Decimal)
+import Time
 
 
 type WorkingTime
@@ -41,12 +41,20 @@ type alias Theme =
     }
 
 
+type alias Account =
+    { firstname : String
+    , lastname : String
+    , structureName : Maybe String
+    }
+
+
 type alias ProfessionalProject =
     { id : String
     , rome : Maybe Rome
     , mobilityRadius : Maybe Int
-    , createdAt : Maybe Date
-    , updatedAt : Maybe Date
+    , createdAt : Maybe Time.Posix
+    , updatedAt : Maybe Time.Posix
+    , updater : String
     , hourlyRate : Maybe Decimal
     , contractType : Maybe ContractType
     , workingTimeType : Maybe WorkingTime

--- a/app/elm/Domain/ProfessionalProject.elm
+++ b/app/elm/Domain/ProfessionalProject.elm
@@ -1,5 +1,6 @@
 module Domain.ProfessionalProject exposing (..)
 
+import Domain.Account exposing (Account)
 import Decimal exposing (Decimal)
 import Time
 
@@ -41,20 +42,13 @@ type alias Theme =
     }
 
 
-type alias Account =
-    { firstname : String
-    , lastname : String
-    , structureName : Maybe String
-    }
-
-
 type alias ProfessionalProject =
     { id : String
     , rome : Maybe Rome
     , mobilityRadius : Maybe Int
     , createdAt : Maybe Time.Posix
     , updatedAt : Maybe Time.Posix
-    , updater : String
+    , updater : Maybe Account
     , hourlyRate : Maybe Decimal
     , contractType : Maybe ContractType
     , workingTimeType : Maybe WorkingTime

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -8699,6 +8699,7 @@ export type NotebookSituation = {
 	/** An object relationship */
 	refSituation?: Maybe<RefSituation>;
 	situationId: Scalars['uuid'];
+	updatedBy?: Maybe<Scalars['uuid']>;
 };
 
 /** aggregated selection of "notebook_situation" */
@@ -8763,6 +8764,7 @@ export type NotebookSituationBoolExp = {
 	notebookId?: InputMaybe<UuidComparisonExp>;
 	refSituation?: InputMaybe<RefSituationBoolExp>;
 	situationId?: InputMaybe<UuidComparisonExp>;
+	updatedBy?: InputMaybe<UuidComparisonExp>;
 };
 
 /** unique or primary key constraints on table "notebook_situation" */
@@ -8786,6 +8788,7 @@ export type NotebookSituationInsertInput = {
 	notebookId?: InputMaybe<Scalars['uuid']>;
 	refSituation?: InputMaybe<RefSituationObjRelInsertInput>;
 	situationId?: InputMaybe<Scalars['uuid']>;
+	updatedBy?: InputMaybe<Scalars['uuid']>;
 };
 
 /** aggregate max on columns */
@@ -8798,6 +8801,7 @@ export type NotebookSituationMaxFields = {
 	id?: Maybe<Scalars['uuid']>;
 	notebookId?: Maybe<Scalars['uuid']>;
 	situationId?: Maybe<Scalars['uuid']>;
+	updatedBy?: Maybe<Scalars['uuid']>;
 };
 
 /** order by max() on columns of table "notebook_situation" */
@@ -8809,6 +8813,7 @@ export type NotebookSituationMaxOrderBy = {
 	id?: InputMaybe<OrderBy>;
 	notebookId?: InputMaybe<OrderBy>;
 	situationId?: InputMaybe<OrderBy>;
+	updatedBy?: InputMaybe<OrderBy>;
 };
 
 /** aggregate min on columns */
@@ -8821,6 +8826,7 @@ export type NotebookSituationMinFields = {
 	id?: Maybe<Scalars['uuid']>;
 	notebookId?: Maybe<Scalars['uuid']>;
 	situationId?: Maybe<Scalars['uuid']>;
+	updatedBy?: Maybe<Scalars['uuid']>;
 };
 
 /** order by min() on columns of table "notebook_situation" */
@@ -8832,6 +8838,7 @@ export type NotebookSituationMinOrderBy = {
 	id?: InputMaybe<OrderBy>;
 	notebookId?: InputMaybe<OrderBy>;
 	situationId?: InputMaybe<OrderBy>;
+	updatedBy?: InputMaybe<OrderBy>;
 };
 
 /** response of any mutation on the table "notebook_situation" */
@@ -8863,6 +8870,7 @@ export type NotebookSituationOrderBy = {
 	notebookId?: InputMaybe<OrderBy>;
 	refSituation?: InputMaybe<RefSituationOrderBy>;
 	situationId?: InputMaybe<OrderBy>;
+	updatedBy?: InputMaybe<OrderBy>;
 };
 
 /** primary key columns input for table: notebook_situation */
@@ -8886,6 +8894,8 @@ export enum NotebookSituationSelectColumn {
 	NotebookId = 'notebookId',
 	/** column name */
 	SituationId = 'situationId',
+	/** column name */
+	UpdatedBy = 'updatedBy',
 }
 
 /** input type for updating data in table "notebook_situation" */
@@ -8897,6 +8907,7 @@ export type NotebookSituationSetInput = {
 	id?: InputMaybe<Scalars['uuid']>;
 	notebookId?: InputMaybe<Scalars['uuid']>;
 	situationId?: InputMaybe<Scalars['uuid']>;
+	updatedBy?: InputMaybe<Scalars['uuid']>;
 };
 
 /** Streaming cursor of the table "notebook_situation" */
@@ -8916,6 +8927,7 @@ export type NotebookSituationStreamCursorValueInput = {
 	id?: InputMaybe<Scalars['uuid']>;
 	notebookId?: InputMaybe<Scalars['uuid']>;
 	situationId?: InputMaybe<Scalars['uuid']>;
+	updatedBy?: InputMaybe<Scalars['uuid']>;
 };
 
 /** update columns of table "notebook_situation" */
@@ -8934,6 +8946,8 @@ export enum NotebookSituationUpdateColumn {
 	NotebookId = 'notebookId',
 	/** column name */
 	SituationId = 'situationId',
+	/** column name */
+	UpdatedBy = 'updatedBy',
 }
 
 export type NotebookSituationUpdates = {
@@ -11222,6 +11236,9 @@ export type ProfessionalProject = {
 	/** An object relationship */
 	rome_code?: Maybe<RomeCode>;
 	updatedAt?: Maybe<Scalars['timestamptz']>;
+	updatedBy?: Maybe<Scalars['uuid']>;
+	/** An object relationship */
+	updater?: Maybe<Account>;
 };
 
 /** aggregated selection of "professional_project" */
@@ -11319,6 +11336,8 @@ export type ProfessionalProjectBoolExp = {
 	romeCodeId?: InputMaybe<UuidComparisonExp>;
 	rome_code?: InputMaybe<RomeCodeBoolExp>;
 	updatedAt?: InputMaybe<TimestamptzComparisonExp>;
+	updatedBy?: InputMaybe<UuidComparisonExp>;
+	updater?: InputMaybe<AccountBoolExp>;
 };
 
 /** unique or primary key constraints on table "professional_project" */
@@ -11352,6 +11371,8 @@ export type ProfessionalProjectInsertInput = {
 	romeCodeId?: InputMaybe<Scalars['uuid']>;
 	rome_code?: InputMaybe<RomeCodeObjRelInsertInput>;
 	updatedAt?: InputMaybe<Scalars['timestamptz']>;
+	updatedBy?: InputMaybe<Scalars['uuid']>;
+	updater?: InputMaybe<AccountObjRelInsertInput>;
 };
 
 /** aggregate max on columns */
@@ -11365,6 +11386,7 @@ export type ProfessionalProjectMaxFields = {
 	notebookId?: Maybe<Scalars['uuid']>;
 	romeCodeId?: Maybe<Scalars['uuid']>;
 	updatedAt?: Maybe<Scalars['timestamptz']>;
+	updatedBy?: Maybe<Scalars['uuid']>;
 };
 
 /** order by max() on columns of table "professional_project" */
@@ -11377,6 +11399,7 @@ export type ProfessionalProjectMaxOrderBy = {
 	notebookId?: InputMaybe<OrderBy>;
 	romeCodeId?: InputMaybe<OrderBy>;
 	updatedAt?: InputMaybe<OrderBy>;
+	updatedBy?: InputMaybe<OrderBy>;
 };
 
 /** aggregate min on columns */
@@ -11390,6 +11413,7 @@ export type ProfessionalProjectMinFields = {
 	notebookId?: Maybe<Scalars['uuid']>;
 	romeCodeId?: Maybe<Scalars['uuid']>;
 	updatedAt?: Maybe<Scalars['timestamptz']>;
+	updatedBy?: Maybe<Scalars['uuid']>;
 };
 
 /** order by min() on columns of table "professional_project" */
@@ -11402,6 +11426,7 @@ export type ProfessionalProjectMinOrderBy = {
 	notebookId?: InputMaybe<OrderBy>;
 	romeCodeId?: InputMaybe<OrderBy>;
 	updatedAt?: InputMaybe<OrderBy>;
+	updatedBy?: InputMaybe<OrderBy>;
 };
 
 /** response of any mutation on the table "professional_project" */
@@ -11435,6 +11460,8 @@ export type ProfessionalProjectOrderBy = {
 	romeCodeId?: InputMaybe<OrderBy>;
 	rome_code?: InputMaybe<RomeCodeOrderBy>;
 	updatedAt?: InputMaybe<OrderBy>;
+	updatedBy?: InputMaybe<OrderBy>;
+	updater?: InputMaybe<AccountOrderBy>;
 };
 
 /** primary key columns input for table: professional_project */
@@ -11462,6 +11489,8 @@ export enum ProfessionalProjectSelectColumn {
 	RomeCodeId = 'romeCodeId',
 	/** column name */
 	UpdatedAt = 'updatedAt',
+	/** column name */
+	UpdatedBy = 'updatedBy',
 }
 
 /** input type for updating data in table "professional_project" */
@@ -11476,6 +11505,7 @@ export type ProfessionalProjectSetInput = {
 	notebookId?: InputMaybe<Scalars['uuid']>;
 	romeCodeId?: InputMaybe<Scalars['uuid']>;
 	updatedAt?: InputMaybe<Scalars['timestamptz']>;
+	updatedBy?: InputMaybe<Scalars['uuid']>;
 };
 
 /** aggregate stddev on columns */
@@ -11543,6 +11573,7 @@ export type ProfessionalProjectStreamCursorValueInput = {
 	notebookId?: InputMaybe<Scalars['uuid']>;
 	romeCodeId?: InputMaybe<Scalars['uuid']>;
 	updatedAt?: InputMaybe<Scalars['timestamptz']>;
+	updatedBy?: InputMaybe<Scalars['uuid']>;
 };
 
 /** aggregate sum on columns */
@@ -11580,6 +11611,8 @@ export enum ProfessionalProjectUpdateColumn {
 	RomeCodeId = 'romeCodeId',
 	/** column name */
 	UpdatedAt = 'updatedAt',
+	/** column name */
+	UpdatedBy = 'updatedBy',
 }
 
 export type ProfessionalProjectUpdates = {
@@ -16977,6 +17010,20 @@ export type GetNotebookByBeneficiaryIdQuery = {
 			rome_code?: { __typename?: 'rome_code'; id: string; label: string } | null;
 			contract_type?: { __typename?: 'contract_type'; id: string; label: string } | null;
 			employment_type?: { __typename?: 'employment_type'; id: string; label: string } | null;
+			updater?: {
+				__typename?: 'account';
+				orientation_manager?: {
+					__typename?: 'orientation_manager';
+					firstname?: string | null;
+					lastname?: string | null;
+				} | null;
+				professional?: {
+					__typename?: 'professional';
+					firstname: string;
+					lastname: string;
+					structure: { __typename?: 'structure'; name: string };
+				} | null;
+			} | null;
 		}>;
 		notebookInfo?: { __typename?: 'notebook_info'; needOrientation: boolean } | null;
 		beneficiary: {
@@ -17173,6 +17220,20 @@ export type GetNotebookByIdQuery = {
 			rome_code?: { __typename?: 'rome_code'; id: string; label: string } | null;
 			contract_type?: { __typename?: 'contract_type'; id: string; label: string } | null;
 			employment_type?: { __typename?: 'employment_type'; id: string; label: string } | null;
+			updater?: {
+				__typename?: 'account';
+				orientation_manager?: {
+					__typename?: 'orientation_manager';
+					firstname?: string | null;
+					lastname?: string | null;
+				} | null;
+				professional?: {
+					__typename?: 'professional';
+					firstname: string;
+					lastname: string;
+					structure: { __typename?: 'structure'; name: string };
+				} | null;
+			} | null;
 		}>;
 		notebookInfo?: { __typename?: 'notebook_info'; needOrientation: boolean } | null;
 		beneficiary: {
@@ -17362,6 +17423,20 @@ export type NotebookFragmentFragment = {
 		rome_code?: { __typename?: 'rome_code'; id: string; label: string } | null;
 		contract_type?: { __typename?: 'contract_type'; id: string; label: string } | null;
 		employment_type?: { __typename?: 'employment_type'; id: string; label: string } | null;
+		updater?: {
+			__typename?: 'account';
+			orientation_manager?: {
+				__typename?: 'orientation_manager';
+				firstname?: string | null;
+				lastname?: string | null;
+			} | null;
+			professional?: {
+				__typename?: 'professional';
+				firstname: string;
+				lastname: string;
+				structure: { __typename?: 'structure'; name: string };
+			} | null;
+		} | null;
 	}>;
 	notebookInfo?: { __typename?: 'notebook_info'; needOrientation: boolean } | null;
 	beneficiary: {
@@ -18046,6 +18121,20 @@ export type GetNotebookQuery = {
 				rome_code?: { __typename?: 'rome_code'; id: string; label: string } | null;
 				contract_type?: { __typename?: 'contract_type'; id: string; label: string } | null;
 				employment_type?: { __typename?: 'employment_type'; id: string; label: string } | null;
+				updater?: {
+					__typename?: 'account';
+					orientation_manager?: {
+						__typename?: 'orientation_manager';
+						firstname?: string | null;
+						lastname?: string | null;
+					} | null;
+					professional?: {
+						__typename?: 'professional';
+						firstname: string;
+						lastname: string;
+						structure: { __typename?: 'structure'; name: string };
+					} | null;
+				} | null;
 			}>;
 			situations: Array<{
 				__typename?: 'notebook_situation';
@@ -18751,6 +18840,47 @@ export const NotebookFragmentFragmentDoc = {
 								{ kind: 'Field', name: { kind: 'Name', value: 'mobilityRadius' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'updater' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'orientation_manager' },
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{ kind: 'Field', name: { kind: 'Name', value: 'firstname' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'lastname' } },
+													],
+												},
+											},
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'professional' },
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{ kind: 'Field', name: { kind: 'Name', value: 'firstname' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'lastname' } },
+														{
+															kind: 'Field',
+															name: { kind: 'Name', value: 'structure' },
+															selectionSet: {
+																kind: 'SelectionSet',
+																selections: [
+																	{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+																],
+															},
+														},
+													],
+												},
+											},
+										],
+									},
+								},
 							],
 						},
 					},
@@ -29335,6 +29465,62 @@ export const GetNotebookDocument = {
 														{ kind: 'Field', name: { kind: 'Name', value: 'mobilityRadius' } },
 														{ kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
 														{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+														{
+															kind: 'Field',
+															name: { kind: 'Name', value: 'updater' },
+															selectionSet: {
+																kind: 'SelectionSet',
+																selections: [
+																	{
+																		kind: 'Field',
+																		name: { kind: 'Name', value: 'orientation_manager' },
+																		selectionSet: {
+																			kind: 'SelectionSet',
+																			selections: [
+																				{
+																					kind: 'Field',
+																					name: { kind: 'Name', value: 'firstname' },
+																				},
+																				{
+																					kind: 'Field',
+																					name: { kind: 'Name', value: 'lastname' },
+																				},
+																			],
+																		},
+																	},
+																	{
+																		kind: 'Field',
+																		name: { kind: 'Name', value: 'professional' },
+																		selectionSet: {
+																			kind: 'SelectionSet',
+																			selections: [
+																				{
+																					kind: 'Field',
+																					name: { kind: 'Name', value: 'firstname' },
+																				},
+																				{
+																					kind: 'Field',
+																					name: { kind: 'Name', value: 'lastname' },
+																				},
+																				{
+																					kind: 'Field',
+																					name: { kind: 'Name', value: 'structure' },
+																					selectionSet: {
+																						kind: 'SelectionSet',
+																						selections: [
+																							{
+																								kind: 'Field',
+																								name: { kind: 'Name', value: 'name' },
+																							},
+																						],
+																					},
+																				},
+																			],
+																		},
+																	},
+																],
+															},
+														},
 													],
 												},
 											},

--- a/app/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/app/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -55,6 +55,7 @@
 						contract_type,
 						employment_type,
 						hourlyRate,
+						updater,
 					}) => ({
 						id,
 						createdAt,
@@ -64,6 +65,7 @@
 						hourlyRate,
 						contractType: contract_type,
 						employmentType: employment_type,
+						updater,
 					})
 				),
 				peGeneralData: externalDataDetail?.data?.source || null,

--- a/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
@@ -107,11 +107,12 @@
 		rhs: ProfessionalProject
 	): boolean {
 		return (
-			lhs.contractTypeId === rhs.contractTypeId &&
-			lhs.employmentTypeId === rhs.employmentTypeId &&
-			lhs.romeCodeId === rhs.romeCodeId &&
-			lhs.hourlyRate === rhs.hourlyRate &&
-			lhs.mobilityRadius === rhs.mobilityRadius
+			// null and undefined are considered equal
+			lhs.contractTypeId == rhs.contractTypeId &&
+			lhs.employmentTypeId == rhs.employmentTypeId &&
+			lhs.romeCodeId == rhs.romeCodeId &&
+			lhs.hourlyRate == rhs.hourlyRate &&
+			lhs.mobilityRadius == rhs.mobilityRadius
 		);
 	}
 

--- a/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
@@ -44,6 +44,9 @@
 	>;
 	export let refSituations: RefSituation[];
 
+	type NotebookProfessionalProject =
+		GetNotebookQuery['notebook_public_view'][number]['notebook']['professionalProjects'][number];
+
 	let stuck = true;
 	const stickToTop = false;
 	function handleStuck(e: CustomEvent<{ isStuck: boolean }>) {
@@ -52,10 +55,11 @@
 
 	$: errorMessage = '';
 	let selectedSituations: string[] = notebook.situations.map(({ refSituation }) => refSituation.id);
-	let professionalProjects: Pick<
+	type ProfessionalProject = Pick<
 		ProfessionalProjectInsertInput,
 		'id' | 'mobilityRadius' | 'contractTypeId' | 'romeCodeId' | 'hourlyRate' | 'employmentTypeId'
-	>[] =
+	>;
+	let professionalProjects: ProfessionalProject[] =
 		notebook?.professionalProjects?.map((professionalProject) => {
 			return {
 				id: professionalProject.id,
@@ -81,6 +85,47 @@
 
 	function close() {
 		onClose();
+	}
+
+	function professionalProjectIsModified(professionalProject: ProfessionalProject): boolean {
+		const currentProfessionalProject = notebook.professionalProjects.find(
+			({ id }) => id === professionalProject.id
+		);
+
+		if (!currentProfessionalProject) {
+			return true;
+		}
+
+		return !areEqualsProfessionalProjects(
+			toProfessionalProject(currentProfessionalProject),
+			professionalProject
+		);
+	}
+
+	function areEqualsProfessionalProjects(
+		lhs: ProfessionalProject,
+		rhs: ProfessionalProject
+	): boolean {
+		return (
+			lhs.contractTypeId === rhs.contractTypeId &&
+			lhs.employmentTypeId === rhs.employmentTypeId &&
+			lhs.romeCodeId === rhs.romeCodeId &&
+			lhs.hourlyRate === rhs.hourlyRate &&
+			lhs.mobilityRadius === rhs.mobilityRadius
+		);
+	}
+
+	function toProfessionalProject(
+		notebookProfessionalProject: NotebookProfessionalProject
+	): ProfessionalProject {
+		return {
+			contractTypeId: (notebookProfessionalProject.contract_type?.id ?? null) as ContractTypeEnum,
+			employmentTypeId: (notebookProfessionalProject.employment_type?.id ??
+				null) as EmploymentTypeEnum,
+			romeCodeId: notebookProfessionalProject.rome_code?.id ?? null,
+			hourlyRate: notebookProfessionalProject.hourlyRate,
+			mobilityRadius: notebookProfessionalProject.mobilityRadius,
+		};
 	}
 
 	async function handleSubmit(values: ProNotebookSocioproInput) {
@@ -122,6 +167,7 @@
 
 		const professionalProjectsToUpdate: ProfessionalProjectUpdates[] = professionalProjects
 			.filter(({ id }) => id)
+			.filter(professionalProjectIsModified)
 			.map((project) => {
 				return {
 					where: {

--- a/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
@@ -227,6 +227,7 @@
 						hourlyRate,
 						employment_type,
 						contract_type,
+						updater,
 					}) => ({
 						id,
 						createdAt,
@@ -236,6 +237,7 @@
 						hourlyRate,
 						contractType: contract_type,
 						employmentType: employment_type,
+						updater,
 					})
 				),
 			},

--- a/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
+++ b/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
@@ -41,6 +41,19 @@ fragment notebookFragment on notebook {
     mobilityRadius
     updatedAt
     createdAt
+    updater {
+      orientation_manager {
+        firstname
+        lastname
+      }
+      professional {
+        firstname
+        lastname
+        structure {
+          name
+        }
+      }
+    }
   }
   notebookInfo {
     needOrientation

--- a/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
+++ b/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
@@ -126,6 +126,19 @@ query GetNotebook(
         mobilityRadius
         updatedAt
         createdAt
+        updater {
+          orientation_manager {
+            firstname
+            lastname
+          }
+          professional {
+            firstname
+            lastname
+            structure {
+              name
+            }
+          }
+        }
       }
       situations(where: { deletedAt: { _is_null: true } }, order_by: { createdAt: desc }) {
         id

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_professional_project.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_professional_project.yaml
@@ -19,6 +19,8 @@ configuration:
       custom_name: romeCodeId
     updated_at:
       custom_name: updatedAt
+    updated_by:
+      custom_name: updatedBy
   custom_column_names:
     contract_type_id: contractTypeId
     created_at: createdAt
@@ -28,6 +30,7 @@ configuration:
     notebook_id: notebookId
     rome_code_id: romeCodeId
     updated_at: updatedAt
+    updated_by: updatedBy
   custom_root_fields: {}
 object_relationships:
   - name: contract_type
@@ -54,6 +57,15 @@ object_relationships:
   - name: rome_code
     using:
       foreign_key_constraint_on: rome_code_id
+  - name: updater
+    using:
+      manual_configuration:
+        column_mapping:
+          updated_by: id
+        insertion_order: null
+        remote_table:
+          name: account
+          schema: public
 insert_permissions:
   - role: manager
     permission:
@@ -118,6 +130,7 @@ select_permissions:
         - notebook_id
         - rome_code_id
         - updated_at
+        - updated_by
       filter: {}
   - role: admin_structure
     permission:
@@ -127,10 +140,11 @@ select_permissions:
         - employment_type_id
         - hourly_rate
         - id
-        - notebook_id
         - mobility_radius
+        - notebook_id
         - rome_code_id
         - updated_at
+        - updated_by
       filter:
         notebook:
           _or:
@@ -160,6 +174,7 @@ select_permissions:
         - notebook_id
         - rome_code_id
         - updated_at
+        - updated_by
       filter:
         notebook:
           beneficiary_id:
@@ -177,6 +192,7 @@ select_permissions:
         - notebook_id
         - rome_code_id
         - updated_at
+        - updated_by
       filter:
         notebook:
           beneficiary:
@@ -195,6 +211,7 @@ select_permissions:
         - notebook_id
         - rome_code_id
         - updated_at
+        - updated_by
       filter:
         notebook:
           beneficiary:
@@ -212,6 +229,7 @@ select_permissions:
         - notebook_id
         - rome_code_id
         - updated_at
+        - updated_by
       filter:
         notebook:
           members:
@@ -235,6 +253,8 @@ update_permissions:
               - active:
                   _eq: true
       check: null
+      set:
+        updated_by: x-hasura-User-Id
   - role: professional
     permission:
       columns:
@@ -252,6 +272,8 @@ update_permissions:
               - active:
                   _eq: true
       check: null
+      set:
+        updated_by: x-hasura-User-Id
 delete_permissions:
   - role: orientation_manager
     permission:

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_professional_project.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_professional_project.yaml
@@ -93,6 +93,8 @@ insert_permissions:
                   _eq: X-Hasura-User-Id
               - active:
                   _eq: true
+      set:
+        updated_by: x-hasura-User-Id
       columns:
         - contract_type_id
         - employment_type_id
@@ -110,6 +112,8 @@ insert_permissions:
                   _eq: X-Hasura-User-Id
               - active:
                   _eq: true
+      set:
+        updated_by: x-hasura-User-Id
       columns:
         - contract_type_id
         - employment_type_id

--- a/hasura/migrations/carnet_de_bord/1678998383915_alter_table_public_professional_project_add_column_updated_by/down.sql
+++ b/hasura/migrations/carnet_de_bord/1678998383915_alter_table_public_professional_project_add_column_updated_by/down.sql
@@ -1,0 +1,1 @@
+ alter table "public"."professional_project" drop column "updated_by";

--- a/hasura/migrations/carnet_de_bord/1678998383915_alter_table_public_professional_project_add_column_updated_by/up.sql
+++ b/hasura/migrations/carnet_de_bord/1678998383915_alter_table_public_professional_project_add_column_updated_by/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."professional_project" add column "updated_by" UUID
+ null;


### PR DESCRIPTION
## :wrench: Problème

Lorsqu'un professionnel consulte le projet d'un bénéficiaire, il ne connait pas la date et l'auteur de la dernière mise à jour du projet.

## :cake: Solution

On enregistre l'auteur de chaque mise à jour de projet professionnel dans le champ `updatedBy`.
On affiche l'auteur, sa structure et la date de mise à jour de chaque projet professionnel.


## :rotating_light:  Points d'attention / Remarques

Il faut modifier la mise à jour actuel car on met à jour tous les projets professionnels à chaque enregistrement ...

## :desert_island: Comment tester

Se connecter en tant que `pierre.chevalier`.
Se rendre sur un carnet.
Vérifier que les dates de mises à jour des projets professionnels sont affichées.
Ouvrir le formulaire d'édition d'un diagnostic socioprofessionnel.
Enregistrer le diagnostic sans faire de modification.
Vérifier que les dates de mises à jour des projets professionnels n'ont pas changé.
Ouvrir le formulaire d'édition d'un diagnostic socioprofessionnel.
Enregistrer le diagnostic en modifiant un projet professionnel.
Vérifier que la date de mise à jour du projet professionnel modifié est la date du jour.


closes #1535
