### PR TITLE
fix: Corrige les CSP.

### DIFF
--- a/app/svelte.config.js
+++ b/app/svelte.config.js
@@ -1,6 +1,16 @@
 import { vitePreprocess } from '@sveltejs/kit/vite';
 import adapter from '@sveltejs/adapter-node';
 import { resolve } from 'path';
+
+function formatURLForCsp(originalUrl) {
+	if (!originalUrl) return;
+	const url = new URL(originalUrl);
+	url.username = '';
+	url.password = '';
+
+	return url.href;
+}
+
 const config = {
 	kit: {
 		env: {
@@ -18,6 +28,7 @@ const config = {
 					'self',
 					...(process.env.NODE_ENV === 'production' ? [''] : ['unsafe-eval']),
 					'https://client.crisp.chat/',
+					...(process.env.PUBLIC_MATOMO_URL ? [process.env.PUBLIC_MATOMO_URL] : []),
 				],
 				'connect-src': [
 					'self',
@@ -25,14 +36,18 @@ const config = {
 					...(process.env.NODE_ENV === 'production' ? [] : ['ws:', 'http:']),
 					'wss://client.relay.crisp.chat/',
 					'https://client.crisp.chat/static/',
-					// Note that in development, PUBLIC_MATOMO_URL(or PUBLIC_SENTRY_DSN) will not be read from .env
-					// (because dotenv has not been loaded at this point), you have to set it
-					// in the environment explicitly, e.g. `PUBLIC_MATOMO_URL=... npm run dev`
-					process.env?.GRAPHQL_API_URL,
-					process.env?.BACKEND_API_URL,
-					process.env?.PUBLIC_MATOMO_URL,
-					process.env?.PUBLIC_SENTRY_DSN,
-				].filter(Boolean),
+					...[
+						// Note that in development, environment variables will not be read from .env
+						// (because dotenv has not been loaded at this point), you have to set it
+						// in the environment explicitly, e.g. `PUBLIC_MATOMO_URL=... npm run dev`
+						// or use shdotenv script, e.g. `./scripts/shdotenv make start-app`
+						process.env.GRAPHQL_API_URL,
+						process.env.BACKEND_API_URL,
+						process.env.PUBLIC_SENTRY_DSN,
+					]
+						.map(formatURLForCsp)
+						.filter(Boolean),
+				],
 			},
 		},
 		adapter: adapter({ precompress: true }),


### PR DESCRIPTION
## :wrench: Problème

En regardant la console de l'environnement de démo, on constate qu'il existe encore deux ⚠️ warnings ⚠️ liés aux CSP :
```
The source list for the Content Security Policy directive 'connect-src' contains an invalid source: ***redacted Sentry URL***. It will be ignored.
```
et
```
Refused to load the script 'https://matomo.inclusion.beta.gouv.fr/matomo.js' because it violates the following Content Security Policy directive: "script-src 'self'  ***redacted Crisp URL***". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.
```

On risque d'avoir des problèmes de non remontée d'information (tracking + monitoring des erreurs) lors de la prochaine mise en production.

## :cake: Solution

Concernant le warning lié à l'URL Sentry, celui-ci est du au fait que la variable d'environnement contient un mot de passe. Bien que ce soit une URL valide, celle-ci n'est pas une source CSP valide. (cf la [documentation Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources))

Pour le second warning, lié à Matomo, celui-ci est du au fait qu'on autorise l'exécution du script Matomo.js dans la configuration `connect-src` alors que les scripts sont à autoriser dans la partie `script-src`.

## :rotating_light:  Points d'attention / Remarques

RAS.

## :desert_island: Comment tester

Se rendre sur la review app.
Ouvrir la console web.
Vérifier qu'il n'y a aucun warning.