### PR TITLE
Gestion des variables d'environnement dynamiques dans la Content-Security-Policy

### DIFF
--- a/app/__tests__/csp.test.ts
+++ b/app/__tests__/csp.test.ts
@@ -1,0 +1,14 @@
+import { expandURLsInCSP } from '$lib/utils/csp';
+
+it('should expand environment variables in the generated CSP', async () => {
+	const originalCSP =
+		"default-src 'self'; connect-src 'self' %GRAPHQL_API_URL% %PUBLIC_SENTRY_DSN%; style-src 'self'";
+	const expandedCSP = expandURLsInCSP(
+		originalCSP,
+		{ GRAPHQL_API_URL: 'https://graphql.example.org:5000/v1' },
+		{ PUBLIC_SENTRY_DSN: 'https://user@sentry.example.org/123' }
+	);
+	expect(expandedCSP).toEqual(
+		`default-src 'self'; connect-src 'self' https://graphql.example.org:5000 https://sentry.example.org; style-src 'self'`
+	);
+});

--- a/app/src/hooks.server.ts
+++ b/app/src/hooks.server.ts
@@ -2,6 +2,7 @@ import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { logger } from '$lib/utils/logger';
 import * as Sentry from '@sentry/node';
 import { initSentry, captureException } from '$lib/utils/sentry';
+import { expandURLsInCSP } from '$lib/utils/csp';
 
 initSentry(Sentry);
 
@@ -14,6 +15,11 @@ export const handle: Handle = async ({ event, resolve }) => {
 		// @see https://kit.svelte.dev/docs/hooks#server-hooks-handle
 		filterSerializedResponseHeaders: (name) => name.toLowerCase().startsWith('content'),
 	});
+
+	const csp = response.headers.get('content-security-policy');
+	if (csp) {
+		response.headers.set('content-security-policy', expandURLsInCSP(csp));
+	}
 
 	logger.info({
 		startTime: new Date(requestStartTime).toISOString(),

--- a/app/src/lib/utils/csp.ts
+++ b/app/src/lib/utils/csp.ts
@@ -1,0 +1,19 @@
+import { env as realPrivateEnv } from '$env/dynamic/private';
+import { env as realPublicEnv } from '$env/dynamic/public';
+
+function formatURLForCSP(originalUrl) {
+	if (!originalUrl) return;
+	const url = new URL(originalUrl);
+
+	return `${url.protocol}//${url.host}`;
+}
+
+export function expandURLsInCSP(
+	csp,
+	privateEnv: Record<string, string> = realPrivateEnv,
+	publicEnv: Record<string, string> = realPublicEnv
+) {
+	return csp.replace(/%(\w+)%/g, (_, varname) => {
+		return formatURLForCSP(privateEnv[varname] ?? publicEnv[varname] ?? '');
+	});
+}

--- a/app/svelte.config.js
+++ b/app/svelte.config.js
@@ -2,15 +2,6 @@ import { vitePreprocess } from '@sveltejs/kit/vite';
 import adapter from '@sveltejs/adapter-node';
 import { resolve } from 'path';
 
-function formatURLForCsp(originalUrl) {
-	if (!originalUrl) return;
-	const url = new URL(originalUrl);
-	url.username = '';
-	url.password = '';
-
-	return url.href;
-}
-
 const config = {
 	kit: {
 		env: {
@@ -18,17 +9,20 @@ const config = {
 		},
 		csp: {
 			mode: 'auto',
+			// The %…% delimited identifiers in these directives are processed by the 'handle' hook
+			// in hooks.server.ts to expand environment variables at runtime
 			directives: {
 				'base-uri': ['self'],
 				'default-src': ['self'],
 				'font-src': ['self', 'https://client.crisp.chat/static/'],
 				'img-src': ['self', 'data:', 'https://*.crisp.chat/'],
 				'style-src': ['self', '*.crisp.chat', 'unsafe-inline'],
+				'media-src': ['self', 'nextcloud.fabrique.social.gouv.fr'],
 				'script-src': [
 					'self',
 					...(process.env.NODE_ENV === 'production' ? [''] : ['unsafe-eval']),
 					'https://client.crisp.chat/',
-					...(process.env.PUBLIC_MATOMO_URL ? [process.env.PUBLIC_MATOMO_URL] : []),
+					'%PUBLIC_MATOMO_URL%',
 				],
 				'connect-src': [
 					'self',
@@ -36,17 +30,10 @@ const config = {
 					...(process.env.NODE_ENV === 'production' ? [] : ['ws:', 'http:']),
 					'wss://client.relay.crisp.chat/',
 					'https://client.crisp.chat/static/',
-					...[
-						// Note that in development, environment variables will not be read from .env
-						// (because dotenv has not been loaded at this point), you have to set it
-						// in the environment explicitly, e.g. `PUBLIC_MATOMO_URL=... npm run dev`
-						// or use shdotenv script, e.g. `./scripts/shdotenv make start-app`
-						process.env.GRAPHQL_API_URL,
-						process.env.BACKEND_API_URL,
-						process.env.PUBLIC_SENTRY_DSN,
-					]
-						.map(formatURLForCsp)
-						.filter(Boolean),
+					'%GRAPHQL_API_URL%',
+					'%BACKEND_API_URL%',
+					'%PUBLIC_MATOMO_URL%',
+					'%PUBLIC_SENTRY_DSN%',
 				],
 			},
 		},


### PR DESCRIPTION
## :wrench: Problème

La _Content Security Policy_ (CSP) générée par SvelteKit actuellement ne prend pas en compte les changements de variables d'environnements après le déploiement (build) de l'application. Ceci pose un problème pour les _review apps_ qui sont reconfigurées après leur déploiement.

De plus, il manque une directive `connect-src` pour permettre l'envoi de données à Matomo.

## :cake: Solution

SvelteKit ne permet pas d'évaluer dynamiquement la CSP. Pour contourner cette limitation, on utilise des marqueurs de la forme `%GRAPHQL_API_URL%` dans les directives fournies à SvelteKit, qui sont ensuite remplacés à la volée dans un _hook_ qui traite les réponses HTTP avant l'envoi au client.

## :desert_island: Comment tester

Vérifier le bon fonctionnement en _review app_, y compris la remontée vers Matomo et Sentry.

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
