### PR TITLE
feat: Suppression du bleu france.

### DIFF
--- a/app/src/app.css
+++ b/app/src/app.css
@@ -2,10 +2,6 @@
 @import url('./tailwind.css');
 @import url('./dsfr.css');
 
-.--bg-blue-france-975 {
-	background: #f5f5fe !important;
-}
-
 :root {
 	--vert-cdb: rgba(0, 88, 93, 1);
 	--vert-cdb-hover: rgba(0, 129, 138, 1);

--- a/app/src/lib/ui/ProNotebookMember/ProAppointment.svelte
+++ b/app/src/lib/ui/ProNotebookMember/ProAppointment.svelte
@@ -212,7 +212,7 @@
 	<div class="fr-table fr-table--layout-fixed blue-france-950">
 		<table>
 			<caption class="sr-only">Liste des rendez-vous</caption>
-			<thead class="--bg-blue-france-975">
+			<thead>
 				<tr>
 					<th style="width:54%">Date et heure </th>
 					<th style="width:23%">Présence</th>


### PR DESCRIPTION
## :wrench: Problème

Lors de la refont du header, la couleur "france-bleu" a été supprimée.
Il reste néanmoins une utilisation dans l'entête du tableau des rendez-vous.
Voir ce message : https://github.com/gip-inclusion/carnet-de-bord/pull/1732#issuecomment-1545317427.

## :cake: Solution

On supprime la classe en question et on laisse le design du DSFR.

## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Se rendre sur un carnet.
Vérifier que le tableau des rendez-vous a une entête grise (et non bleu).
