### PR TITLE
fix: problèmes d'affichage de la donnée RQTH dans le formulaire du diagnostic sociopro

### DIFF
--- a/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
@@ -407,7 +407,7 @@
 		<div class="fr-form-group">
 			<Input name="lastJobEndedAt" inputLabel="Date de fin du dernier emploi" type="date" />
 		</div>
-		<div class="pb-4">
+		<div class="pb-4 pt-6">
 			<Checkbox name="rightRqth" label="RQTH" />
 		</div>
 


### PR DESCRIPTION
## :wrench: Problème

La checbox RQTH se retrouve collée au champ du dessus.

## :cake: Solution

On ajoute un padding top.

## :desert_island: Comment tester

On s'assure que la checkbox RQTH est bien espacée comme il faut.

![Screenshot from 2023-05-17 10-48-51](https://github.com/gip-inclusion/carnet-de-bord/assets/154904/98a773ac-1df8-4baa-85d1-a5567c715f8b)

fix #1745 

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
