### PR TITLE
feat: permettre aux admin de structures de modifier les informations personnelles

### DIFF
--- a/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
+++ b/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
@@ -1,5 +1,12 @@
 <script context="module" lang="ts">
-	export type Field = 'firstname' | 'lastname' | 'dateOfBirth';
+	export type Field =
+		| 'firstname'
+		| 'lastname'
+		| 'dateOfBirth'
+		| 'rightRsa'
+		| 'rightAre'
+		| 'rightAss'
+		| 'rightBonus';
 </script>
 
 <script lang="ts">
@@ -11,7 +18,6 @@
 	export let disabledFields: Field[];
 	// Keep the same behavior as before, we can by default
 	// edit everything
-	export let canEditDetailedInfo = true;
 
 	function isFieldDisabled(fieldName: Field) {
 		return disabledFields.includes(fieldName);
@@ -68,25 +74,24 @@
 	<Input class="fr-col-9 mb-1" inputLabel="Ville" placeholder="Paris" name="city" />
 </div>
 
-{#if canEditDetailedInfo}
-	<div class="fr-form-group mt-6">
-		<Radio
-			legend="Revenu de solidarité active (RSA)"
-			name="rightRsa"
-			options={rsaRightKeys.options}
-		/>
-	</div>
+<div class="fr-form-group mt-6">
+	<Radio
+		legend="Revenu de solidarité active (RSA)"
+		name="rightRsa"
+		options={rsaRightKeys.options}
+		disabled={isFieldDisabled('rightRsa')}
+	/>
+</div>
 
-	<div class="fr-fieldset">
-		<legend class="fr-fieldset__legend--regular fr-fieldset__legend">Autres aides</legend>
-		<div class="fr-fieldset__element">
-			<Checkbox name="rightAre" label="ARE" />
-		</div>
-		<div class="fr-fieldset__element">
-			<Checkbox name="rightAss" label="ASS" />
-		</div>
-		<div class="fr-fieldset__element">
-			<Checkbox name="rightBonus" label="Prime d'activité" />
-		</div>
+<div class="fr-fieldset">
+	<legend class="fr-fieldset__legend--regular fr-fieldset__legend">Autres aides</legend>
+	<div class="fr-fieldset__element">
+		<Checkbox name="rightAre" label="ARE" disabled={isFieldDisabled('rightAre')} />
 	</div>
-{/if}
+	<div class="fr-fieldset__element">
+		<Checkbox name="rightAss" label="ASS" disabled={isFieldDisabled('rightAss')} />
+	</div>
+	<div class="fr-fieldset__element">
+		<Checkbox name="rightBonus" label="Prime d'activité" disabled={isFieldDisabled('rightBonus')} />
+	</div>
+</div>

--- a/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
+++ b/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
@@ -16,8 +16,7 @@
 	import { Checkbox, Radio } from '../forms';
 
 	export let disabledFields: Field[];
-	// Keep the same behavior as before, we can by default
-	// edit everything
+	// We can by default edit any field
 
 	function isFieldDisabled(fieldName: Field) {
 		return disabledFields.includes(fieldName);

--- a/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
+++ b/app/src/lib/ui/ProBeneficiaryUpdate/ProBeneficiaryUpdateFields.svelte
@@ -8,10 +8,13 @@
 	import Input from '$lib/ui/forms/Input.svelte';
 	import { Checkbox, Radio } from '../forms';
 
-	export let forbiddenFields: Field[];
+	export let disabledFields: Field[];
+	// Keep the same behavior as before, we can by default
+	// edit everything
+	export let canEditDetailedInfo = true;
 
 	function isFieldDisabled(fieldName: Field) {
-		return forbiddenFields.includes(fieldName);
+		return disabledFields.includes(fieldName);
 	}
 
 	function titleForField(fieldName: Field) {
@@ -65,23 +68,25 @@
 	<Input class="fr-col-9 mb-1" inputLabel="Ville" placeholder="Paris" name="city" />
 </div>
 
-<div class="fr-form-group mt-6">
-	<Radio
-		legend="Revenu de solidarité active (RSA)"
-		name="rightRsa"
-		options={rsaRightKeys.options}
-	/>
-</div>
+{#if canEditDetailedInfo}
+	<div class="fr-form-group mt-6">
+		<Radio
+			legend="Revenu de solidarité active (RSA)"
+			name="rightRsa"
+			options={rsaRightKeys.options}
+		/>
+	</div>
 
-<div class="fr-fieldset">
-	<legend class="fr-fieldset__legend--regular fr-fieldset__legend">Autres aides</legend>
-	<div class="fr-fieldset__element">
-		<Checkbox name="rightAre" label="ARE" />
+	<div class="fr-fieldset">
+		<legend class="fr-fieldset__legend--regular fr-fieldset__legend">Autres aides</legend>
+		<div class="fr-fieldset__element">
+			<Checkbox name="rightAre" label="ARE" />
+		</div>
+		<div class="fr-fieldset__element">
+			<Checkbox name="rightAss" label="ASS" />
+		</div>
+		<div class="fr-fieldset__element">
+			<Checkbox name="rightBonus" label="Prime d'activité" />
+		</div>
 	</div>
-	<div class="fr-fieldset__element">
-		<Checkbox name="rightAss" label="ASS" />
-	</div>
-	<div class="fr-fieldset__element">
-		<Checkbox name="rightBonus" label="Prime d'activité" />
-	</div>
-</div>
+{/if}

--- a/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoUpdate.svelte
@@ -81,7 +81,7 @@
 			? { ...values, firstname: undefined, lastname: undefined, dateOfBirth: undefined }
 			: { ...values };
 
-		const detailedPayload = canEditDetailedInfo
+		const payload = canEditDetailedInfo
 			? { ...partialUpdatePayload }
 			: {
 					...partialUpdatePayload,
@@ -96,7 +96,7 @@
 
 		await update({
 			id: beneficiary.id,
-			payload: detailedPayload,
+			payload,
 		});
 		openComponent.close();
 	}

--- a/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoUpdate.svelte
@@ -68,7 +68,13 @@
 		? beneficiaryAccountPartialSchema
 		: beneficiaryAccountSchema;
 
-	const disabledFields: Field[] = isPartialUpdate ? ['firstname', 'lastname', 'dateOfBirth'] : [];
+	const partialUpdateDisabledFields: Field[] = isPartialUpdate
+		? ['firstname', 'lastname', 'dateOfBirth']
+		: [];
+
+	const disabledFields: Field[] = partialUpdateDisabledFields.concat(
+		canEditDetailedInfo ? [] : ['rightRsa', 'rightAre', 'rightAss', 'rightBonus']
+	);
 
 	async function updateBeneficiary(values: BeneficiaryAccountInput) {
 		const partialUpdatePayload = isPartialUpdate
@@ -102,8 +108,9 @@
 
 <section>
 	<h1>Informations personnelles</h1>
+	{canEditDetailedInfo}
 	<Form {initialValues} {validationSchema} onSubmit={updateBeneficiary}>
-		<ProBeneficiaryUpdateFields {disabledFields} {canEditDetailedInfo} />
+		<ProBeneficiaryUpdateFields {disabledFields} />
 		<Input
 			name="peNumber"
 			placeholder={'123456789A'}

--- a/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoUpdate.svelte
@@ -108,7 +108,6 @@
 
 <section>
 	<h1>Informations personnelles</h1>
-	{canEditDetailedInfo}
 	<Form {initialValues} {validationSchema} onSubmit={updateBeneficiary}>
 		<ProBeneficiaryUpdateFields {disabledFields} />
 		<Input

--- a/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoUpdate.svelte
@@ -17,6 +17,8 @@
 	import Input from '$lib/ui/forms/Input.svelte';
 	import { trackEvent } from '$lib/tracking/matomo';
 
+	import { RoleEnum } from '$lib/graphql/_gen/typed-document-nodes';
+
 	export let beneficiary: Pick<
 		Beneficiary,
 		| 'id'
@@ -36,6 +38,8 @@
 		| 'rightAss'
 		| 'rightBonus'
 	>;
+
+	export let canEditDetailedInfo = false;
 
 	const updateStore = operationStore(UpdateBeneficiaryPersonalInfoDocument);
 	const update = mutation(updateStore);
@@ -58,22 +62,35 @@
 		rightBonus: beneficiary.rightBonus,
 	};
 
-	const isPartialUpdate = $accountData.type !== 'manager';
+	const isPartialUpdate = $accountData.type !== RoleEnum.Manager;
 
 	const validationSchema = isPartialUpdate
 		? beneficiaryAccountPartialSchema
 		: beneficiaryAccountSchema;
 
-	const forbiddenFields: Field[] = isPartialUpdate ? ['firstname', 'lastname', 'dateOfBirth'] : [];
+	const disabledFields: Field[] = isPartialUpdate ? ['firstname', 'lastname', 'dateOfBirth'] : [];
 
 	async function updateBeneficiary(values: BeneficiaryAccountInput) {
-		const payload = isPartialUpdate
+		const partialUpdatePayload = isPartialUpdate
 			? { ...values, firstname: undefined, lastname: undefined, dateOfBirth: undefined }
 			: { ...values };
+
+		const detailedPayload = canEditDetailedInfo
+			? { ...partialUpdatePayload }
+			: {
+					...partialUpdatePayload,
+					peNumber: undefined,
+					cafNumber: undefined,
+					rightAre: undefined,
+					rightAss: undefined,
+					rightBonus: undefined,
+					rightRsa: undefined,
+			  };
 		trackEvent('pro', 'notebook', 'update personnal info');
+
 		await update({
 			id: beneficiary.id,
-			payload,
+			payload: detailedPayload,
 		});
 		openComponent.close();
 	}
@@ -86,14 +103,20 @@
 <section>
 	<h1>Informations personnelles</h1>
 	<Form {initialValues} {validationSchema} onSubmit={updateBeneficiary}>
-		<ProBeneficiaryUpdateFields {forbiddenFields} />
+		<ProBeneficiaryUpdateFields {disabledFields} {canEditDetailedInfo} />
 		<Input
 			name="peNumber"
 			placeholder={'123456789A'}
 			class="pt-6"
 			inputLabel={'Identifiant Pôle emploi'}
+			disabled={!canEditDetailedInfo}
 		/>
-		<Input name="cafNumber" placeholder={'123456789A'} inputLabel={'Identifiant CAF/MSA'} />
+		<Input
+			name="cafNumber"
+			placeholder={'123456789A'}
+			inputLabel={'Identifiant CAF/MSA'}
+			disabled={!canEditDetailedInfo}
+		/>
 		<div class="flex flex-row gap-6 pt-4 pb-12">
 			<Button type="submit">Enregistrer</Button>
 			<Button outline on:click={onCancel}>Annuler</Button>

--- a/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoView.svelte
+++ b/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoView.svelte
@@ -39,6 +39,7 @@
 	export let lastUpdateDate: string;
 	export let lastUpdateFrom: Pro;
 	export let displayEditButton = false;
+	export let canEditDetailedInfo = true;
 
 	const elmSetup = (node: HTMLElement) => {
 		PersonalInfoElm.PersonalInfo.Main.init({
@@ -55,7 +56,10 @@
 	};
 
 	function edit() {
-		openComponent.open({ component: ProNotebookPersonalInfoUpdate, props: { beneficiary } });
+		openComponent.open({
+			component: ProNotebookPersonalInfoUpdate,
+			props: { beneficiary, canEditDetailedInfo },
+		});
 	}
 </script>
 

--- a/app/src/lib/ui/forms/Radio.svelte
+++ b/app/src/lib/ui/forms/Radio.svelte
@@ -26,7 +26,6 @@
 <div class="fr-form-group">
 	<fieldset
 		class="fr-fieldset"
-		{disabled}
 		{...(valid || hasError) && {
 			role: 'group',
 			'aria-labelledby': `radio-${name}-legend radio-${name}-${
@@ -47,6 +46,7 @@
 						type="radio"
 						{name}
 						{required}
+						{disabled}
 						id={`radio-${name}-${option.name}`}
 						on:change
 						on:change={handleChange}

--- a/app/src/lib/ui/views/NotebookView.svelte
+++ b/app/src/lib/ui/views/NotebookView.svelte
@@ -26,7 +26,10 @@
 	$: lastUpdateFrom = members[0]?.account?.professional || members[0]?.account?.orientation_manager;
 	$: orientationRequest =
 		beneficiary?.orientationRequest?.length > 0 ? beneficiary.orientationRequest[0] : null;
-	$: isManager = $accountData.type === RoleEnum.Manager;
+	$: canEdit =
+		$accountData.type === RoleEnum.Manager || $accountData.type === RoleEnum.AdminStructure;
+
+	$: canEditDetailedInfo = $accountData.type === RoleEnum.Manager;
 
 	$: externalData =
 		beneficiary?.externalDataInfos.length > 0
@@ -46,11 +49,13 @@
 	{:else}
 		<OrientationHeader {notebook} on:beneficiary-orientation-changed />
 	{/if}
+
 	<ProNotebookPersonalInfoView
 		{beneficiary}
 		lastUpdateDate={members[0]?.lastModifiedAt}
 		{lastUpdateFrom}
-		displayEditButton={isManager}
+		displayEditButton={canEdit}
+		{canEditDetailedInfo}
 	/>
 	<div>
 		<MainSection title="Groupe de suivi">

--- a/app/src/routes/(auth)/structures/[uuid]/carnets/[notebook_id]/+page.svelte
+++ b/app/src/routes/(auth)/structures/[uuid]/carnets/[notebook_id]/+page.svelte
@@ -18,5 +18,5 @@
 </svelte:head>
 
 <LoaderIndicator result={getNotebookResult}>
-	<NotebookView notebook={getNotebookResult.data.notebook} />
+	<NotebookView notebook={$getNotebookResult.data.notebook} />
 </LoaderIndicator>

--- a/e2e/features/structureAdmin/carnet/edit.feature
+++ b/e2e/features/structureAdmin/carnet/edit.feature
@@ -1,0 +1,21 @@
+#language: fr
+
+Fonctionnalité: Mise à jour du carnet par un administrateur de structure
+	En tant qu'administrateur de structure
+	Je veux voir et mettre à jour les informations contact du bénéficiaire
+
+	Scénario: Saisie des informations personnelles par l'administrateur de structure
+		Soit un "administrateur de structures" authentifié avec l'email "jacques.celaire@livry-gargan.fr"
+		Quand je clique sur "Centre Communal d'action social Livry-Gargan"
+		Alors je clique sur "Bénéficiaires non accompagnés"
+		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
+		Quand je clique sur "Voir le carnet de Lindsay Aguilar"
+		Quand je vais sur l'onglet suivant
+		Alors j'attends que le texte "Lindsay Aguilar" apparaisse
+		Alors je vois "Informations personnelles"
+		Alors je vois "lindsay.aguilar@nisi.fr"
+		Quand je clique sur "Mettre à jour les informations personnelles"
+		Alors je vois qu'un élément avec l'id "peNumber" est désactivé
+		Quand je renseigne "0601234566" dans le champ "Téléphone"
+		Quand je clique sur "Enregistrer"
+		Alors je vois "06 01 23 45 66"

--- a/e2e/features/structureAdmin/carnet/edit.feature
+++ b/e2e/features/structureAdmin/carnet/edit.feature
@@ -15,11 +15,10 @@ Fonctionnalité: Mise à jour du carnet par un administrateur de structure
 		Alors je vois "Informations personnelles"
 		Alors je vois "lindsay.aguilar@nisi.fr"
 		Quand je clique sur "Mettre à jour les informations personnelles"
-		Alors je vois qu'un élément avec l'id "peNumber" est désactivé
-		Alors je vois qu'un élément avec l'id "cafNumber" est désactivé
-		Alors je vois qu'un élément avec l'id "rightAre" est désactivé
-		Alors je vois qu'un élément avec l'id "rightAss" est désactivé
-		Alors je vois qu'un élément avec l'id "rightBonus" est désactivé
+		Alors je vois que le champ de formulaire "Revenu de solidarité active (RSA)" est désactivé
+		Alors je vois que le champ de formulaire "Autres aides" est désactivé
+		Alors je vois que le champ de formulaire "Identifiant Pôle emploi" est désactivé
+		Alors je vois que le champ de formulaire "Identifiant CAF/MSA" est désactivé
 		Quand je renseigne "0601234566" dans le champ "Téléphone"
 		Quand je clique sur "Enregistrer"
 		Alors je vois "06 01 23 45 66"

--- a/e2e/features/structureAdmin/carnet/edit.feature
+++ b/e2e/features/structureAdmin/carnet/edit.feature
@@ -16,6 +16,10 @@ Fonctionnalité: Mise à jour du carnet par un administrateur de structure
 		Alors je vois "lindsay.aguilar@nisi.fr"
 		Quand je clique sur "Mettre à jour les informations personnelles"
 		Alors je vois qu'un élément avec l'id "peNumber" est désactivé
+		Alors je vois qu'un élément avec l'id "cafNumber" est désactivé
+		Alors je vois qu'un élément avec l'id "rightAre" est désactivé
+		Alors je vois qu'un élément avec l'id "rightAss" est désactivé
+		Alors je vois qu'un élément avec l'id "rightBonus" est désactivé
 		Quand je renseigne "0601234566" dans le champ "Téléphone"
 		Quand je clique sur "Enregistrer"
 		Alors je vois "06 01 23 45 66"

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -255,8 +255,13 @@ Alors('je vois que bouton {string} est désactivé', (text) => {
 	I.seeElement(`//button[text()="${text}" and @disabled]`);
 });
 
-Alors("je vois qu'un élément avec l'id {string} est désactivé", (text) => {
-	I.seeElement(`//*[@id="${text}" and @disabled]`);
+Alors('je vois que le champ de formulaire {string} est désactivé', (element) => {
+	const inputs = locate('*')
+		.withChild(locate('//label|//fieldset').withChild(locate('*').withText(element)))
+		.before(locate('*').withChild('input'))
+		.find('input');
+
+	I.seeAttributesOnElements(inputs, { disabled: true });
 });
 
 Alors('je vois {int} fois le {string} {string}', (num, element, text) => {

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -255,6 +255,10 @@ Alors('je vois que bouton {string} est désactivé', (text) => {
 	I.seeElement(`//button[text()="${text}" and @disabled]`);
 });
 
+Alors("je vois qu'un élément avec l'id {string} est désactivé", (text) => {
+	I.seeElement(`//*[@id="${text}" and @disabled]`);
+});
+
 Alors('je vois {int} fois le {string} {string}', (num, element, text) => {
 	I.seeNumberOfVisibleElements(`//${element}[contains(., "${text}")]`, num);
 });

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_beneficiary.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_beneficiary.yaml
@@ -409,6 +409,7 @@ update_permissions:
         - city
         - email
         - mobile_number
+        - postal_code
       filter:
         _or:
           - structures:

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_beneficiary.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_beneficiary.yaml
@@ -401,6 +401,33 @@ update_permissions:
         - right_rsa
       filter: {}
       check: {}
+  - role: admin_structure
+    permission:
+      columns:
+        - address1
+        - address2
+        - city
+        - email
+        - mobile_number
+      filter:
+        _or:
+          - structures:
+              structure:
+                admins:
+                  admin_structure_id:
+                    _eq: X-Hasura-AdminStructure-Id
+          - notebook:
+              members:
+                _and:
+                  - active:
+                      _eq: true
+                  - account:
+                      professional:
+                        structure:
+                          admins:
+                            admin_structure_id:
+                              _eq: X-Hasura-AdminStructure-Id
+      check: null
   - role: beneficiary
     permission:
       columns:

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_member.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_member.yaml
@@ -247,6 +247,7 @@ update_permissions:
     permission:
       columns:
         - active
+        - last_modified_at
         - member_type
         - membership_ended_at
       filter:


### PR DESCRIPTION
## :wrench: Problème

ETQ gestionnaire de structure, je veux pouvoir mettre à jour les informations personnelles des bénéficiaires orientés vers ma structure pour ne pas devoir demander à un des pros de le faire alors que je suis sur le dossier

Fix #1679 

## :cake: Solution

On rend le volet de modification des informations personnelles configurable pour ne pouvoir modifier que les données de contact (email / téléphone) et l'adresse pour les admin de structure.


## :desert_island: Comment tester

Se connecter avec un admin de structure comme `jacques.celaire` par exemple. Cliquer sur `Centre Communal d'action social Livry-Gargan` puis sur `28 bénéficiaires non accompagnés` et se rendre sur le carnet de de Lindsay Aguilar. Cliquer sur `Mettre à jour` dans la rubrique des informations personnelles. S'assurer qu'on peut mettre à jour les informations de contact (email, téléphone, adresse) mais pas le reste.

S'assurer que pour les autres profils (pro, manager, co) les fonctionnalités d'édition restent les mêmes.