### PR TITLE
feat: ajout de l'historique de parcours pour les Chargés d'Orientation

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -19389,8 +19389,6 @@ export type SearchPublicNotebooksQuery = {
 
 export type GetNotebookQueryVariables = Exact<{
 	id: Scalars['uuid'];
-	eventsStart?: InputMaybe<Scalars['timestamptz']>;
-	eventsEnd?: InputMaybe<Scalars['timestamptz']>;
 	withOrientationRequests?: InputMaybe<Scalars['Boolean']>;
 }>;
 
@@ -19608,22 +19606,6 @@ export type GetNotebookQuery = {
 				__typename?: 'notebook_appointment';
 				date: any;
 				memberAccountId: string;
-			}>;
-			events: Array<{
-				__typename?: 'notebook_event';
-				id: string;
-				eventDate: string;
-				event: any;
-				eventType: NotebookEventTypeEnum;
-				creatorId?: string | null;
-				creator?: {
-					__typename?: 'account';
-					professional?: {
-						__typename?: 'professional';
-						structureId: string;
-						structure: { __typename?: 'structure'; name: string };
-					} | null;
-				} | null;
 			}>;
 		} | null;
 	}>;
@@ -31789,18 +31771,6 @@ export const GetNotebookDocument = {
 				},
 				{
 					kind: 'VariableDefinition',
-					variable: { kind: 'Variable', name: { kind: 'Name', value: 'eventsStart' } },
-					type: { kind: 'NamedType', name: { kind: 'Name', value: 'timestamptz' } },
-					defaultValue: { kind: 'StringValue', value: '-infinity', block: false },
-				},
-				{
-					kind: 'VariableDefinition',
-					variable: { kind: 'Variable', name: { kind: 'Name', value: 'eventsEnd' } },
-					type: { kind: 'NamedType', name: { kind: 'Name', value: 'timestamptz' } },
-					defaultValue: { kind: 'StringValue', value: 'infinity', block: false },
-				},
-				{
-					kind: 'VariableDefinition',
 					variable: { kind: 'Variable', name: { kind: 'Name', value: 'withOrientationRequests' } },
 					type: { kind: 'NamedType', name: { kind: 'Name', value: 'Boolean' } },
 					defaultValue: { kind: 'BooleanValue', value: true },
@@ -32801,111 +32771,6 @@ export const GetNotebookDocument = {
 														{ kind: 'Field', name: { kind: 'Name', value: 'date' } },
 														{ kind: 'Field', name: { kind: 'Name', value: 'memberAccountId' } },
 													],
-												},
-											},
-											{
-												kind: 'Field',
-												name: { kind: 'Name', value: 'events' },
-												arguments: [
-													{
-														kind: 'Argument',
-														name: { kind: 'Name', value: 'order_by' },
-														value: {
-															kind: 'ObjectValue',
-															fields: [
-																{
-																	kind: 'ObjectField',
-																	name: { kind: 'Name', value: 'eventDate' },
-																	value: { kind: 'EnumValue', value: 'desc_nulls_first' },
-																},
-															],
-														},
-													},
-													{
-														kind: 'Argument',
-														name: { kind: 'Name', value: 'where' },
-														value: {
-															kind: 'ObjectValue',
-															fields: [
-																{
-																	kind: 'ObjectField',
-																	name: { kind: 'Name', value: 'eventDate' },
-																	value: {
-																		kind: 'ObjectValue',
-																		fields: [
-																			{
-																				kind: 'ObjectField',
-																				name: { kind: 'Name', value: '_gte' },
-																				value: {
-																					kind: 'Variable',
-																					name: { kind: 'Name', value: 'eventsStart' },
-																				},
-																			},
-																			{
-																				kind: 'ObjectField',
-																				name: { kind: 'Name', value: '_lte' },
-																				value: {
-																					kind: 'Variable',
-																					name: { kind: 'Name', value: 'eventsEnd' },
-																				},
-																			},
-																		],
-																	},
-																},
-															],
-														},
-													},
-												],
-												selectionSet: {
-													kind: 'SelectionSet',
-													selections: [
-														{
-															kind: 'FragmentSpread',
-															name: { kind: 'Name', value: 'eventFields' },
-														},
-													],
-												},
-											},
-										],
-									},
-								},
-							],
-						},
-					},
-				],
-			},
-		},
-		{
-			kind: 'FragmentDefinition',
-			name: { kind: 'Name', value: 'eventFields' },
-			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'notebook_event' } },
-			selectionSet: {
-				kind: 'SelectionSet',
-				selections: [
-					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'eventDate' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'event' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'eventType' } },
-					{ kind: 'Field', name: { kind: 'Name', value: 'creatorId' } },
-					{
-						kind: 'Field',
-						name: { kind: 'Name', value: 'creator' },
-						selectionSet: {
-							kind: 'SelectionSet',
-							selections: [
-								{
-									kind: 'Field',
-									name: { kind: 'Name', value: 'professional' },
-									selectionSet: {
-										kind: 'SelectionSet',
-										selections: [
-											{ kind: 'Field', name: { kind: 'Name', value: 'structureId' } },
-											{
-												kind: 'Field',
-												name: { kind: 'Name', value: 'structure' },
-												selectionSet: {
-													kind: 'SelectionSet',
-													selections: [{ kind: 'Field', name: { kind: 'Name', value: 'name' } }],
 												},
 											},
 										],

--- a/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
+++ b/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+	import { MainSection, SearchBar, Select } from '$lib/ui/base';
+	import type {
+		GetNotebookQuery,
+		GetNotebookEventsQueryStore,
+	} from '$lib/graphql/_gen/typed-document-nodes';
+	import { stringsMatch } from '$lib/helpers';
+	import { addMonths } from 'date-fns';
+	import { operationStore } from '@urql/svelte';
+	import {
+		GetNotebookEventsDocument,
+		NotebookEventTypeEnum,
+	} from '$lib/graphql/_gen/typed-document-nodes';
+	import { focusThemeKeys } from '$lib/constants/keys';
+	import { actionStatusValues, eventTypes, targetStatusValues } from '$lib/constants';
+	import { formatDateLocale } from '$lib/utils/date';
+
+	type Notebook = GetNotebookQuery['notebook_public_view'][0]['notebook'];
+	export let notebook: Notebook;
+
+	let search = '';
+	const allValues = targetStatusValues.concat(actionStatusValues);
+
+	const getNotebookEvents: GetNotebookEventsQueryStore = operationStore(
+		GetNotebookEventsDocument,
+		{ notebookId: notebook.id },
+		{ pause: true }
+	);
+	$: filteredEvents = events;
+	$: events = $getNotebookEvents.data?.notebook_event || notebook?.events;
+
+	function eventCategory(event): string {
+		if (
+			(event.eventType == NotebookEventTypeEnum.Action ||
+				event.eventType == NotebookEventTypeEnum.Target) &&
+			focusThemeKeys.byKey[event.event.category]
+		) {
+			return (
+				constantToString(event.eventType, eventTypes) +
+				' ' +
+				focusThemeKeys.byKey[event.event.category]
+			);
+		} else {
+			return 'Action inconnue';
+		}
+	}
+
+	function constantToString(
+		status: string,
+		statusValues: { label: string; name: string }[]
+	): string {
+		const status_string: { label: string; name: string } = statusValues.find(
+			(v) => v.name == status
+		);
+
+		return status_string ? status_string.label : 'Inconnu';
+	}
+
+	function handleSearch() {
+		const matcher = stringsMatch(search);
+		filteredEvents = events?.filter(
+			(filtered_event) =>
+				matcher(filtered_event.event.event_label) ||
+				matcher(filtered_event.creator?.professional?.structure.name) ||
+				matcher(eventCategory(filtered_event)) ||
+				matcher(constantToString(filtered_event.event.status, allValues))
+		);
+	}
+
+	function toDateFormat(date: Date) {
+		const yyyy = date.getFullYear().toString().padStart(4, '0');
+		const mm = (1 + date.getMonth()).toString().padStart(2, '0');
+		const dd = date.getDate().toString().padStart(2, '0');
+
+		return `${yyyy}-${mm}-${dd}`;
+	}
+
+	function buildQueryVariables<Vars>(
+		variables: Vars & {
+			eventsStart?: string;
+			eventsEnd?: string;
+		},
+		selected: Period
+	) {
+		let eventsStart: Date;
+		let eventsEnd: Date;
+		const today = new Date();
+		if (selected === threeMonths) {
+			eventsStart = addMonths(today, -3);
+		} else if (selected === threeSixMonths) {
+			eventsStart = addMonths(today, -6);
+			eventsEnd = addMonths(today, -3);
+		} else if (selected === sixTwelveMonths) {
+			eventsStart = addMonths(today, -12);
+			eventsEnd = addMonths(today, -6);
+		} else if (selected === twelveMonths) {
+			eventsEnd = addMonths(today, -12);
+		}
+
+		if (eventsStart) {
+			variables.eventsStart = toDateFormat(eventsStart);
+		}
+		if (eventsEnd) {
+			variables.eventsEnd = toDateFormat(eventsEnd);
+		}
+		return variables;
+	}
+	const allEvents = 'allEvents';
+	const threeMonths = '-3months';
+	const threeSixMonths = '3-6months';
+	const sixTwelveMonths = '6-12months';
+	const twelveMonths = '+12months';
+
+	type Period =
+		| typeof allEvents
+		| typeof threeMonths
+		| typeof threeSixMonths
+		| typeof sixTwelveMonths
+		| typeof twelveMonths
+		| null;
+
+	let selected: Period = threeMonths;
+
+	function onSelect(event: CustomEvent<{ selected: Period }>) {
+		selected = event.detail.selected;
+		$getNotebookEvents.context.pause = false;
+		const variables = { notebookId: notebook.id };
+		$getNotebookEvents.variables = buildQueryVariables(variables, selected);
+		$getNotebookEvents.reexecute();
+	}
+</script>
+
+{#if notebook?.events}
+	<MainSection title="Historique de parcours">
+		<div class="flex flex-row justify-between mb-2">
+			<Select
+				on:select={onSelect}
+				options={[
+					{ name: allEvents, label: 'Tous les évènements' },
+					{ name: threeMonths, label: 'Dans les 3 derniers mois' },
+					{ name: threeSixMonths, label: 'Entre les 3 et 6 derniers mois' },
+					{ name: sixTwelveMonths, label: 'Entre les 6 et 12 derniers mois' },
+					{ name: twelveMonths, label: 'Il y a plus de 12 mois' },
+				]}
+				{selected}
+				selectHint="Sélectionner un filtre"
+				selectLabel="Période"
+				classNames="self-center"
+				twWidthClass="w-5/12"
+			/>
+			<SearchBar
+				inputLabel=""
+				inputHint="Axe de travail, action, structure"
+				bind:search
+				handleSubmit={handleSearch}
+				classNames="self-center"
+				twWidthClass="w-5/12"
+			/>
+		</div>
+		<div class={`w-full fr-table fr-table--layout-fixed`}>
+			<table class="w-full">
+				<thead>
+					<tr>
+						<th>Date</th>
+						<th>Catégorie</th>
+						<th>Évènements</th>
+						<th>Structure</th>
+						<th>Statut</th>
+					</tr>
+				</thead>
+				<tbody class="w-full">
+					{#each filteredEvents || [] as event (event.id)}
+						<tr>
+							<td>{formatDateLocale(event.eventDate)} </td>
+							<td>{eventCategory(event)}</td>
+							<td>{event.event.event_label}</td>
+							<td
+								>{#if !event.creator && event.event.from == 'pole_emploi'}
+									Pôle emploi
+								{:else}
+									{event.creator?.professional?.structure.name ?? '-'}
+								{/if}</td
+							>
+							<td
+								>{constantToString(
+									event.event.status,
+									event.eventType == NotebookEventTypeEnum.Action
+										? actionStatusValues
+										: targetStatusValues
+								)}</td
+							>
+						</tr>
+					{:else}
+						<tr class="shadow-sm">
+							<td class="!text-center" colspan="5">
+								{#if events.length > 0}
+									Aucun évènement ne correspond à votre recherche.
+								{:else}
+									Aucun évènement pour le moment.
+								{/if}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</MainSection>
+{/if}

--- a/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
+++ b/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
@@ -38,7 +38,7 @@
 
 	const getNotebookEvents: GetNotebookEventsQueryStore = operationStore(
 		GetNotebookEventsDocument,
-		buildQueryVariables({ notebookId: notebook.id }, selected)
+		buildQueryVariables({ notebookId: notebook?.id }, selected)
 	);
 
 	query(getNotebookEvents);
@@ -125,7 +125,7 @@
 
 	function onSelect(event: CustomEvent<{ selected: Period }>) {
 		selected = event.detail.selected;
-		$getNotebookEvents.variables = buildQueryVariables({ notebookId: notebook.id }, selected);
+		$getNotebookEvents.variables = buildQueryVariables({ notebookId: notebook?.id }, selected);
 		$getNotebookEvents.reexecute();
 	}
 </script>

--- a/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
+++ b/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
@@ -48,18 +48,18 @@
 
 	function eventCategory(event): string {
 		if (
-			(event.eventType == NotebookEventTypeEnum.Action ||
-				event.eventType == NotebookEventTypeEnum.Target) &&
-			focusThemeKeys.byKey[event.event.category]
+			(event.eventType != NotebookEventTypeEnum.Action &&
+				event.eventType != NotebookEventTypeEnum.Target) ||
+			!focusThemeKeys.byKey[event.event.category]
 		) {
-			return (
-				constantToString(event.eventType, eventTypes) +
-				' ' +
-				focusThemeKeys.byKey[event.event.category]
-			);
-		} else {
 			return 'Action inconnue';
 		}
+
+		return (
+			constantToString(event.eventType, eventTypes) +
+			' ' +
+			focusThemeKeys.byKey[event.event.category]
+		);
 	}
 
 	function constantToString(

--- a/app/src/routes/(auth)/orientation/carnets/edition/[notebook_id]/+page.svelte
+++ b/app/src/routes/(auth)/orientation/carnets/edition/[notebook_id]/+page.svelte
@@ -4,6 +4,7 @@
 	import LoaderIndicator from '$lib/ui/utils/LoaderIndicator.svelte';
 	import { operationStore, query } from '@urql/svelte';
 	import type { PageData } from './$types';
+	import NotebookEventList from '$lib/ui/NotebookEvent/NotebookEventList.svelte';
 
 	export let data: PageData;
 
@@ -33,4 +34,5 @@
 
 <LoaderIndicator result={getNotebookResult}>
 	<NotebookEdit notebook={notebookPublic} on:beneficiary-orientation-changed={refreshNotebook} />
+	<NotebookEventList notebook={notebookPublic['notebook']} />
 </LoaderIndicator>

--- a/app/src/routes/(auth)/orientation/carnets/edition/[notebook_id]/+page.svelte
+++ b/app/src/routes/(auth)/orientation/carnets/edition/[notebook_id]/+page.svelte
@@ -34,5 +34,8 @@
 
 <LoaderIndicator result={getNotebookResult}>
 	<NotebookEdit notebook={notebookPublic} on:beneficiary-orientation-changed={refreshNotebook} />
-	<NotebookEventList notebook={notebookPublic['notebook']} />
+
+	{#if notebookPublic['notebook']}
+		<NotebookEventList notebook={notebookPublic['notebook']} />
+	{/if}
 </LoaderIndicator>

--- a/app/src/routes/(auth)/orientation/carnets/edition/[notebook_id]/+page.svelte
+++ b/app/src/routes/(auth)/orientation/carnets/edition/[notebook_id]/+page.svelte
@@ -35,7 +35,5 @@
 <LoaderIndicator result={getNotebookResult}>
 	<NotebookEdit notebook={notebookPublic} on:beneficiary-orientation-changed={refreshNotebook} />
 
-	{#if notebookPublic['notebook']}
-		<NotebookEventList notebook={notebookPublic['notebook']} />
-	{/if}
+	<NotebookEventList notebook={notebookPublic['notebook']} />
 </LoaderIndicator>

--- a/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
@@ -176,7 +176,9 @@
 					<ProNotebookFocusView {notebook} focuses={notebook.focuses} />
 				</MainSection>
 			{/if}
-			<NotebookEventList {notebook} />
+			{#if notebook}
+				<NotebookEventList {notebook} />
+			{/if}
 		</div>
 	{/if}
 </LoaderIndicator>

--- a/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
@@ -73,7 +73,6 @@
 
 	function refreshNotebook() {
 		$getNotebook.reexecute({ requestPolicy: 'network-only' });
-		//@TODO: reload events componenent NotebookEventList ?
 	}
 
 	$: publicNotebook = $getNotebook.data?.notebook_public_view[0];
@@ -176,9 +175,7 @@
 					<ProNotebookFocusView {notebook} focuses={notebook.focuses} />
 				</MainSection>
 			{/if}
-			{#if notebook}
-				<NotebookEventList {notebook} />
-			{/if}
+			<NotebookEventList {notebook} />
 		</div>
 	{/if}
 </LoaderIndicator>

--- a/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
+++ b/app/src/routes/(auth)/pro/carnet/[uuid]/+page.svelte
@@ -175,7 +175,9 @@
 					<ProNotebookFocusView {notebook} focuses={notebook.focuses} />
 				</MainSection>
 			{/if}
-			<NotebookEventList {notebook} />
+			{#if isMember}
+				<NotebookEventList {notebook} />
+			{/if}
 		</div>
 	{/if}
 </LoaderIndicator>

--- a/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
+++ b/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
@@ -1,9 +1,4 @@
-query GetNotebook(
-  $id: uuid!
-  $eventsStart: timestamptz = "-infinity"
-  $eventsEnd: timestamptz = "infinity"
-  $withOrientationRequests: Boolean = true
-) {
+query GetNotebook($id: uuid!, $withOrientationRequests: Boolean = true) {
   refSituations: ref_situation {
     id
     description
@@ -220,12 +215,6 @@ query GetNotebook(
       ) {
         date
         memberAccountId
-      }
-      events(
-        order_by: { eventDate: desc_nulls_first }
-        where: { eventDate: { _gte: $eventsStart, _lte: $eventsEnd } }
-      ) {
-        ...eventFields
       }
     }
   }

--- a/hasura/seeds/carnet_de_bord/seed-data.sql
+++ b/hasura/seeds/carnet_de_bord/seed-data.sql
@@ -259,6 +259,13 @@ INSERT INTO public.notebook_appointment (id, notebook_id, account_id, date, stat
 INSERT INTO public.notebook_appointment (id, notebook_id, account_id, date, status, created_at, updated_at) VALUES ('5ab6baed-fa1f-4bc2-ab93-be3c07f632f7', '9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d', 'd0b8f314-5e83-4535-9360-60f29dcfb5c8', '2021-09-11 13:15:00.000+00', 'absent', '2021-09-11 13:15:00.000+00', '2021-09-11 13:06:45.076+00');
 INSERT INTO public.notebook_appointment (id, notebook_id, account_id, date, status, created_at, updated_at) VALUES ('4d1fff01-463b-4c1b-94e2-f3588a6cbf88', '9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d', '17434464-5f69-40cc-8172-40160958a33d', '2021-08-11 13:15:00.000+00', 'current', '2021-08-11 13:15:00.000+00', '2021-08-11 13:06:45.076+00');
 
+INSERT INTO public.notebook_event (id, notebook_id, event_date, creator_id, event, event_type) VALUES ('a2c2949c-9b30-4fdc-b974-b85e571422b6', '9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d', now() - INTERVAL '4 months', 'd0b8f314-5e83-4535-9360-60f29dcfb5c8', '{ "status": "in_progress", "category": "emploi", "event_label": "Prépa-Compétences" }', 'action');
+
+
+INSERT INTO public.notebook_event (id, notebook_id, event_date, creator_id, event, event_type) VALUES ('26b0af96-5b22-4eb1-9d37-7785337d2de2', '9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d', now() - INTERVAL '7 months', 'd0b8f314-5e83-4535-9360-60f29dcfb5c8', '{ "status": "in_progress", "category": "emploi", "event_label": "Avoir un pass IAE validé" }', 'action');
+
+
+INSERT INTO public.notebook_event (id, notebook_id, event_date, creator_id, event, event_type) VALUES ('9db21f40-593f-4711-8104-d9412ad63785', '9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d', now() - INTERVAL '2 years', 'd0b8f314-5e83-4535-9360-60f29dcfb5c8', '{ "status": "in_progress", "category": "emploi", "event_label": "Orientation vers une SIAE" }', 'action');
 
 
 -- Marc Saintpa


### PR DESCRIPTION
## :wrench: Problème

ETQ CO, je veux pouvoir consulter l'historique de parcours

## :cake: Solution

On extraie l'affichage des évènements dans un composant Svelte pour pouvoir le réutiliser côté CO.


## :rotating_light:  Points d'attention / Remarques

J'ai enlevé du code qui me semblait obsolète de rafraîchissement des events en même temps que le Notebook. A vérifier que le rafraîchissement des events lors du rechargement du Notebook se passe bien.

## :desert_island: Comment tester

Se connecter avec un CO (`giulia.diaby` par exemple) et s'assurer que l'on peut voir la liste des actions lorsque l'on est sur un carnet.
fix #1678 
