### PR TITLE
fix(actions): utiliser la date de début dans l'historique de carnet

### DIFF
--- a/hasura/migrations/carnet_de_bord/1684934249002_actions_events_are_listed_at_the_starting_at_date/down.sql
+++ b/hasura/migrations/carnet_de_bord/1684934249002_actions_events_are_listed_at_the_starting_at_date/down.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION public.record_notebook_action_event()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  new_notebook_id uuid;
+  focus_theme text;
+BEGIN
+  SELECT notebook_focus.notebook_id, notebook_focus.theme
+  INTO new_notebook_id, focus_theme
+  FROM notebook_focus, notebook_target
+  WHERE notebook_focus.id = notebook_target.focus_id
+  AND notebook_target.id = NEW.target_id;
+
+  INSERT INTO notebook_event
+  (notebook_id, event_date, creator_id, event, event_type)
+  VALUES
+  (new_notebook_id, now(), NEW.creator_id, ('{ "category": "' || focus_theme || '", "status": "' || NEW.status || '", "event_label": "' || NEW.action || '"}')::jsonb, 'action');
+  RETURN NEW;
+END;
+$function$;

--- a/hasura/migrations/carnet_de_bord/1684934249002_actions_events_are_listed_at_the_starting_at_date/up.sql
+++ b/hasura/migrations/carnet_de_bord/1684934249002_actions_events_are_listed_at_the_starting_at_date/up.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION public.record_notebook_action_event()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  new_notebook_id uuid;
+  focus_theme text;
+BEGIN
+
+  SELECT notebook_focus.notebook_id, notebook_focus.theme
+  INTO new_notebook_id, focus_theme
+  FROM notebook_focus, notebook_target
+  WHERE notebook_focus.id = notebook_target.focus_id
+  AND notebook_target.id = NEW.target_id;
+
+  INSERT INTO notebook_event
+  (notebook_id, event_date, creator_id, event, event_type)
+  VALUES
+  (new_notebook_id, NEW.starting_at, NEW.creator_id, ('{ "category": "' || focus_theme || '", "status": "' || NEW.status || '", "event_label": "' || NEW.action || '"}')::jsonb, 'action');
+  RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
## :wrench: Problème

L'historique du carnet affiche les actions à leur date de création. On s'attend à ce que ce soit la date de début.
Fix #1767 

## :cake: Solution

Modifier le trigger record_notebook_action_event_init_trigger.

## ⚠️ Points d'attention

Je n'ai pas fait de migration de données. Je ne voyais pas comment relier les événements aux actions de manière fiable. Est-ce acceptable ?

## :desert_island: Comment tester

Ajouter une action avec une date de début différente de la date du jour. Elle apparait dans l'historique à la date de début sélectionnée.