### PR TITLE
chore: Suppression du warning lors de la notification d'un nouveau déploiement.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: Find last deployed commit
-        uses: SamhammerAG/last-successful-build-action@a54c030db88e60c06a9e50c25418748afc623c20
+        uses: SamhammerAG/last-successful-build-action@1c368a27a90596574a71ac0ede422a897d0e8e84
         id: latest-deployment
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## :wrench: Problème

L'action GitHub qui notifie d'un nouveau déploiement en production affiche les warnings suivants :
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: SamhammerAG/last-successful-build-action@a54c030db88e60c06a9e50c25418748afc623c20. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

## :cake: Solution

Le premier warning concerne l'utilisation de Node.js 12 par l'action `SamhammerAG/last-successful-build-action`.
La dernière version disponible de cette action utilise Node.js 16. On met donc à jour la version que l'on utilise dans le workflow `deploy.yml`.

Concernant le second warning, je n'ai pas trouvé d'usage de `set-output` dans notre workflow.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Lors du prochain déploiement en production, vérifier que le job `Notify` n'émet aucun warning.
