### PR TITLE
Revert "chore: Ne pas annuler le déploiement d'une release en cours."

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: deploy
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
## :wrench: Problème

En essayant de ne pas annuler les déploiements de release en cours, on bloque les déploiements en preprod car le workflow de déploiement attend la validation des environnements pour être considéré comme terminé.

## :cake: Solution

On revert le changement précédent en attendant une meilleure solution au problème initial.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

RAS