### PR TITLE
feat: ajoute le deploiement à la contrainte d'unicité sur l'email des  manager

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -4109,8 +4109,8 @@ export type ManagerBoolExp = {
 
 /** unique or primary key constraints on table "manager" */
 export enum ManagerConstraint {
-	/** unique or primary key constraint on columns "email" */
-	ManagerEmailKey = 'manager_email_key',
+	/** unique or primary key constraint on columns "email", "deployment_id" */
+	ManagerEmailDeploymentIdKey = 'manager_email_deployment_id_key',
 	/** unique or primary key constraint on columns "id" */
 	ManagerPkey = 'manager_pkey',
 }

--- a/backend/cdb/api/_gen/schema_gql.py
+++ b/backend/cdb/api/_gen/schema_gql.py
@@ -5012,9 +5012,9 @@ schema = build_schema(
     """
     enum manager_constraint {
       """
-      unique or primary key constraint on columns "email"
+      unique or primary key constraint on columns "email", "deployment_id"
       """
-      manager_email_key
+      manager_email_deployment_id_key
 
       """
       unique or primary key constraint on columns "id"

--- a/hasura/migrations/carnet_de_bord/1683801154520_alter_table_public_manager_add_unique_email_deployment_id/down.sql
+++ b/hasura/migrations/carnet_de_bord/1683801154520_alter_table_public_manager_add_unique_email_deployment_id/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."manager" drop constraint "manager_email_deployment_id_key";
+alter table "public"."manager" add constraint "manager_email_key" unique ("email");

--- a/hasura/migrations/carnet_de_bord/1683801154520_alter_table_public_manager_add_unique_email_deployment_id/up.sql
+++ b/hasura/migrations/carnet_de_bord/1683801154520_alter_table_public_manager_add_unique_email_deployment_id/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."manager" drop constraint "manager_email_key";
+alter table "public"."manager" add constraint "manager_email_deployment_id_key" unique ("email", "deployment_id");


### PR DESCRIPTION
## :wrench: Problème

Actuellement on ne peut pas créer plusieurs compte d'administrateur avec le même courriel sur des territoire différent, ce qui est problématique pour certains déploiement ou la même personne opère sur 2 déploiements différent cf #1722

## :cake: Solution

On ajoute l'id du deploiement à la contrainte d'unicité de l'email


## :rotating_light:  Points d'attention / Remarques

ras

## :desert_island: Comment tester


se connecter en tant qu'admin et créer  2 déploiements avec le même courriel d'admin
 

