### PR TITLE
chore: Suppression de dépendances superflues de flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680487167,
-        "narHash": "sha256-9FNIqrxDZgSliGGN2XJJSvcDYmQbgOANaZA4UWnTdg4=",
+        "lastModified": 1683082554,
+        "narHash": "sha256-emO6mChgdBi4RwchtCCtAkvFf/OSkMyOQMqk6EZEPJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53dad94e874c9586e71decf82d972dfb640ef044",
+        "rev": "0d373d5af960504dd60c3d06c65e553b36ef29d8",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -12,12 +12,16 @@
       in
       {
         devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            libxml2 # Libxml2 is required for the python lib lxml
+            # Indirect dependencies of libxml2
+            zlib
+            pkg-config
+          ];
           packages = with pkgs; [
             nodejs-16_x
-            python310
             pre-commit
             poetry
-            python310Packages.magic
             gnumake
           ];
         };


### PR DESCRIPTION
## :wrench: Problème

Le setup nix actuel pose des problèmes avec le lancement des tests ou du serveur. Il semble y avoir des conflits de contexte entre nix et poetry.

## :cake: Solution

Supprimer les dépendances python explicites et utiliser poetry uniquement.


## :rotating_light:  Points d'attention / Remarques
Pour que ce setup fonctionne, j'ai ajouté libxml2 et ses dépendances dans le setup.

## :desert_island: Comment tester
Lancer les tests end to end dans le contexte nix. S'ils fonctionnent correctement c'est que le setup est juste.

```bash
# À la racine du projet
nix develop

# Dans le terminal nix
make install
./scripts/launch_tests.sh e2e
```

