### PR TITLE
fix: Corrige l'import de fichiers de bénéficiaires.

### DIFF
--- a/app/src/routes/v1/[...endpoint]/+server.ts
+++ b/app/src/routes/v1/[...endpoint]/+server.ts
@@ -16,6 +16,14 @@ export const POST = (async ({ request, cookies, params }) => {
 			...(request.headers.get('content-disposition')
 				? { 'Content-Disposition': request.headers.get('content-disposition') }
 				: null),
+			// Prevent the fetch implementation (undici most likely) from requesting
+			// compressed data from the upstream server. Because the same fetch implementation
+			// automatically uncompresses the received data, it would make work for this proxy
+			// and require us to scrub the 'Content-Encoding' header from the response before
+			// forwarding it.
+			// The Scalingo router will compress our responses for the client if necessary in
+			// any case.
+			'Accept-Encoding': 'identity',
 		},
 		// A cast to RequestInit is required because TypeScript's idea of fetch is outdated
 		// and does not know about "duplex", while the "fetch" polyfill provided by


### PR DESCRIPTION
## :wrench: Problème

Suite à la mise en prod de la PR #1698, l'envoi de fichier ne marchait plus mais seulement sur scalingo (les tests e2e lançaient en local ou depuis la CI fonctionnaient)

## :cake: Solution

Après investigations, il s'est avéré que le problème était du à un header manquant (Accept-encoding) entrainant une erreur d'encodage sur scalingo.  Le soucis avait été rencontré lors de la mise en place de la route `/graphql` dans sveltekit. La solution avait été de rajouter le header `Accept-encoding: Identity`. Nous avons donc rajouté ce header qui a permis de résoudre le soucis


## :rotating_light:  Points d'attention / Remarques


## :desert_island: Comment tester

- se connecter en tant que manager.cd93
- importer un fichier de bénéficiaire
- voir le recap du fichier 

fix #1739
