### PR TITLE
fix(diagnostic): afficher l'ombre portée par les diagnostics professionnels

### DIFF
--- a/app/elm/Diagnostic/Main.elm
+++ b/app/elm/Diagnostic/Main.elm
@@ -317,7 +317,7 @@ workSituationDateFormat startDate endDate =
 
 socioProDiagFirstRowView : Model -> List (Html.Html msg)
 socioProDiagFirstRowView { professionalSituation, peGeneralData } =
-    [ Html.div [ class "fr-container--fluid" ]
+    [ Html.div [ class "fr-container--fluid overflow-visible" ]
         [ Html.div [ class "fr-grid-row fr-grid-row--gutters flex" ]
             [ socioProView professionalSituation
             , peInformationsView peGeneralData


### PR DESCRIPTION
## :wrench: Problème

Fix #1757 

## :cake: Solution
Autoriser l'overflow sur le container dsfr. 

## :rotating_light:  Points d'attention / Remarques
RAS

## :desert_island: Comment tester
Afficher un carnet. L'ombre des boites de diagnostic n'est pas coupée.