### PR TITLE
fix: Permettre aux administrateurs de structure de voir les membres de carnet au sein du même déploiement.

### DIFF
--- a/hasura/metadata/databases/carnet_de_bord/tables/public_account.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_account.yaml
@@ -231,6 +231,9 @@ select_permissions:
               structure:
                 deployment_id:
                   _eq: X-Hasura-Deployment-Id
+          - orientation_manager:
+              deployment_id:
+                _eq: X-Hasura-Deployment-Id
   - role: beneficiary
     permission:
       columns:

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_member.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_member.yaml
@@ -148,10 +148,14 @@ select_permissions:
         - account_id
       filter:
         account:
-          professional:
-            structure:
-              deployment_id:
-                _eq: X-Hasura-Deployment-Id
+          _or:
+            - professional:
+                structure:
+                  deployment_id:
+                    _eq: X-Hasura-Deployment-Id
+            - orientation_manager:
+                deployment_id:
+                  _eq: X-Hasura-Deployment-Id
       allow_aggregations: true
   - role: beneficiary
     permission:


### PR DESCRIPTION
## :wrench: Problème

En tant qu’Administrateur de structure, quand je consulte un carnet, je ne vois pas le chargé d'orientation.

## :cake: Solution

Les permissions des tables `account` et `notebook_member` sont trop restrictives : elles limitent la visibilité pour les Administrateurs de structure aux seuls professionnels du même déploiement.
On ajoute donc la visibilité des chargés d'orientation dont le déploiement est le même que celui de l'Administrateur de structure.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Se connecter en tant que `jacques.celaire`.
Se rendre sur le carnet de `Sophie Tifour`.
Vérifier que `Giulia Diaby` apparaît comme Chargé d'orientation.

closes #1633
