### PR TITLE
chore: Ajouter la variable BACKEND_API_URL dans les déploiements des review app Hasura.

### DIFF
--- a/scripts/create-review-apps.sh
+++ b/scripts/create-review-apps.sh
@@ -107,7 +107,7 @@ function set_backend_env() {
 
 function set_hasura_env() {
   env_set hasura ACTION_BASE_URL "$APP_URL/actions"
-  env_set app BACKEND_API_URL "$BACKEND_URL"
+  env_set hasura BACKEND_API_URL "$BACKEND_URL"
 }
 
 function set_app_env() {


### PR DESCRIPTION
## :wrench: Problème

Lors de la création de la tâche périodique via Hasura, une coquille s'est glissée dans la création de la variable d'environnement `BACKEND_API_URL`pour la review app d'Hasura.

## :cake: Solution

Corriger la coquille (remplacer `app` par `hasura`).


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Les reviews app doivent se déployer sans problème.
