### PR TITLE
fix: affichage des actions du thème courant en premier

### DIFF
--- a/app/elm/DiagnosticEdit/RomeSelect.elm
+++ b/app/elm/DiagnosticEdit/RomeSelect.elm
@@ -38,6 +38,7 @@ init props =
         , label = "Métier recherché"
         , searchPlaceholder = "Rechercher un métier ou un code ROME"
         , defaultOption = "Projet en construction"
+        , postProcess = \id -> id
         }
 
 

--- a/app/elm/Pages/Pro/Carnet/Action/List/ActionSelect.elm
+++ b/app/elm/Pages/Pro/Carnet/Action/List/ActionSelect.elm
@@ -28,8 +28,8 @@ type alias Model =
     UI.SearchSelect.Component.Model RefAction
 
 
-init : (List RefAction -> List RefAction) -> ( Model, Cmd Msg )
-init postProcess =
+init : { postProcess : List RefAction -> List RefAction } -> ( Model, Cmd Msg )
+init props =
     UI.SearchSelect.Component.init
         { id = "select-action"
         , selected = Nothing
@@ -38,7 +38,7 @@ init postProcess =
         , label = "Actions"
         , searchPlaceholder = "Rechercher une action"
         , defaultOption = "Sélectionner une action"
-        , postProcess = postProcess
+        , postProcess = props.postProcess
         }
         -- Call update with the initial model in order to get a visible list of actions when
         -- we open the select

--- a/app/elm/Pages/Pro/Carnet/Action/List/Page.elm
+++ b/app/elm/Pages/Pro/Carnet/Action/List/Page.elm
@@ -60,7 +60,7 @@ init :
 init { actions, theme, targetId } =
     let
         ( actionSelect, actionSelectCmd ) =
-            Pages.Pro.Carnet.Action.List.ActionSelect.init (groupRefActionsByTheme theme)
+            Pages.Pro.Carnet.Action.List.ActionSelect.init { postProcess = groupRefActionsByTheme theme }
     in
     ( { actions = toActionDict actions
       , theme = theme

--- a/app/elm/Pages/Pro/Carnet/Action/List/Page.elm
+++ b/app/elm/Pages/Pro/Carnet/Action/List/Page.elm
@@ -8,7 +8,7 @@ import Extra.Date
 import Html
 import Html.Attributes as Attr
 import Html.Events as Evts
-import Pages.Pro.Carnet.Action.List.ActionSelect
+import Pages.Pro.Carnet.Action.List.ActionSelect exposing (RefAction)
 import Pages.Pro.Carnet.Action.List.AllActions exposing (Action)
 
 
@@ -60,7 +60,7 @@ init :
 init { actions, theme, targetId } =
     let
         ( actionSelect, actionSelectCmd ) =
-            Pages.Pro.Carnet.Action.List.ActionSelect.init
+            Pages.Pro.Carnet.Action.List.ActionSelect.init (groupRefActionsByTheme theme)
     in
     ( { actions = toActionDict actions
       , theme = theme
@@ -77,6 +77,20 @@ toActionDict actions =
     actions
         |> List.map (\action -> ( action.id |> Domain.Action.Id.printId, action ))
         |> Dict.fromList
+
+
+groupRefActionsByTheme : String -> List RefAction -> List RefAction
+groupRefActionsByTheme theme actions =
+    -- First only keep actions of the current theme and sort them alphabetically
+    (actions
+        |> List.filter (\action -> action.theme == theme)
+        |> List.sortBy .description
+    )
+        -- Then keep the other actions and sort them alphabetically
+        ++ (actions
+                |> List.filter (\action -> action.theme /= theme)
+                |> List.sortBy .description
+           )
 
 
 

--- a/app/elm/UI/SearchSelect/Component.elm
+++ b/app/elm/UI/SearchSelect/Component.elm
@@ -25,6 +25,7 @@ type alias Model a =
         , callbackMsg : Result Http.Error (List a) -> Msg a
         }
         -> Cmd (Msg a)
+    , postProcess : List a -> List a
     }
 
 
@@ -40,6 +41,7 @@ init :
     , label : String
     , searchPlaceholder : String
     , defaultOption : String
+    , postProcess : List a -> List a
     }
     -> Model a
 init props =
@@ -55,6 +57,7 @@ init props =
     , selected = props.selected
     , debouncer = debounce (fromSeconds 0.5) |> toDebouncer
     , api = props.api
+    , postProcess = props.postProcess
     }
 
 
@@ -141,7 +144,7 @@ update msg model =
         Fetched result ->
             case result of
                 Ok values ->
-                    ( model |> updateStatus (UI.SearchSelect.View.Success values), Cmd.none )
+                    ( model |> updateStatus (values |> model.postProcess |> UI.SearchSelect.View.Success), Cmd.none )
 
                 Err httpError ->
                     ( model |> updateStatus UI.SearchSelect.View.Failed

--- a/app/tests/Pages/Pro/Carnet/Action/List/Tests.elm
+++ b/app/tests/Pages/Pro/Carnet/Action/List/Tests.elm
@@ -105,6 +105,7 @@ suite =
                                 (UI.SearchSelect.Component.Select
                                     { id = "Id" |> Domain.Action.Id.ActionId
                                     , description = "an action"
+                                    , theme = "a theme"
                                     }
                                 )
                             )


### PR DESCRIPTION
## :wrench: Problème

Auparavant, les actions de thème courant étaient affichées en premier, ce n'est plus le cas suite à une régression introduite par le refactoring des actions.

## :cake: Solution

On ajoute une fonction de post processing générique au composant Select, fonction appliquée après la réception du référentiel des actions du serveur. Dans notre cas, nous utilisons une fonction qui fait la concaténation de deux listes : la première étant celle des actions ayant un thème identique au thème courant, la deuxième étant le reste des actions. On trie chaque groupe par ordre alphabétique.

## :desert_island: Comment tester

Se rendre sur la review app https://cdb-app-review-pr1743.osc-fr1.scalingo.io/

Charger la liste des actions et s'assurer que les actions du thème courant sont bien en haut et que les autres arrivent après, cf vidéo ci-dessous.

![Peek 2023-05-16 11-49](https://github.com/gip-inclusion/carnet-de-bord/assets/154904/74284d0c-a7c2-4cdc-b38a-57ff49ac2670)

Fix #1736 