### PR TITLE
fix: Ne pas verrouiller les données lors de la migration.

### DIFF
--- a/hasura/migrations/carnet_de_bord/1680096458377_add-ref-theme/up.sql
+++ b/hasura/migrations/carnet_de_bord/1680096458377_add-ref-theme/up.sql
@@ -1,6 +1,4 @@
-ALTER TABLE "public"."notebook_action" DISABLE TRIGGER USER;
-ALTER TABLE "public"."notebook_target" DISABLE TRIGGER USER;
-
+SET session_replication_role = replica;
 
 CREATE TABLE "public"."ref_theme" (
 	"name" text NOT NULL,
@@ -188,5 +186,4 @@ alter table "public"."ref_situation"
   references "public"."ref_theme"
   ("name") on update restrict on delete restrict;
 
-ALTER TABLE "public"."notebook_action" ENABLE TRIGGER USER;
-ALTER TABLE "public"."notebook_target" ENABLE TRIGGER USER;
+SET session_replication_role = DEFAULT;


### PR DESCRIPTION
## :wrench: Problème

Lors de la désactivation des triggers dans la migration [https://github.com/gip-inclusion/carnet-de-bord/blob/master/hasura/migrations/carnet_de_bord/1680096458377_add-ref-theme/up.sql](https://github.com/gip-inclusion/carnet-de-bord/blob/master/hasura/migrations/carnet_de_bord/1680096458377_add-ref-theme/up.sql), l'instruction utilisée pose un lock sur la table, ce qui entraine un deadlock et empêche la migration de terminer.

## :cake: Solution

Comme expliqué dans [ce fil](https://stackoverflow.com/questions/37730870/how-to-disable-postgresql-triggers-in-one-transaction-only), on utilise l'instruction `SET session_replication_role = replica;` pour désactiver les triggers au sein de la migration uniquement.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

La migration a été testée au sein d'une transaction sur la production.
