### PR TITLE
chore: Améliore le montage des éléments elm.

### DIFF
--- a/app/elm/README.md
+++ b/app/elm/README.md
@@ -11,22 +11,19 @@ Pour utiliser le composant Elm dans svelte
 
 ```svelte
 	import { Elm } from '$elm/MainApp/Main.elm';
-	import { afterUpdate } from 'svelte';
+	import ElmWrapper from '$lib/utils/ElmWrapper.svelte';
 
-	let elmNode: HTMLElement;
-	afterUpdate(() => {
-		if (!elmNode) return;
+	const elmSetup = (node: HTMLElement) => {
 		Elm.MainApp.Main.init({
-			node: elmNode,
+			node,
 			flags: {
 				...some_data
 			},
 		});
-	});
+	};
 
 <div>
-	<!-- Elm app needs to be wrapped by a div to avoid navigation exceptions when unmounting -->
-	<div bind:this={elmNode} />
+	<ElmWrapper setup={elmSetup} />
 </div>
 ```
 

--- a/app/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/app/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -24,18 +24,15 @@
 	export let externalDataDetail: ExternalDataDetail | null;
 
 	import { Elm as DiagnosticElm } from '$elm/Diagnostic/Main.elm';
-	import { afterUpdate } from 'svelte';
+	import ElmWrapper from '$lib/utils/ElmWrapper.svelte';
 
-	let elmNode: HTMLElement;
-	afterUpdate(() => {
-		if (!elmNode) return;
-
+	const elmSetup = (node: HTMLElement) => {
 		const situationsWithFormattedDates = notebook.situations?.map((situation) => {
 			return { ...situation, createdAt: formatDateLocale(situation.createdAt) };
 		});
 
 		DiagnosticElm.Diagnostic.Main.init({
-			node: elmNode,
+			node,
 			flags: {
 				professionalSituation: {
 					workSituation: notebook.workSituation,
@@ -72,12 +69,9 @@
 				personalSituations: situationsWithFormattedDates || null,
 			},
 		});
-	});
+	};
 </script>
 
 {#key notebook}
-	<div class="elm-node">
-		<!-- Elm app needs to be wrapped by a div to avoid navigation exceptions when unmounting -->
-		<div bind:this={elmNode} />
-	</div>
+	<ElmWrapper setup={elmSetup} />
 {/key}

--- a/app/src/lib/ui/NPSRating/NPSRating.svelte
+++ b/app/src/lib/ui/NPSRating/NPSRating.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
-	import { afterUpdate } from 'svelte';
 	import { backendAPI, token, graphqlAPI } from '$lib/stores';
 	import { captureException } from '$lib/utils/sentry';
 	import { Elm as NPSRatingElm } from '../../../../elm/NPSRating/Main.elm';
+	import ElmWrapper from '$lib/utils/ElmWrapper.svelte';
 
-	let elmNode: HTMLElement;
-	afterUpdate(async () => {
+	const elmSetup = (node: HTMLElement) => {
 		const app = NPSRatingElm.NPSRating.Main.init({
-			node: elmNode,
+			node,
 			flags: {
 				backendAPI: $backendAPI,
 				token: $token,
@@ -18,7 +17,7 @@
 		app.ports.sendError.subscribe((message: string) => {
 			setTimeout(() => captureException(new Error(message)), 10);
 		});
-	});
+	};
 </script>
 
-<div bind:this={elmNode} />
+<ElmWrapper setup={elmSetup} />

--- a/app/src/lib/ui/ProNotebookAction/ProNotebookActionList.svelte
+++ b/app/src/lib/ui/ProNotebookAction/ProNotebookActionList.svelte
@@ -7,7 +7,7 @@
 		type AddNotebookActionMutation,
 	} from '$lib/graphql/_gen/typed-document-nodes';
 	import { Elm } from '$elm/Pages/Pro/Carnet/Action/List/Main.elm';
-	import ElmWrapper from '../../utils/ElmWrapper.svelte';
+	import ElmWrapper from '$lib/utils/ElmWrapper.svelte';
 	import { graphqlAPI, token } from '$lib/stores';
 	import { captureException } from '$lib/utils/sentry';
 	import { type OperationStore, mutation, operationStore } from '@urql/svelte';
@@ -26,7 +26,7 @@
 
 	const elmSetup = (node: HTMLElement) => {
 		const app = Elm.Pages.Pro.Carnet.Action.List.Main.init({
-			node: node,
+			node,
 			flags: {
 				api: { token: $token, url: $graphqlAPI },
 				targetId: target.id,

--- a/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoView.svelte
+++ b/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoView.svelte
@@ -11,7 +11,7 @@
 	import { Text } from '$lib/ui/utils';
 	import ProNotebookPersonalInfoUpdate from './ProNotebookPersonalInfoUpdate.svelte';
 	import { Elm as PersonalInfoElm } from '$elm/PersonalInfo/Main.elm';
-	import { afterUpdate } from 'svelte';
+	import ElmWrapper from '$lib/utils/ElmWrapper.svelte';
 
 	type Pro =
 		| Pick<Professional, 'firstname' | 'lastname'>
@@ -40,11 +40,9 @@
 	export let lastUpdateFrom: Pro;
 	export let displayEditButton = false;
 
-	let elmNode: HTMLElement;
-	afterUpdate(() => {
-		if (!elmNode) return;
+	const elmSetup = (node: HTMLElement) => {
 		PersonalInfoElm.PersonalInfo.Main.init({
-			node: elmNode,
+			node,
 			flags: {
 				rightAre: beneficiary.rightAre,
 				rightAss: beneficiary.rightAss,
@@ -54,7 +52,7 @@
 				cafNumber: beneficiary.cafNumber,
 			},
 		});
-	});
+	};
 
 	function edit() {
 		openComponent.open({ component: ProNotebookPersonalInfoUpdate, props: { beneficiary } });
@@ -109,8 +107,7 @@
 		</div>
 		{#key beneficiary}
 			<div class="w-full">
-				<!-- Elm app needs to be wrapped by a div to avoid navigation exceptions when unmounting -->
-				<div bind:this={elmNode} />
+				<ElmWrapper setup={elmSetup} />
 			</div>
 		{/key}
 	</div>

--- a/app/src/lib/utils/ElmWrapper.svelte
+++ b/app/src/lib/utils/ElmWrapper.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { afterUpdate } from 'svelte';
+	import { onMount } from 'svelte';
 
 	export let setup: (node: HTMLElement) => void;
 	let elmNode: HTMLElement;
-	afterUpdate(() => {
+	onMount(() => {
 		if (!elmNode || !elmNode.parentNode) return;
 		setup(elmNode);
 	});

--- a/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
@@ -36,15 +36,11 @@
 	import type { PageData } from './$types';
 	import NotebookMembers from '$lib/ui/Beneficiary/NotebookMembers.svelte';
 	import { goto } from '$app/navigation';
-	import { afterUpdate } from 'svelte';
+	import ElmWrapper from '$lib/utils/ElmWrapper.svelte';
 
-	let elmRsaHeaderNode: HTMLDivElement;
-
-	afterUpdate(() => {
-		if (!elmRsaHeaderNode || !notebook) return;
-		console.log(notebook);
+	const elmSetup = (node: HTMLElement) => {
 		RsaRightNotice.RsaRightNotice.Main.init({
-			node: elmRsaHeaderNode,
+			node,
 			flags: {
 				rsaRight: publicNotebook?.beneficiary.rightRsa,
 				rsaClosureDate: publicNotebook?.beneficiary.rsaClosureDate,
@@ -52,7 +48,7 @@
 				rsaSuspensionReason: publicNotebook?.beneficiary.rsaSuspensionReason,
 			},
 		});
-	});
+	};
 
 	function toDateFormat(date: Date) {
 		const yyyy = date.getFullYear().toString().padStart(4, '0');
@@ -236,7 +232,7 @@
 		>
 	{:else}
 		<Portal target="#bandeau">
-			<div bind:this={elmRsaHeaderNode} />
+			<ElmWrapper setup={elmSetup} />
 			{#if reorientationRequest}
 				<ProOrientationRequestBanner {reorientationRequest} />
 			{/if}


### PR DESCRIPTION
## :wrench: Problème

Lors du développement de l'application front, on rencontre des erreurs lors du rechargement à chaud de certains composants elm (`elm-hot-reload`), bien que ces erreurs ne soient pas présentes en production, on préfère s'en prémunir dès le développement pour éviter de masquer d'autres erreurs.

## :cake: Solution

On utilise le composant `ElmWrapper.svelte` partout où on utilise un composant elm.
On change le montage du composant elm dans `onMount` (au premier affichage de la page) plutôt qu'à l'événement `onUpdate` qui est appelé à chaque rafraichissement de la page.
Ces mises à jour de page arrivent fréquemment quand on développe car l'application "watch" les changements de fichiers et recharge la page courante. C'est dans ces conditions que le rechargement à chaud de elm et de svelte entrent en conflit (elm essaie de remplacer un noeud HTML qui a déjà été supprimé par svelte).

## :rotating_light:  Points d'attention / Remarques

On en profite pour mentionner le composant `ElmWrapper` dans la documentation.

## :desert_island: Comment tester

Tests auto vert.
