### PR TITLE
chore: utiliser le mode non durable de PostgreSQL

### DIFF
--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -14,6 +14,14 @@ services:
       - '5433:5432'
     volumes:
       - cdb-pgdata-test:/var/lib/postgresql/data
+    command:
+      - postgres
+      - -c
+      - fsync=off
+      - -c
+      - synchronous_commit=off
+      - -c
+      - full_page_writes=off
 
   hasura_test:
     image: hasura/graphql-engine:v2.15.2-ce.cli-migrations-v3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,14 @@ services:
       - '5432:5432'
     volumes:
       - cdb-pgdata:/var/lib/postgresql/data
+    command:
+      - postgres
+      - -c
+      - fsync=off
+      - -c
+      - synchronous_commit=off
+      - -c
+      - full_page_writes=off
 
   hasura:
     image: hasura/graphql-engine:v2.15.2-ce.cli-migrations-v3


### PR DESCRIPTION
https://www.postgresql.org/docs/current/non-durability.html

Rend PostgreSQL bien plus rapide, au détriment de la durabilité en cas
de crash de la base de données ou d’arrêt brutal de la machine.
L’opération `TRUNCATE` (utilisée par `seed.sql`) est notamment bien plus
rapide dans cette configuration.
Configuration adaptée au développement et aux tests.


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->