### PR TITLE
fix: Rend optionnelle la donnée soumis aux droits et devoirs lors de l'import.

### DIFF
--- a/backend/cdb/caf_msa/parse_infos_foyer_rsa.py
+++ b/backend/cdb/caf_msa/parse_infos_foyer_rsa.py
@@ -18,7 +18,7 @@ class CafInfoFlux(BaseModel):
 
 class CafBeneficiary(BaseModel):
     nir: str
-    soumis_droit_et_devoir: bool
+    soumis_droit_et_devoir: bool | None
 
     @validator("soumis_droit_et_devoir", pre=True)
     def validate_soumis_droit_devoir(value):
@@ -42,7 +42,7 @@ class CafMsaInfosFoyer(BaseModel):
 class CdbBeneficiaryInfos(BaseModel):
     cafNumber: str = Field(alias="caf_number")
     rightRsa: str = Field(alias="right_rsa")
-    subjectToRightAndDuty: bool = Field(alias="subject_right_and_duty")
+    subjectToRightAndDuty: bool | None = Field(alias="subject_right_and_duty")
     rsaSuspensionReason: str | None = Field(alias="rsa_suspension_reason")
     rsaClosureReason: str | None = Field(alias="rsa_closure_reason")
     rsaClosureDate: str | None = Field(alias="rsa_closure_date")

--- a/backend/tests/caf_msa/test_parse_infos_foyer.py
+++ b/backend/tests/caf_msa/test_parse_infos_foyer.py
@@ -150,3 +150,18 @@ def test_transform_cafMsaFoyer_to_beneficiary():
     )
 
     assert transform_cafMsaFoyer_to_beneficiary(personne, foyer) == beneficiary
+
+
+soumis_droit_et_devoir_test_data = [
+    ("0", False),
+    (False, False),
+    ("1", True),
+    (True, True),
+    (None, None),
+]
+
+
+@pytest.mark.parametrize("a,expected", soumis_droit_et_devoir_test_data)
+def test_transform_soumis_droit_et_devoir(a, expected):
+    beneficiary = CafBeneficiary(nir="1231231231231", soumis_droit_et_devoir=a)
+    assert beneficiary.soumis_droit_et_devoir == expected


### PR DESCRIPTION
## :wrench: Problème

Certains utilisateurs / utilisatrices ne reçoivent pas le courriel récapitulatif lors d'un import de fichier CAF/MSA.
En regardant les logs, on voit que le traitement en tâche de fond échoue :
```
2023-05-03 15:41:33.201268961 +0200 CEST [web-1] {"logger": "cdb.caf_msa.update_cafmsa_infos", "level": "error", "timestamp": "2023-05-03T13:41:33.134648Z", "sentry_id": "0c00a5cbd8be483d926514fe0874dfe4", "message": "1 validation error for CafBeneficiary\nsoumis_droit_et_devoir\n  none is not an allowed value (type=type_error.none.not_allowed)"}
```
Après analyse, il apparait que l'information `soumis au droit et devoir` n'est pas une information obligatoire.

## :cake: Solution

La donnée `soumis au droit et devoir` est bien une donnée optionnelle en base de données.
En revanche, lors du parsing du fichier, le champ est considéré obligatoire, aussi la validation de la donnée d'entrée échoue.

Pour corriger le problème, on change le type de `soumis_droit_et_devoir` pour être `bool | None`.

## :rotating_light:  Points d'attention / Remarques

Il faudra surement  investiguer pour comprendre pourquoi le traitement en échec s'arrête plutôt que de comptabiliser le bénéficiaire en erreur et continuer sur les autres lignes du fichier.

## :desert_island: Comment tester

Importer un fichier CAF/MSA au format XML dans lequel la donnée `soumis au droit et devoir` n'est pas renseignée.
Vérifier que le courriel de récapitulatif est bien reçu (sur Mailtrap).

fix #1703 
