### PR TITLE
fix: Correction de l'impossibilité de choisir le type de contrat `libéral`.

### DIFF
--- a/app/elm/Domain/ProfessionalProject.elm
+++ b/app/elm/Domain/ProfessionalProject.elm
@@ -105,7 +105,7 @@ contractTypeToKey contractType =
             "saisonnier"
 
         Liberal ->
-            "liberale"
+            "liberal"
 
         Professionalization ->
             "contrat_professionnalisation"
@@ -147,7 +147,7 @@ contractTypeStringToType contractType =
         "Libéral" ->
             Just Liberal
 
-        "liberale" ->
+        "liberal" ->
             Just Liberal
 
         "Contrat de professionnalisation" ->


### PR DESCRIPTION
## :wrench: Problème

Lors de la saisie du type de contrat d'un projet professionnel, la sélection du type `Libéral` entraine une erreur, empêchant la sauvegarde du projet professionnel.
Cela est du à une typo dans l'enum utilisé (`liberale` côté `elm`, `liberal` côté `postgresql`).


## :cake: Solution

Corriger la typo dans l'enum `elm`.


## :rotating_light:  Points d'attention / Remarques

RAS


## :desert_island: Comment tester

Se connecter en tant que `pierre.chevalier`.
Se rendre sur le carnet de `Sophie Tifour`.
Modifier les projets professionnels.
Sélectionner `Libéral` comme type de contrat.
Enregistrer les projets professionnels.
Vérifier que le projet est enregistré avec le type de contrat `Libéral`.

closes #1619
