### PR TITLE
fix: allow NIR from corse

### DIFF
--- a/backend/cdb/api/db/models/nir.py
+++ b/backend/cdb/api/db/models/nir.py
@@ -1,12 +1,17 @@
 def nir_format(field: str):
     if field:
         nir = field.strip()
-        if len(nir) != 15:
-            return "The NIR must be 15 digits long"
-        if not all([char.isdigit() for char in nir]):
+        if len(nir) != 15 and len(nir) != 13:
+            return "The NIR must be 13 or 15 (with control key) digits long"
+        if not all([char.isdigit() or char == "A" or char == "B" for char in nir]):
             return "The NIR cannot contain letters"
+        # https://fr.wikipedia.org/wiki/Num%C3%A9ro_de_s%C3%A9curit%C3%A9_sociale_en_France#cite_note-F
+        nir = nir.replace("2A", "19").replace("2B", "18")
         payload = int(nir[:13])
-        check = int(nir[13:])
-        valid = 97 - payload % 97 == check
-        if not valid:
-            return "The provided NIR is not valid"
+
+        # Run control key validation only if we have it
+        if len(nir) == 15:
+            check = int(nir[13:])
+            valid = 97 - payload % 97 == check
+            if not valid:
+                return "The provided NIR is not valid"

--- a/backend/tests/test_nir_check.py
+++ b/backend/tests/test_nir_check.py
@@ -14,3 +14,12 @@ async def test_nir_only_digits():
 
 async def test_nir_wrong_key():
     assert nir_format("185077505612324") == "The provided NIR is not valid"
+
+
+async def test_nir_corse():
+    assert nir_format("192102A131123") is None
+    assert nir_format("192102B131123") is None
+
+    assert nir_format("192102A13112318") == "The provided NIR is not valid"
+
+    assert nir_format("192102A13112357") is None

--- a/backend/tests/test_nir_check.py
+++ b/backend/tests/test_nir_check.py
@@ -2,8 +2,14 @@ from cdb.api.db.models.nir import nir_format
 
 
 async def test_nir_length():
-    assert nir_format("12345678901234") == "The NIR must be 15 digits long"
-    assert nir_format("1234567890123456") == "The NIR must be 15 digits long"
+    assert (
+        nir_format("12345678901234")
+        == "The NIR must be 13 or 15 (with control key) digits long"
+    )
+    assert (
+        nir_format("1234567890123456")
+        == "The NIR must be 13 or 15 (with control key) digits long"
+    )
     assert nir_format("185077505612323") is None
 
 


### PR DESCRIPTION
## :wrench: Problème

L'import d'un NIR avec une lettre (Corse) échoue.

## :cake: Solution

Autoriser le A et le B dans le NIR pour les codes postaux de la Corse.


## :desert_island: Comment tester

Importer des bénéficiaires avec un NIR corse et vérifier que le NIR est accepté

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
fix #1671 
