### PR TITLE
chore: Spécifier la branche à release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,12 @@ jobs:
           persist-credentials: false
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: 19
+          branches: main
           extra_plugins: |
-            @semantic-release/changelog@6.0.1
+            @semantic-release/changelog@6.0.3
             @semantic-release/git@10.0.1
             @semantic-release/exec@6.0.3
         env:


### PR DESCRIPTION
## :wrench: Problème

Suite au renommage de la branche `master` en `main`, le worklfow de release est en échec.
Après analyse, il appraît que l'action `semantic-release` a une configuration des branches par défaut qui contient `master`, ce qui était pratique jusqu'alors mais ne fonctionne plus avec `main`.

## :cake: Solution

On spécifie la branche `main` dans les options de `semantic-release`.

## :rotating_light:  Points d'attention / Remarques

On en profite pour passer à la version 3 de `semantic-release` et ainsi supprimer le warning relatif à l'utilisation de `node 12`.

## :desert_island: Comment tester

Merger et croiser les doigts pour que la release soit bien réalisée.
