### PR TITLE
fix: Correction de la faute dans le nom du type de contrat `saisonnier`.

### DIFF
--- a/app/elm/Domain/ProfessionalProject.elm
+++ b/app/elm/Domain/ProfessionalProject.elm
@@ -74,7 +74,7 @@ contractTypeToLabel contractType =
             "Intérim"
 
         Seasonal ->
-            "Saisonier"
+            "Saisonnier"
 
         Liberal ->
             "Libéral"
@@ -138,7 +138,7 @@ contractTypeStringToType contractType =
         "interim" ->
             Just Interim
 
-        "Saisonier" ->
+        "Saisonnier" ->
             Just Seasonal
 
         "saisonnier" ->


### PR DESCRIPTION
## :wrench: Problème

Une erreur d'orthographe s'est glissée dans le type de contrat `saisonnier` (oubli d'un `n` dans la liste de choix).

## :cake: Solution

Ajout du `n` manquant.


## :rotating_light:  Points d'attention / Remarques

Merci Arnaud !

## :desert_island: Comment tester

Se rendre sur un carnet en édition.
Vérifier que la liste de choix de type de contrat affiche `Saisonnier`.
