### PR TITLE
chore: ajout d'un Makefile

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -41,17 +41,9 @@ query SearchBeneficiaries($filter: String) {
 Avec **l’environnement de dev démarré**, on génère les types avec `codegen` :
 
 ```sh
-# Pour Python, depuis le répertoire backend/
-poetry run cdb/scripts/codegen.py
+make codegen
 ```
-
 Le schéma est écrit dans un module Python `backend.cdb.api._gen.schema_gql`.
-
-```sh
-# Pour JavaScript, depuis le répertoire app/
-npm run codegen
-```
-
 Les types graphql sont générés dans `src/_gen`. On peut alors les utiliser dans les composants
 
 ```ts

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,8 @@ Vous devez au préalable avoir correctement installé les logiciels suivants :
 - hasura-cli (latest)
 - pre-commit https://pre-commit.com
 - poetry (1.2)
+- [make](https://www.gnu.org/software/make/)
+  - Il vient souvent pré-installé et est disponible sur les gestionnaires de paquets
 
 > ℹ️️ Les versions indiquées sont celles utilisées et préconisées par l'équipe de développement. Il est possible que l'application fonctionne avec des versions différentes.
 
@@ -24,23 +26,15 @@ git clone git@github.com:gip-inclusion/carnet-de-bord.git
 cd carnet-de-bord
 ```
 
-**2/** Créer et adapter les fichiers d'environnement
+**2/** Lancer l'installation avec make
 
 ```sh
-cp .env.sample .env
-cp .env.test.sample .env.test
+make install # copie les fichiers d'environnement et télécharge les dépendances
 ````
-
-**3/** Récupérer les dépendances du projet
-
-```sh
-npm ci --prefix app # installer les dépendances de l'application
-pre-commit install # installer les hooks Git
-```
 
 > ℹ️ Parmi les dépendances de développement du projet (cf. [package.json](./app/package.json)), on retrouve la CLI Hasura, utile pour l'étape #5.
 
-**4/** Démarrer les composants tiers
+**3/** Démarrer les composants tiers
 
 L'application repose sur Hasura et PostgreSQL. Une [stack docker-compose](./docker-compose.yaml) est maintenue par l'équipe pour instancier et démarrer ces services.
 
@@ -48,44 +42,41 @@ L'application repose sur Hasura et PostgreSQL. Une [stack docker-compose](./dock
 docker compose up
 ```
 
-**5/** Alimenter la base de données
+**4/** Alimenter la base de données
 
 Dans un second terminal :
 
 ```sh
-cd hasura
-hasura seed apply # initialiser les données de test
-hasura console # lancer la console hasura
+make seed-database
 ```
 ou
 ```sh
+cd hasura
 hasura console --envfile ../.env # lancer la console hasura en utilisant les variables définies dans le fichier .env
 ```
 
-**6/** Compiler et démarrer l'application SvelteKit
+**5/** Compiler et démarrer l'application SvelteKit
 
 Dans un troisième terminal :
 
 ```sh
-npm --prefix app run dev # démarrer le serveur de développement SvelteKit
+make start:app # démarrer le serveur de développement SvelteKit
 ```
 
-**7/** Configurer et démarrer l'API back-end métier
+**6/** Configurer et démarrer l'API back-end métier
 
 Dans un quatrième et dernier terminal
 ```sh
-cd backend
-poetry install # installer les dépendances python
-poetry run uvicorn --reload cdb.api.main:app # démarrer l'instance de serveur FastAPI
+make start:backend # démarre l'instance de serveur FastAPI
 ```
 
-**8/** Accéder aux applications & outils (cf. captures ci-dessous)
+**7/** Accéder aux applications & outils (cf. captures ci-dessous)
 
 - Webapp SvelteKit → http://localhost:3000
 - API FastAPI → http://localhost:8000/docs
 - Console Hasura →  http://localhost:9695
 
-**9/** Accéder aux différents comptes de démonstration
+**8/** Accéder aux différents comptes de démonstration
 
 L'équipe maintient des comptes de démo, renseignés dans le fichier [DEMO.md](./DEMO.md).
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -51,8 +51,7 @@ make seed-database
 ```
 ou
 ```sh
-cd hasura
-hasura console --envfile ../.env # lancer la console hasura en utilisant les variables définies dans le fichier .env
+hasura --project ./hasura console
 ```
 
 **5/** Compiler et démarrer l'application SvelteKit

--- a/Makefile
+++ b/Makefile
@@ -2,28 +2,41 @@
 # Be sure to place this BEFORE `include` directives, if any.
 THIS_FILE := $(lastword $(MAKEFILE_LIST))
 
+# -------------------------------------
+# Install
+# -------------------------------------
+
 install:
 	-cp -n .env.sample .env
 	-cp -n .env.test.sample .env.test
 	pre-commit install
 	@$(MAKE) -f $(THIS_FILE) .install-app
 	@$(MAKE) -f $(THIS_FILE) .install-backend
-	npm install --prefix e2e
+	@$(MAKE) -f $(THIS_FILE) .install-e2e
 
 .install-app:
-	npm install --prefix app
+	cd app; \
+		npm install
 
 .install-backend:
 	cd backend; \
 		poetry install
+
+.install-e2e:
+	cd e2e; \
+		npm install
 
 seed-database:
 	cd hasura; \
 		hasura seed apply; \
 		hasura console
 
+# -------------------------------------
+# Start
+# -------------------------------------
 start-app:
-	npm --prefix app run dev
+	cd app; \
+		npm run dev
 
 start-backend:
 	cd backend; \

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,10 @@ THIS_FILE := $(lastword $(MAKEFILE_LIST))
 # Install
 # -------------------------------------
 
-install:
+install: .install-app .install-backend .install-e2e
 	-cp -n .env.sample .env
 	-cp -n .env.test.sample .env.test
 	pre-commit install
-	@$(MAKE) -f $(THIS_FILE) .install-app
-	@$(MAKE) -f $(THIS_FILE) .install-backend
-	@$(MAKE) -f $(THIS_FILE) .install-e2e
 
 .install-app:
 	cd app && \
@@ -45,11 +42,11 @@ test-backend:
 
 test-backend-watch:
 	./scripts/launch_tests.sh
-	cd backend; \
+	cd backend && \
 		ENV_FILE=../.env.test poetry run ptw --runner "pytest --testmon"
 
 test-app:
-	cd app;
+	cd app && \
 		npm run test
 
 
@@ -60,7 +57,7 @@ seed-database:
 	hasura --project ./hasura seed apply --database-name carnet_de_bord
 
 codegen:
-	cd backend; \
+	cd backend && \
 		poetry run cdb/scripts/codegen.py
-	cd app; \
+	cd app && \
 		npm run codegen

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
+# Determine this makefile's path.
+# Be sure to place this BEFORE `include` directives, if any.
+THIS_FILE := $(lastword $(MAKEFILE_LIST))
+
 install:
 	-cp -n .env.sample .env
 	-cp -n .env.test.sample .env.test
-	npm ci --prefix app
 	pre-commit install
+	@$(MAKE) -f $(THIS_FILE) .install-app
+	@$(MAKE) -f $(THIS_FILE) .install-backend
+
+.install-app:
+	npm ci --prefix app
+
+.install-backend:
 	cd backend; \
 		poetry install
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 	@$(MAKE) -f $(THIS_FILE) .install-e2e
 
 .install-app:
-	cd app; \
+	cd app && \
 		npm ci
 
 .install-backend:

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ seed-database:
 		hasura seed apply; \
 		hasura console
 
-start-front:
+start-app:
 	npm --prefix app run dev
 
-start-back:
+start-backend:
 	cd backend; \
 		poetry run uvicorn --reload cdb.api.main:app

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,7 @@ test-app:
 # Other
 # -------------------------------------
 seed-database:
-	cd hasura; \
-		hasura seed apply; \
-		hasura console
+	hasura --project ./hasura seed apply --database-name carnet_de_bord
 
 codegen:
 	cd backend; \

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install:
 
 .install-app:
 	cd app; \
-		npm install
+		npm ci
 
 .install-backend:
 	cd backend; \
@@ -24,7 +24,7 @@ install:
 
 .install-e2e:
 	cd e2e; \
-		npm install
+		npm ci
 
 seed-database:
 	cd hasura; \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-# Determine this makefile's path.
-# Be sure to place this BEFORE `include` directives, if any.
-THIS_FILE := $(lastword $(MAKEFILE_LIST))
-
 # -------------------------------------
 # Install
 # -------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,6 @@ seed-database:
 
 codegen:
 	cd backend; \
-		petry run cdb/scripts/codegen.py
+		poetry run cdb/scripts/codegen.py
 	cd app; \
 		npm run codegen

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,6 @@ install:
 	cd e2e; \
 		npm ci
 
-seed-database:
-	cd hasura; \
-		hasura seed apply; \
-		hasura console
-
 # -------------------------------------
 # Start
 # -------------------------------------
@@ -41,3 +36,35 @@ start-app:
 start-backend:
 	cd backend; \
 		poetry run uvicorn --reload cdb.api.main:app
+
+# --------------------------------------
+#  Test
+# --------------------------------------
+test-backend:
+	./scripts/launch_tests.sh
+	cd backend; \
+		ENV_FILE=../.env.test poetry run pytest -s tests
+
+test-backend-watch:
+	./scripts/launch_tests.sh
+	cd backend; \
+		ENV_FILE=../.env.test poetry run ptw --runner "pytest --testmon"
+
+test-app:
+	cd app;
+		npm run test
+
+
+# -------------------------------------
+# Other
+# -------------------------------------
+seed-database:
+	cd hasura; \
+		hasura seed apply; \
+		hasura console
+
+codegen:
+	cd backend; \
+		petry run cdb/scripts/codegen.py
+	cd app; \
+		npm run codegen

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ install:
 	pre-commit install
 	@$(MAKE) -f $(THIS_FILE) .install-app
 	@$(MAKE) -f $(THIS_FILE) .install-backend
+	npm install --prefix e2e
 
 .install-app:
-	npm ci --prefix app
+	npm install --prefix app
 
 .install-backend:
 	cd backend; \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 install:
-	cp -n .env.sample .env
-	cp -n .env.test.sample .env.test
+	-cp -n .env.sample .env
+	-cp -n .env.test.sample .env.test
 	npm ci --prefix app
 	pre-commit install
 	cd backend; \

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,7 @@ start-backend:
 #  Test
 # --------------------------------------
 test-backend:
-	./scripts/launch_tests.sh
-	cd backend; \
-		ENV_FILE=../.env.test poetry run pytest -s tests
+	./scripts/launch_tests.sh python
 
 test-backend-watch:
 	./scripts/launch_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+install:
+	cp -n .env.sample .env
+	cp -n .env.test.sample .env.test
+	npm ci --prefix app
+	pre-commit install
+	cd backend; \
+		poetry install
+
+seed-database:
+	cd hasura; \
+		hasura seed apply; \
+		hasura console
+
+start-front:
+	npm --prefix app run dev
+
+start-back:
+	cd backend; \
+		poetry run uvicorn --reload cdb.api.main:app

--- a/TESTING.md
+++ b/TESTING.md
@@ -4,18 +4,16 @@ L’application bénéficie de tests frontend, backend et d’intégration (end-
 
 ## Backend
 
-Dans le répertoire racine du projet, lancez `./scripts/launch_tests.sh` pour lancer les dockers de test en local. PostgreSQL devrait alors écouter sur 5433. Pour s'y connecter :
+Lancez dans le répertoire racine du projet:
+```
+make test-backend
+# ou en mode watch
+make test-backend-watch
+```
+Pendant les tests, postgreSQL devrait écouter sur 5433. Pour s'y connecter :
 
     psql -U cdb -h localhost -p 5433 postgres;
 
-Lancez dans le répertoire `backend` les tests pytest avec poetry :
-
-    ENV_FILE=../.env.test poetry run pytest -s tests
-
-Pour lancer les tests en mode watch :
-```
-ENV_FILE=../.env.test poetry run ptw --runner "pytest --testmon"
-```
 
 ## Frontend
 


### PR DESCRIPTION
## :wrench: Problème

La procédure d'installation et de démarrage est claire et bien documentée. Mais elle pourrait être plus simple.

## :cake: Solution
### Installation
`make install` est une commande classique. Dans notre cas elle permet d'automatiser les différentes commandes nécessaire à l'installation du projet.

### Démarrage
Make est un outil bien supporté. Les shells proposent de l'auto-complétion pour les commandes make. Cela facilite le démarrage de l'application grâce à deux targets: start-front et start-back

## :desert_island: Comment tester
Aller dans le répertoire racine du projet et lancer les commandes suivantes : 
```bash
make install
make start-app
make start-backend
```