### PR TITLE
fix: problèmes d'affichage sur le formulaire de mise à jour des informations personnelles

### DIFF
--- a/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
+++ b/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
@@ -55,21 +55,28 @@
 <Input inputLabel="Téléphone" placeholder="0123456789" name="mobileNumber" class="max-w-max" />
 <Input inputLabel="Adresse" placeholder="55-57 rue du Faubourg Saint-Honoré" name="address1" />
 <Input inputLabel="Adresse (complément)" placeholder="1er étage" name="address2" />
-<div class="fr-grid-row fr-grid-row--gutters">
-	<Input
-		class="fr-col-3 max-w-max"
-		inputLabel="Code postal"
-		placeholder="75008"
-		name="postalCode"
-	/>
-	<Input class="fr-col-9" inputLabel="Ville" placeholder="Paris" name="city" />
+<div class="fr-grid-row fr-grid-row--gutters" style="justify-content: flex-start">
+	<Input class="fr-col-2 mb-1" inputLabel="Code postal" placeholder="75008" name="postalCode" />
+	<Input class="fr-col-10 mb-1" inputLabel="Ville" placeholder="Paris" name="city" />
 </div>
 
-<Radio legend="Revenu de solidarité active (RSA)" name="rightRsa" options={rsaRightKeys.options} />
+<div class="fr-form-group mt-6">
+	<Radio
+		legend="Revenu de solidarité active (RSA)"
+		name="rightRsa"
+		options={rsaRightKeys.options}
+	/>
+</div>
 
-<div class="fr-form-group">
-	<div class="pb-2 font-bold">Autres aides</div>
-	<Checkbox name="rightAre" label="ARE" />
-	<Checkbox name="rightAss" label="ASS" />
-	<Checkbox name="rightBonus" label="Prime d'activité" />
+<div class="fr-fieldset">
+	<legend class="fr-fieldset__legend--regular fr-fieldset__legend">Autres aides</legend>
+	<div class="fr-fieldset__element">
+		<Checkbox name="rightAre" label="ARE" />
+	</div>
+	<div class="fr-fieldset__element">
+		<Checkbox name="rightAss" label="ASS" />
+	</div>
+	<div class="fr-fieldset__element">
+		<Checkbox name="rightBonus" label="Prime d'activité" />
+	</div>
 </div>

--- a/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
+++ b/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
@@ -55,7 +55,7 @@
 <Input inputLabel="Téléphone" placeholder="0123456789" name="mobileNumber" class="max-w-max" />
 <Input inputLabel="Adresse" placeholder="55-57 rue du Faubourg Saint-Honoré" name="address1" />
 <Input inputLabel="Adresse (complément)" placeholder="1er étage" name="address2" />
-<div class="fr-grid-row fr-grid-row--gutters" style="justify-content: flex-start">
+<div class="fr-grid-row fr-grid-row--gutters">
 	<Input class="fr-col-2 mb-1" inputLabel="Code postal" placeholder="75008" name="postalCode" />
 	<Input class="fr-col-10 mb-1" inputLabel="Ville" placeholder="Paris" name="city" />
 </div>

--- a/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
+++ b/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
@@ -56,8 +56,13 @@
 <Input inputLabel="Adresse" placeholder="55-57 rue du Faubourg Saint-Honoré" name="address1" />
 <Input inputLabel="Adresse (complément)" placeholder="1er étage" name="address2" />
 <div class="fr-grid-row fr-grid-row--gutters">
-	<Input class="fr-col-2 mb-1" inputLabel="Code postal" placeholder="75008" name="postalCode" />
-	<Input class="fr-col-10 mb-1" inputLabel="Ville" placeholder="Paris" name="city" />
+	<Input
+		class="fr-col-3 mb-1 max-w-max"
+		inputLabel="Code postal"
+		placeholder="75008"
+		name="postalCode"
+	/>
+	<Input class="fr-col-9 mb-1" inputLabel="Ville" placeholder="Paris" name="city" />
 </div>
 
 <div class="fr-form-group mt-6">

--- a/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoUpdate.svelte
@@ -87,7 +87,12 @@
 	<h1>Informations personnelles</h1>
 	<Form {initialValues} {validationSchema} onSubmit={updateBeneficiary}>
 		<ProBeneficiaryUpdateFields {forbiddenFields} />
-		<Input name="peNumber" placeholder={'123456789A'} inputLabel={'Identifiant Pôle emploi'} />
+		<Input
+			name="peNumber"
+			placeholder={'123456789A'}
+			class="pt-6"
+			inputLabel={'Identifiant Pôle emploi'}
+		/>
 		<Input name="cafNumber" placeholder={'123456789A'} inputLabel={'Identifiant CAF/MSA'} />
 		<div class="flex flex-row gap-6 pt-4 pb-12">
 			<Button type="submit">Enregistrer</Button>


### PR DESCRIPTION
## :wrench: Problème

La ville et le code postal sont décalés sur le formulaire de modification des informations personnelles. Les cases à cocher sont trop serrées.

## :cake: Solution

On corrige le souci de margin sur la ville et le code postal et on applique le DSFR pour les cases à cocher.


## :desert_island: Comment tester

On s'assure que le rendu ressemble bien à celui-là.

![Screenshot from 2023-05-17 10-29-32](https://github.com/gip-inclusion/carnet-de-bord/assets/154904/1e7bcc48-c421-49a5-9d14-b0d9f7ccf1e1)


fix #1744 

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
