### PR TITLE
chore: Tester la branche `master` uniquement pour les releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   workflow_dispatch:
   push:
-    branches: [master, alpha, beta, next]
+    branches: master
 
 jobs:
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     # as every commit on master led to a release tag creation
     # we do not want to test every commit on master
     # but only every release tag
-    branches-ignore:
-      - master
     tags:
       - v*
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,13 @@ name: Test
 
 on:
   push:
-    branches:
-      - "master"
+    # as every commit on master led to a release tag creation
+    # we do not want to test every commit on master
+    # but only every release tag
+    branches-ignore:
+      - master
     tags:
-      - "!v*"
+      - v*
   pull_request:
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    # as every commit on master led to a release tag creation
+    # as every commit on master leads to a release tag
     # we do not want to test every commit on master
     # but only every release tag
     tags:


### PR DESCRIPTION
## :wrench: Problème

Chaque commit sur `master` entraine la création d'une release.
Cela se traduit par un commit supplémentaire qui est lui-même taggé.
La création de ce commit automatique annule les tests qui sont en cours sur le commit précédent.
Cela entraine une CI en échec un commit sur deux, ce qui ne reflète pas l'état réel de la branche `master`.

## :cake: Solution

Sur la branche `master`, on ne déclenche plus les tests sur les commits qui ne sont pas des release.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Les tests ne devront être exécutés qu'une seule fois lors du merge sur `master`.
