### PR TITLE
chore: Renommage de la branche `master` en `main`.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
       - main
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: Release
 on:
   workflow_dispatch:
   push:
-    branches: master
+    branches:
+      - master
+      - main
 
 jobs:
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ name: Test
 
 on:
   push:
-    # as every commit on master leads to a release tag
-    # we do not want to test every commit on master
+    # as every commit on main leads to a release tag
+    # we do not want to test every commit on main
     # but only every release tag
     tags:
       - v*

--- a/app/src/lib/ui/base/Footer.svelte
+++ b/app/src/lib/ui/base/Footer.svelte
@@ -40,7 +40,7 @@
 				<li class="fr-footer__bottom-item">
 					<a
 						class="fr-footer__bottom-link"
-						href="https://github.com/gip-inclusion/carnet-de-bord/blob/master/CHANGELOG.md"
+						href="https://github.com/gip-inclusion/carnet-de-bord/blob/main/CHANGELOG.md"
 						target="_blank"
 						rel="noreferrer"
 					>


### PR DESCRIPTION
## :wrench: Problème

La branche principale s'appelle `master` ce qui n'est pas très inclusif.

## :cake: Solution

Suite au sondage entre dev, c'est le nom `main` qui est choisi.
On remplace les occurences de `master` en `main`.


## :rotating_light:  Points d'attention / Remarques

Ne pas oublier de renommer la branche sur GitHub avant de merger.
Il faut également que chaque dev renomme localement en suivant ces étapes.
https://gist.github.com/danieldogeanu/739f88ea5312aaa23180e162e3ae89ab

## :desert_island: Comment tester

Aucune idée.
