### PR TITLE
chore: Mise à jour de SvelteKit pour supprimer la vulnérabilité CSRF.

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -45,7 +45,7 @@
 				"@graphql-codegen/urql-svelte-operations-store": "^1.3.2",
 				"@sentry/types": "7.46.0",
 				"@sveltejs/adapter-node": "1.2.3",
-				"@sveltejs/kit": "1.15.0",
+				"@sveltejs/kit": "1.15.4",
 				"@tailwindcss/forms": "^0.5.0",
 				"@tailwindcss/typography": "^0.5.0",
 				"@testing-library/jest-dom": "^5.16.1",
@@ -3975,9 +3975,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.0.tgz",
-			"integrity": "sha512-fvDsW9msxWjDU/j9wwLlxEZ6cpXQYcmcQHq7neJMqibMEl39gI1ztVymGnYqM8KLqZXwNmhKtLu8EPheukKtXQ==",
+			"version": "1.15.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.4.tgz",
+			"integrity": "sha512-m+Tid9nbtFawmiu85lDlal0AQ7UeuV48UsuKMe06QLr3ntMQSUzIPqyswNRZqFrar6NhVTUXQ0aO61M3U4MWpQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -3993,7 +3993,7 @@
 				"set-cookie-parser": "^2.5.1",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.21.0"
+				"undici": "5.20.0"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -13960,9 +13960,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
-			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
 			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
@@ -17521,9 +17521,9 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.0.tgz",
-			"integrity": "sha512-fvDsW9msxWjDU/j9wwLlxEZ6cpXQYcmcQHq7neJMqibMEl39gI1ztVymGnYqM8KLqZXwNmhKtLu8EPheukKtXQ==",
+			"version": "1.15.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.4.tgz",
+			"integrity": "sha512-m+Tid9nbtFawmiu85lDlal0AQ7UeuV48UsuKMe06QLr3ntMQSUzIPqyswNRZqFrar6NhVTUXQ0aO61M3U4MWpQ==",
 			"dev": true,
 			"requires": {
 				"@sveltejs/vite-plugin-svelte": "^2.0.0",
@@ -17538,7 +17538,7 @@
 				"set-cookie-parser": "^2.5.1",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.21.0"
+				"undici": "5.20.0"
 			},
 			"dependencies": {
 				"magic-string": {
@@ -24912,9 +24912,9 @@
 			"dev": true
 		},
 		"undici": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
-			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
 			"dev": true,
 			"requires": {
 				"busboy": "^1.6.0"

--- a/app/package.json
+++ b/app/package.json
@@ -50,7 +50,7 @@
 		"@graphql-codegen/urql-svelte-operations-store": "^1.3.2",
 		"@sentry/types": "7.46.0",
 		"@sveltejs/adapter-node": "1.2.3",
-		"@sveltejs/kit": "1.15.0",
+		"@sveltejs/kit": "1.15.4",
 		"@tailwindcss/forms": "^0.5.0",
 		"@tailwindcss/typography": "^0.5.0",
 		"@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
## :wrench: Problème

En faisant un `npm audit`, on peut voir que SvelteKit présente la vulnérabilité suivante :

> SvelteKit vulnerable to Cross-Site Request Forgery - https://github.com/advisories/GHSA-5p75-vc5g-8rv2
> SvelteKit framework has Insufficient CSRF protection for CORS requests - https://github.com/advisories/GHSA-gv7g-x59x-wf8f


## :cake: Solution

Mettre à jour SvelteKit avec la version 1.15.4.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Vérifier que les tests automatisés passent.
Aucun changement fonctionnel n'est apporté.
