### PR TITLE
fix: filtre les membres actifs dans nbNotbookWith2MembersOrMore

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -12,7 +12,6 @@ export type Scalars = {
 	Boolean: boolean;
 	Int: number;
 	Float: number;
-	bigint: any;
 	citext: string;
 	date: string;
 	float8: any;
@@ -2523,19 +2522,6 @@ export type BeneficiaryUpdates = {
 	_set?: InputMaybe<BeneficiarySetInput>;
 	/** filter the rows which have to be updated */
 	where: BeneficiaryBoolExp;
-};
-
-/** Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'. */
-export type BigintComparisonExp = {
-	_eq?: InputMaybe<Scalars['bigint']>;
-	_gt?: InputMaybe<Scalars['bigint']>;
-	_gte?: InputMaybe<Scalars['bigint']>;
-	_in?: InputMaybe<Array<Scalars['bigint']>>;
-	_is_null?: InputMaybe<Scalars['Boolean']>;
-	_lt?: InputMaybe<Scalars['bigint']>;
-	_lte?: InputMaybe<Scalars['bigint']>;
-	_neq?: InputMaybe<Scalars['bigint']>;
-	_nin?: InputMaybe<Array<Scalars['bigint']>>;
 };
 
 /** Boolean expression to compare columns of type "citext". All fields are combined with logical 'AND'. */
@@ -6662,8 +6648,6 @@ export type Notebook = {
 	members_aggregate: NotebookMemberAggregate;
 	/** An object relationship */
 	notebookInfo?: Maybe<NotebookInfo>;
-	/** return the number of professionnal for a notebook */
-	notebookMemberCount?: Maybe<Scalars['bigint']>;
 	/** An array relationship */
 	professionalProjects: Array<ProfessionalProject>;
 	/** An aggregate relationship */
@@ -7383,7 +7367,6 @@ export type NotebookBoolExp = {
 	members?: InputMaybe<NotebookMemberBoolExp>;
 	members_aggregate?: InputMaybe<NotebookMemberAggregateBoolExp>;
 	notebookInfo?: InputMaybe<NotebookInfoBoolExp>;
-	notebookMemberCount?: InputMaybe<BigintComparisonExp>;
 	professionalProjects?: InputMaybe<ProfessionalProjectBoolExp>;
 	professionalProjects_aggregate?: InputMaybe<ProfessionalProjectAggregateBoolExp>;
 	rightRqth?: InputMaybe<BooleanComparisonExp>;
@@ -8798,7 +8781,6 @@ export type NotebookOrderBy = {
 	lastJobEndedAt?: InputMaybe<OrderBy>;
 	members_aggregate?: InputMaybe<NotebookMemberAggregateOrderBy>;
 	notebookInfo?: InputMaybe<NotebookInfoOrderBy>;
-	notebookMemberCount?: InputMaybe<OrderBy>;
 	professionalProjects_aggregate?: InputMaybe<ProfessionalProjectAggregateOrderBy>;
 	rightRqth?: InputMaybe<OrderBy>;
 	situations_aggregate?: InputMaybe<NotebookSituationAggregateOrderBy>;

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -1794,7 +1794,7 @@ export type BeneficiaryBoolExp = {
 /** unique or primary key constraints on table "beneficiary" */
 export enum BeneficiaryConstraint {
 	/** unique or primary key constraint on columns "deployment_id", "internal_id" */
-	BeneficiaryInternalIdDeploymentIdKey = 'beneficiary_internal_id_deployment_id_key',
+	BeneficiaryDeploymentIdInternalIdKey = 'beneficiary_deployment_id_internal_id_key',
 	/** unique or primary key constraint on columns "nir" */
 	BeneficiaryNirKey = 'beneficiary_nir_key',
 	/** unique or primary key constraint on columns "id" */
@@ -6780,7 +6780,6 @@ export type NotebookAction = {
 	creator: Account;
 	creatorId: Scalars['uuid'];
 	id: Scalars['uuid'];
-	initialId?: Maybe<Scalars['String']>;
 	status: Scalars['String'];
 	/** An object relationship */
 	target: NotebookTarget;
@@ -6844,7 +6843,6 @@ export type NotebookActionBoolExp = {
 	creator?: InputMaybe<AccountBoolExp>;
 	creatorId?: InputMaybe<UuidComparisonExp>;
 	id?: InputMaybe<UuidComparisonExp>;
-	initialId?: InputMaybe<StringComparisonExp>;
 	status?: InputMaybe<StringComparisonExp>;
 	target?: InputMaybe<NotebookTargetBoolExp>;
 	targetId?: InputMaybe<UuidComparisonExp>;
@@ -6853,8 +6851,6 @@ export type NotebookActionBoolExp = {
 
 /** unique or primary key constraints on table "notebook_action" */
 export enum NotebookActionConstraint {
-	/** unique or primary key constraint on columns "initial_id" */
-	NotebookActionInitialIdKey = 'notebook_action_initial_id_key',
 	/** unique or primary key constraint on columns "id" */
 	NotebookActionPkey = 'notebook_action_pkey',
 	/** unique or primary key constraint on columns "action", "target_id" */
@@ -6868,7 +6864,6 @@ export type NotebookActionInsertInput = {
 	creator?: InputMaybe<AccountObjRelInsertInput>;
 	creatorId?: InputMaybe<Scalars['uuid']>;
 	id?: InputMaybe<Scalars['uuid']>;
-	initialId?: InputMaybe<Scalars['String']>;
 	status?: InputMaybe<Scalars['String']>;
 	target?: InputMaybe<NotebookTargetObjRelInsertInput>;
 	targetId?: InputMaybe<Scalars['uuid']>;
@@ -6882,7 +6877,6 @@ export type NotebookActionMaxFields = {
 	createdAt?: Maybe<Scalars['timestamptz']>;
 	creatorId?: Maybe<Scalars['uuid']>;
 	id?: Maybe<Scalars['uuid']>;
-	initialId?: Maybe<Scalars['String']>;
 	status?: Maybe<Scalars['String']>;
 	targetId?: Maybe<Scalars['uuid']>;
 	updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -6894,7 +6888,6 @@ export type NotebookActionMaxOrderBy = {
 	createdAt?: InputMaybe<OrderBy>;
 	creatorId?: InputMaybe<OrderBy>;
 	id?: InputMaybe<OrderBy>;
-	initialId?: InputMaybe<OrderBy>;
 	status?: InputMaybe<OrderBy>;
 	targetId?: InputMaybe<OrderBy>;
 	updatedAt?: InputMaybe<OrderBy>;
@@ -6907,7 +6900,6 @@ export type NotebookActionMinFields = {
 	createdAt?: Maybe<Scalars['timestamptz']>;
 	creatorId?: Maybe<Scalars['uuid']>;
 	id?: Maybe<Scalars['uuid']>;
-	initialId?: Maybe<Scalars['String']>;
 	status?: Maybe<Scalars['String']>;
 	targetId?: Maybe<Scalars['uuid']>;
 	updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -6919,7 +6911,6 @@ export type NotebookActionMinOrderBy = {
 	createdAt?: InputMaybe<OrderBy>;
 	creatorId?: InputMaybe<OrderBy>;
 	id?: InputMaybe<OrderBy>;
-	initialId?: InputMaybe<OrderBy>;
 	status?: InputMaybe<OrderBy>;
 	targetId?: InputMaybe<OrderBy>;
 	updatedAt?: InputMaybe<OrderBy>;
@@ -6948,7 +6939,6 @@ export type NotebookActionOrderBy = {
 	creator?: InputMaybe<AccountOrderBy>;
 	creatorId?: InputMaybe<OrderBy>;
 	id?: InputMaybe<OrderBy>;
-	initialId?: InputMaybe<OrderBy>;
 	status?: InputMaybe<OrderBy>;
 	target?: InputMaybe<NotebookTargetOrderBy>;
 	targetId?: InputMaybe<OrderBy>;
@@ -6971,8 +6961,6 @@ export enum NotebookActionSelectColumn {
 	/** column name */
 	Id = 'id',
 	/** column name */
-	InitialId = 'initialId',
-	/** column name */
 	Status = 'status',
 	/** column name */
 	TargetId = 'targetId',
@@ -6986,7 +6974,6 @@ export type NotebookActionSetInput = {
 	createdAt?: InputMaybe<Scalars['timestamptz']>;
 	creatorId?: InputMaybe<Scalars['uuid']>;
 	id?: InputMaybe<Scalars['uuid']>;
-	initialId?: InputMaybe<Scalars['String']>;
 	status?: InputMaybe<Scalars['String']>;
 	targetId?: InputMaybe<Scalars['uuid']>;
 	updatedAt?: InputMaybe<Scalars['timestamptz']>;
@@ -7006,7 +6993,6 @@ export type NotebookActionStreamCursorValueInput = {
 	createdAt?: InputMaybe<Scalars['timestamptz']>;
 	creatorId?: InputMaybe<Scalars['uuid']>;
 	id?: InputMaybe<Scalars['uuid']>;
-	initialId?: InputMaybe<Scalars['String']>;
 	status?: InputMaybe<Scalars['String']>;
 	targetId?: InputMaybe<Scalars['uuid']>;
 	updatedAt?: InputMaybe<Scalars['timestamptz']>;
@@ -7022,8 +7008,6 @@ export enum NotebookActionUpdateColumn {
 	CreatorId = 'creatorId',
 	/** column name */
 	Id = 'id',
-	/** column name */
-	InitialId = 'initialId',
 	/** column name */
 	Status = 'status',
 	/** column name */

--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -35197,14 +35197,55 @@ export const GetDeploymentStatForDayDocument = {
 									fields: [
 										{
 											kind: 'ObjectField',
-											name: { kind: 'Name', value: 'notebookMemberCount' },
+											name: { kind: 'Name', value: 'members_aggregate' },
 											value: {
 												kind: 'ObjectValue',
 												fields: [
 													{
 														kind: 'ObjectField',
-														name: { kind: 'Name', value: '_gte' },
-														value: { kind: 'IntValue', value: '2' },
+														name: { kind: 'Name', value: 'count' },
+														value: {
+															kind: 'ObjectValue',
+															fields: [
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'filter' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: 'active' },
+																				value: {
+																					kind: 'ObjectValue',
+																					fields: [
+																						{
+																							kind: 'ObjectField',
+																							name: { kind: 'Name', value: '_eq' },
+																							value: { kind: 'BooleanValue', value: true },
+																						},
+																					],
+																				},
+																			},
+																		],
+																	},
+																},
+																{
+																	kind: 'ObjectField',
+																	name: { kind: 'Name', value: 'predicate' },
+																	value: {
+																		kind: 'ObjectValue',
+																		fields: [
+																			{
+																				kind: 'ObjectField',
+																				name: { kind: 'Name', value: '_gte' },
+																				value: { kind: 'IntValue', value: '2' },
+																			},
+																		],
+																	},
+																},
+															],
+														},
 													},
 												],
 											},

--- a/app/src/lib/tracking/matomo.ts
+++ b/app/src/lib/tracking/matomo.ts
@@ -68,8 +68,8 @@ export function logout() {
  * @see https://developer.matomo.org/guides/tracking-javascript-guide#custom-dimensions
  */
 export enum CustomDimensions {
-	Role = 3,
-	Deployment = 4,
+	Deployment = 1,
+	Role = 2,
 }
 
 export function setCustomDimension(id: CustomDimensions, value: string): void {

--- a/app/src/routes/actions/matomo_dashboard/_getDeploymentStats.gql
+++ b/app/src/routes/actions/matomo_dashboard/_getDeploymentStats.gql
@@ -67,7 +67,7 @@ query GetDeploymentStatForDay($day: timestamptz!, $last30Days: timestamptz!, $de
   }
   nbNotbookWith2MembersOrMore: notebook_aggregate(
     where: {
-      notebookMemberCount: { _gte: 2 }
+      members_aggregate: { count: { filter: { active: { _eq: true } }, predicate: { _gte: 2 } } }
       beneficiary: { deploymentId: { _eq: $deploymentId } }
     }
   ) {

--- a/backend/cdb/api/_gen/schema_gql.py
+++ b/backend/cdb/api/_gen/schema_gql.py
@@ -2185,7 +2185,7 @@ schema = build_schema(
       """
       unique or primary key constraint on columns "deployment_id", "internal_id"
       """
-      beneficiary_internal_id_deployment_id_key
+      beneficiary_deployment_id_internal_id_key
 
       """
       unique or primary key constraint on columns "nir"
@@ -8341,7 +8341,6 @@ schema = build_schema(
       creator: account!
       creatorId: uuid!
       id: uuid!
-      initialId: String
       status: String!
 
       """An object relationship"""
@@ -8409,7 +8408,6 @@ schema = build_schema(
       creator: account_bool_exp
       creatorId: uuid_comparison_exp
       id: uuid_comparison_exp
-      initialId: String_comparison_exp
       status: String_comparison_exp
       target: notebook_target_bool_exp
       targetId: uuid_comparison_exp
@@ -8420,11 +8418,6 @@ schema = build_schema(
     unique or primary key constraints on table "notebook_action"
     """
     enum notebook_action_constraint {
-      """
-      unique or primary key constraint on columns "initial_id"
-      """
-      notebook_action_initial_id_key
-
       """
       unique or primary key constraint on columns "id"
       """
@@ -8445,7 +8438,6 @@ schema = build_schema(
       creator: account_obj_rel_insert_input
       creatorId: uuid
       id: uuid
-      initialId: String
       status: String
       target: notebook_target_obj_rel_insert_input
       targetId: uuid
@@ -8458,7 +8450,6 @@ schema = build_schema(
       createdAt: timestamptz
       creatorId: uuid
       id: uuid
-      initialId: String
       status: String
       targetId: uuid
       updatedAt: timestamptz
@@ -8472,7 +8463,6 @@ schema = build_schema(
       createdAt: order_by
       creatorId: order_by
       id: order_by
-      initialId: order_by
       status: order_by
       targetId: order_by
       updatedAt: order_by
@@ -8484,7 +8474,6 @@ schema = build_schema(
       createdAt: timestamptz
       creatorId: uuid
       id: uuid
-      initialId: String
       status: String
       targetId: uuid
       updatedAt: timestamptz
@@ -8498,7 +8487,6 @@ schema = build_schema(
       createdAt: order_by
       creatorId: order_by
       id: order_by
-      initialId: order_by
       status: order_by
       targetId: order_by
       updatedAt: order_by
@@ -8531,7 +8519,6 @@ schema = build_schema(
       creator: account_order_by
       creatorId: order_by
       id: order_by
-      initialId: order_by
       status: order_by
       target: notebook_target_order_by
       targetId: order_by
@@ -8560,9 +8547,6 @@ schema = build_schema(
       id
 
       """column name"""
-      initialId
-
-      """column name"""
       status
 
       """column name"""
@@ -8580,7 +8564,6 @@ schema = build_schema(
       createdAt: timestamptz
       creatorId: uuid
       id: uuid
-      initialId: String
       status: String
       targetId: uuid
       updatedAt: timestamptz
@@ -8603,7 +8586,6 @@ schema = build_schema(
       createdAt: timestamptz
       creatorId: uuid
       id: uuid
-      initialId: String
       status: String
       targetId: uuid
       updatedAt: timestamptz
@@ -8624,9 +8606,6 @@ schema = build_schema(
 
       """column name"""
       id
-
-      """column name"""
-      initialId
 
       """column name"""
       status

--- a/backend/cdb/api/_gen/schema_gql.py
+++ b/backend/cdb/api/_gen/schema_gql.py
@@ -3063,23 +3063,6 @@ schema = build_schema(
       where: beneficiary_bool_exp!
     }
 
-    scalar bigint
-
-    """
-    Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'.
-    """
-    input bigint_comparison_exp {
-      _eq: bigint
-      _gt: bigint
-      _gte: bigint
-      _in: [bigint!]
-      _is_null: Boolean
-      _lt: bigint
-      _lte: bigint
-      _neq: bigint
-      _nin: [bigint!]
-    }
-
     scalar citext
 
     """
@@ -8269,9 +8252,6 @@ schema = build_schema(
       """An object relationship"""
       notebookInfo: notebook_info
 
-      """return the number of professionnal for a notebook"""
-      notebookMemberCount: bigint
-
       """An array relationship"""
       professionalProjects(
         """distinct select on columns"""
@@ -9036,7 +9016,6 @@ schema = build_schema(
       members: notebook_member_bool_exp
       members_aggregate: notebook_member_aggregate_bool_exp
       notebookInfo: notebook_info_bool_exp
-      notebookMemberCount: bigint_comparison_exp
       professionalProjects: professional_project_bool_exp
       professionalProjects_aggregate: professional_project_aggregate_bool_exp
       rightRqth: Boolean_comparison_exp
@@ -10711,7 +10690,6 @@ schema = build_schema(
       lastJobEndedAt: order_by
       members_aggregate: notebook_member_aggregate_order_by
       notebookInfo: notebook_info_order_by
-      notebookMemberCount: order_by
       professionalProjects_aggregate: professional_project_aggregate_order_by
       rightRqth: order_by
       situations_aggregate: notebook_situation_aggregate_order_by

--- a/backend/cdb/api/db/crud/notebook.py
+++ b/backend/cdb/api/db/crud/notebook.py
@@ -59,7 +59,6 @@ na.status as na_status,
 na.creator_id as na_creator_id,
 na.created_at as na_created_at,
 na.updated_at as na_updated_at,
-na.initial_id as na_initial_id,
 ai_action_creator.firstname as na_firstname,
 ai_action_creator.lastname as na_lastname,
 ai_action_creator.email as na_email,
@@ -150,7 +149,6 @@ async def add_professional_projects_to_notebook(
 async def find_focus(
     notebook: Notebook, find_function: Callable[[Focus], bool]
 ) -> Focus | None:
-
     if notebook.focuses is not None:
         return next(
             (f for f in notebook.focuses if find_function(f)),
@@ -161,7 +159,6 @@ async def find_focus(
 async def find_target_from_focus(
     focus: Focus, find_function: Callable[[Target], bool]
 ) -> Target | None:
-
     if focus.targets is not None:
         return next(
             (t for t in focus.targets if find_function(t)),
@@ -172,7 +169,6 @@ async def find_target_from_focus(
 async def find_target_from_notebook(
     notebook: Notebook, focus_id: UUID, target_id: UUID
 ) -> Target | None:
-
     focus: Focus | None = await find_focus(notebook, lambda f: f.id == focus_id)
 
     if focus is None:
@@ -182,7 +178,6 @@ async def find_target_from_notebook(
 
 
 async def find_action_from_target(target: Target, action_id: UUID) -> Action | None:
-
     if target.actions is not None:
         return next(
             (a for a in target.actions if a.id == action_id),
@@ -196,7 +191,6 @@ async def add_action_to_target(
     record_prefix: str = "na_",
     target_record_prefix: str = "nt_",
 ) -> None:
-
     if record[record_prefix + "id"] is None:
         return
 
@@ -228,7 +222,6 @@ async def add_action_to_target(
             creator_id=record[record_prefix + "creator_id"],
             created_at=record[record_prefix + "created_at"],
             updated_at=record[record_prefix + "updated_at"],
-            initial_id=record[record_prefix + "initial_id"],
             account_info=AccountInfo(
                 account_id=record[record_prefix + "creator_id"],
                 firstname=record[record_prefix + "firstname"],
@@ -244,7 +237,6 @@ async def add_target_to_focus(
     notebook: Notebook,
     record_prefix: str = "nt_",
 ) -> None:
-
     if record[record_prefix + "id"] is not None:
         focus: Focus | None = await find_focus(
             notebook, lambda f: f.id == record[record_prefix + "focus_id"]
@@ -320,7 +312,6 @@ async def add_members_to_notebook(
         # The current notebook_member is not already attached to the notebook
         # so let's add it
         if not notebook_member:
-
             notebook.members.append(
                 NotebookMember(
                     id=record[record_prefix + "id"],
@@ -354,7 +345,6 @@ async def add_appointments_to_notebook(
         # The current appointment is not already attached to the notebook
         # so let's add it
         if not appointment:
-
             notebook.appointments.append(
                 Appointment(
                     id=record[record_prefix + "id"],
@@ -382,7 +372,6 @@ async def parse_notebooks_from_records(
     notebooks: list[Notebook],
     id_field: str = "n_id",
 ) -> list[Notebook]:
-
     for record in records:
         notebook: Notebook | None = next(
             (n for n in notebooks if n.id == record[id_field]), None
@@ -410,7 +399,6 @@ async def parse_notebook_from_record(
     add_appointments: bool = True,
     notebook: Notebook | None = None,
 ) -> Notebook:
-
     if not notebook:
         notebook = Notebook(
             id=record[record_prefix + id_field],
@@ -456,7 +444,6 @@ async def get_notebook_member_with_query(
     connection: Connection, query: str, *args
 ) -> NotebookMember | None:
     async with connection.transaction():
-
         notebook_member_record: Record | None = await connection.fetchrow(
             "SELECT nm.* FROM public.notebook_member nm " + query,
             *args,
@@ -470,7 +457,6 @@ async def get_notebook_members_with_query(
     connection: Connection, query: str, *args
 ) -> list[NotebookMember]:
     async with connection.transaction():
-
         records: list[Record] = await connection.fetch(
             "SELECT nm.* FROM public.notebook_member nm " + query,
             *args,
@@ -482,7 +468,6 @@ async def get_notebook_members_with_query(
 async def insert_notebook_member(
     connection: Connection, notebook_member_insert: NotebookMemberInsert
 ) -> NotebookMember | None:
-
     record = await connection.fetchrow(
         """
         INSERT INTO public.notebook_member (
@@ -541,7 +526,6 @@ async def get_notebooks_with_query(
     connection: Connection, query: str, *args
 ) -> list[Notebook]:
     async with connection.transaction():
-
         records: list[Record] = await connection.fetch(
             NOTEBOOK_BASE_QUERY + query,
             *args,
@@ -555,7 +539,6 @@ async def get_notebook_with_query(
     connection: Connection, query: str, *args
 ) -> Notebook | None:
     async with connection.transaction():
-
         record: Record = await connection.fetchrow(
             NOTEBOOK_BASE_QUERY + query,
             *args,
@@ -603,7 +586,6 @@ async def insert_notebook(
     beneficiary_id: UUID,
     beneficiary: BeneficiaryImport,
 ) -> UUID | None:
-
     keys_to_insert = beneficiary.get_notebook_editable_keys()
     sql_values = beneficiary.get_values_for_keys(keys_to_insert)
     # manually add beneficiary_id and its value for insert request
@@ -626,7 +608,6 @@ async def update_notebook(
     beneficiary: BeneficiaryImport,
     beneficiary_id: UUID,
 ) -> UUID | None:
-
     keys_to_update = beneficiary.get_notebook_editable_keys()
 
     if len(keys_to_update) == 0:

--- a/backend/cdb/api/db/models/action.py
+++ b/backend/cdb/api/db/models/action.py
@@ -15,4 +15,3 @@ class Action(BaseModel):
     account_info: AccountInfo
     created_at: datetime
     updated_at: datetime
-    initial_id: str | None

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook.yaml
@@ -100,13 +100,6 @@ array_relationships:
         remote_table:
           name: notebook_situation
           schema: public
-computed_fields:
-  - name: notebookMemberCount
-    definition:
-      function:
-        name: nb_member
-        schema: public
-    comment: return the number of professionnal for a notebook
 insert_permissions:
   - role: admin_cdb
     permission:
@@ -177,8 +170,6 @@ select_permissions:
         - work_situation
         - work_situation_date
         - work_situation_end_date
-      computed_fields:
-        - notebookMemberCount
       filter: {}
       allow_aggregations: true
   - role: admin_structure
@@ -198,8 +189,6 @@ select_permissions:
         - work_situation
         - work_situation_date
         - work_situation_end_date
-      computed_fields:
-        - notebookMemberCount
       filter:
         _or:
           - members:
@@ -236,8 +225,6 @@ select_permissions:
         - work_situation
         - work_situation_date
         - work_situation_end_date
-      computed_fields:
-        - notebookMemberCount
       filter:
         beneficiary_id:
           _eq: X-Hasura-Beneficiary-Id
@@ -258,8 +245,6 @@ select_permissions:
         - work_situation
         - work_situation_date
         - work_situation_end_date
-      computed_fields:
-        - notebookMemberCount
       filter:
         beneficiary:
           deployment_id:
@@ -282,8 +267,6 @@ select_permissions:
         - work_situation
         - work_situation_date
         - work_situation_end_date
-      computed_fields:
-        - notebookMemberCount
       filter:
         beneficiary:
           deployment_id:

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_action.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_action.yaml
@@ -7,8 +7,6 @@ configuration:
       custom_name: createdAt
     creator_id:
       custom_name: creatorId
-    initial_id:
-      custom_name: initialId
     target_id:
       custom_name: targetId
     updated_at:
@@ -16,7 +14,6 @@ configuration:
   custom_column_names:
     created_at: createdAt
     creator_id: creatorId
-    initial_id: initialId
     target_id: targetId
     updated_at: updatedAt
   custom_root_fields: {}
@@ -36,7 +33,6 @@ insert_permissions:
         - created_at
         - creator_id
         - id
-        - initial_id
         - status
         - target_id
   - role: orientation_manager
@@ -85,7 +81,6 @@ select_permissions:
         - created_at
         - creator_id
         - id
-        - initial_id
         - status
         - target_id
         - updated_at
@@ -98,7 +93,6 @@ select_permissions:
         - created_at
         - creator_id
         - id
-        - initial_id
         - status
         - target_id
         - updated_at
@@ -128,7 +122,6 @@ select_permissions:
         - created_at
         - creator_id
         - id
-        - initial_id
         - status
         - target_id
         - updated_at
@@ -145,7 +138,6 @@ select_permissions:
         - created_at
         - creator_id
         - id
-        - initial_id
         - status
         - target_id
         - updated_at
@@ -164,7 +156,6 @@ select_permissions:
         - created_at
         - creator_id
         - id
-        - initial_id
         - status
         - target_id
         - updated_at

--- a/hasura/migrations/carnet_de_bord/1684333811675_alter_table_beneficiary_index/down.sql
+++ b/hasura/migrations/carnet_de_bord/1684333811675_alter_table_beneficiary_index/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."beneficiary" drop constraint "beneficiary_deployment_id_internal_id_key";
+alter table "public"."beneficiary" add constraint "beneficiary_internal_id_deployment_id_key" unique ("internal_id", "deployment_id");

--- a/hasura/migrations/carnet_de_bord/1684333811675_alter_table_beneficiary_index/up.sql
+++ b/hasura/migrations/carnet_de_bord/1684333811675_alter_table_beneficiary_index/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."beneficiary" drop constraint "beneficiary_internal_id_deployment_id_key";
+alter table "public"."beneficiary" add constraint "beneficiary_deployment_id_internal_id_key" unique ("deployment_id", "internal_id");

--- a/hasura/migrations/carnet_de_bord/1684334642154_create_index_notebook_member_notebook_id/down.sql
+++ b/hasura/migrations/carnet_de_bord/1684334642154_create_index_notebook_member_notebook_id/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "public"."notebook_member_notebook_id";

--- a/hasura/migrations/carnet_de_bord/1684334642154_create_index_notebook_member_notebook_id/up.sql
+++ b/hasura/migrations/carnet_de_bord/1684334642154_create_index_notebook_member_notebook_id/up.sql
@@ -1,0 +1,2 @@
+CREATE  INDEX "notebook_member_notebook_id" on
+  "public"."notebook_member" using btree ("notebook_id");

--- a/hasura/migrations/carnet_de_bord/1684334846968_alter_table_public_notebook_action_drop_column_initial_id/down.sql
+++ b/hasura/migrations/carnet_de_bord/1684334846968_alter_table_public_notebook_action_drop_column_initial_id/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."notebook_action" add column "initial_id" varchar null;
+alter table "public"."notebook_action" add constraint "notebook_action_initial_id_key" unique (initial_id);

--- a/hasura/migrations/carnet_de_bord/1684334846968_alter_table_public_notebook_action_drop_column_initial_id/up.sql
+++ b/hasura/migrations/carnet_de_bord/1684334846968_alter_table_public_notebook_action_drop_column_initial_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."notebook_action" drop column "initial_id";


### PR DESCRIPTION
## :wrench: Problème

Une erreur est levée toute les nuits à 1h00 CEST. Après investigation, l'erreur provient du cron qui lance le script matomo_dashboard. Ce script mets plus de 60s à s'éxécuter ce qui entraine un timeout de la part du router scalingo. Le script quant à lui poursuit son exécution sans erreur.  

## :cake: Solution

La requête graphql initiale utilisée un champ calculé (nb_member) qui n'utilisait pas le champ `active` ce qui avait pour conséquence de ne pas profiter de l'index sur les champs notebook_id / active=true
Suite à une mise à jour d'Hasura, il est maintenant possible de se passé du champ calculé et d'exprimer la requête en graphql.

Au cours de l'investigation, plusieurs problèmes sont apparus. 

- [x] les colonnes dimensions ne sont pas remplies dans matomo suite à la migration du matomo de la Fabrique
- [x] la définition de l'index (internal_id, deployment_id) sur beneficiary ne permet pas son utilisation partielle car la première colonne est l'internal_id et il faudrait que ce soit l'inverse
- [x] Il n'existe pas d'index sur notebook_id dans la table notebeook_member
- [x] Le champs internal_id de la table notebook_action ne sert plus

## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Appeler le endpoint `matomo_dashobard`.
```
http -v POST https://cdb-app-review-pr1750.osc-fr1.scalingo.io/actions/matomo_dashboard secret_token:action_secret_token
```

Vérifier que la route répond 200.