### PR TITLE
feat: Gestion des RDV des bénéficiaires par l'administrateur de structure

### DIFF
--- a/app/src/lib/ui/OrientationHeader/OrientationHeader.test.ts
+++ b/app/src/lib/ui/OrientationHeader/OrientationHeader.test.ts
@@ -116,6 +116,7 @@ const notebook: GetNotebookByBeneficiaryIdQuery['notebook'][number] = {
 	notebookInfo: { needOrientation: false },
 	rightRqth: false,
 	situations: [],
+	appointments: [],
 };
 
 test('do not show "Réorienter" button for admin_structure', () => {

--- a/app/src/lib/ui/views/NotebookView.svelte
+++ b/app/src/lib/ui/views/NotebookView.svelte
@@ -13,6 +13,7 @@
 	import ProNotebookPersonalInfoView from '$lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoView.svelte';
 	import OrientationRequestBanner from '../OrientationRequest/OrientationRequestBanner.svelte';
 	import OrientationHeader from '../OrientationHeader/OrientationHeader.svelte';
+	import { ProNotebookMembersView } from '$lib/ui/ProNotebookMember';
 
 	import Portal from 'svelte-portal';
 	import { accountData } from '$lib/stores';
@@ -28,6 +29,7 @@
 		beneficiary?.orientationRequest?.length > 0 ? beneficiary.orientationRequest[0] : null;
 	$: canEdit =
 		$accountData.type === RoleEnum.Manager || $accountData.type === RoleEnum.AdminStructure;
+	$: appointments = notebook?.appointments ?? [];
 
 	$: canEditDetailedInfo = $accountData.type === RoleEnum.Manager;
 
@@ -59,7 +61,18 @@
 	/>
 	<div>
 		<MainSection title="Groupe de suivi">
-			<NotebookMembers members={notebook.members} notebookId={notebook.id} />
+			{#if $accountData.type === RoleEnum.AdminStructure}
+				<ProNotebookMembersView
+					{members}
+					notebookId={notebook.id}
+					beneficiaryFirstname={beneficiary.firstname}
+					beneficiaryLastname={beneficiary.lastname}
+					{appointments}
+					displayMemberManagementButtons={false}
+				/>
+			{:else}
+				<NotebookMembers members={notebook.members} notebookId={notebook.id} />
+			{/if}
 		</MainSection>
 		<MainSection title="Diagnostic socioprofessionnel">
 			<SocioProView {notebook} externalDataDetail={externalData} />

--- a/app/src/routes/(auth)/beneficiaire/+page.svelte
+++ b/app/src/routes/(auth)/beneficiaire/+page.svelte
@@ -13,26 +13,11 @@
 		id: data.user.beneficiaryId,
 	});
 	query(getNotebookResult);
-
-	//let node;
-	//onMount(() => {
-	//	let app = Elm.BeneficiaryApp.Main.init({
-	//		node,
-	//		flags: {
-	//			beneficiaryId: $connectedUser.beneficiaryId,
-	//		},
-	//	});
-	//	app.ports.sendMessage.subscribe((message) => {
-	//		app.ports.messageReceiver.send('Msg from Svelte' + message);
-	//	});
-	//});
 </script>
 
 <svelte:head>
 	<title>Accueil Bénéficiaire - Carnet de bord</title>
 </svelte:head>
-
-<!--<div bind:this={node} />-->
 
 <LoaderIndicator result={getNotebookResult}>
 	<NotebookView notebook={getNotebookResult.data.notebook[0]} />

--- a/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
+++ b/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
@@ -23,6 +23,10 @@ fragment notebookFragment on notebook {
   contractEndDate
   educationLevel
   lastJobEndedAt
+  appointments {
+    date
+    memberAccountId
+  }
   professionalProjects {
     id
     rome_code {
@@ -105,7 +109,9 @@ fragment notebookFragment on notebook {
     memberType
     lastModifiedAt
     lastVisitedAt
+    createdAt
     account {
+      id
       type
       orientation_manager {
         id

--- a/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
+++ b/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
@@ -23,7 +23,11 @@ fragment notebookFragment on notebook {
   contractEndDate
   educationLevel
   lastJobEndedAt
-  appointments {
+  appointments(
+    where: { notebookId: { _eq: $id }, deleted_at: { _is_null: true } }
+    distinct_on: memberAccountId
+    order_by: [{ memberAccountId: asc }, { date: desc }]
+  ) {
     date
     memberAccountId
   }

--- a/app/src/routes/(auth)/structures/[uuid]/carnets/[notebook_id]/+page.svelte
+++ b/app/src/routes/(auth)/structures/[uuid]/carnets/[notebook_id]/+page.svelte
@@ -7,9 +7,13 @@
 
 	export let data: PageData;
 
-	const getNotebookResult = operationStore(GetNotebookByIdDocument, {
-		id: data.notebookId,
-	});
+	const getNotebookResult = operationStore(
+		GetNotebookByIdDocument,
+		{
+			id: data.notebookId,
+		},
+		{ additionalTypenames: ['notebook_appointment'] }
+	);
 	query(getNotebookResult);
 </script>
 

--- a/e2e/features/structureAdmin/carnet/appointments.feature
+++ b/e2e/features/structureAdmin/carnet/appointments.feature
@@ -35,3 +35,48 @@ Fonctionnalité: Gestion des RDV bénéficiaires
 		Alors je ne vois pas "Valider"
 		Alors je vois "15/05/2020 à 15:45"
 		Alors je vois "Présent"
+
+
+	Scénario: Derniers RDV dans Groupe de suivi pour un admin de structure
+		Soit un "administrateur de structures" authentifié avec l'email "jacques.celaire@livry-gargan.fr"
+		Quand je clique sur "Centre Communal d'action social Livry-Gargan"
+		Alors je clique sur "Bénéficiaires non accompagnés"
+		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
+		Quand je clique sur "Voir le carnet de Myrna Henderson"
+		Quand je vais sur l'onglet suivant
+		Alors j'attends que le texte "Myrna Henderson" apparaisse
+		Quand je clique sur la ligne du tableau contenant le texte "Giulia Diaby"
+		Quand je clique sur "Ajouter un rendez-vous"
+		Quand je renseigne "15/05/2020" dans le champ "Date de rendez-vous"
+		Quand je sélectionne l'option "15" dans la liste "Heures"
+		Quand je sélectionne l'option "45" dans la liste "Minutes"
+		Quand je sélectionne l'option "Présent" dans la liste "Statut du rendez-vous"
+		Quand je clique sur "Valider"
+		Quand je clique sur "Fermer"
+		Alors je ne vois pas "Membre du groupe de suivi"
+		Alors je vois "15/05/2020 à 15:45"
+
+
+	Scénario: Suppression d'un RDV par un admin de structure
+		Soit un "administrateur de structures" authentifié avec l'email "jacques.celaire@livry-gargan.fr"
+		Quand je clique sur "Centre Communal d'action social Livry-Gargan"
+		Alors je clique sur "Bénéficiaires non accompagnés"
+		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
+		Quand je clique sur "Voir le carnet de Myrna Henderson"
+		Quand je vais sur l'onglet suivant
+		Alors j'attends que le texte "Myrna Henderson" apparaisse
+		Quand je clique sur la ligne du tableau contenant le texte "Giulia Diaby"
+		Quand je clique sur "Ajouter un rendez-vous"
+		Quand je renseigne "15/05/2020" dans le champ "Date de rendez-vous"
+		Quand je sélectionne l'option "15" dans la liste "Heures"
+		Quand je sélectionne l'option "45" dans la liste "Minutes"
+		Quand je sélectionne l'option "Présent" dans la liste "Statut du rendez-vous"
+		Quand je clique sur "Valider"
+		Quand je clique sur "Modifier"
+		Quand je clique sur "Supprimer"
+		Alors je vois "Vous allez supprimer le rendez-vous du"
+		Alors je vois "15/05/2020 à 15:45"
+		Alors je vois "Veuillez confirmer la suppression."
+		Quand je clique sur le bouton "Supprimer"
+		Alors je ne vois pas "15/05/2020 à 15:45"
+		Alors je ne vois pas "Présent"

--- a/e2e/features/structureAdmin/carnet/appointments.feature
+++ b/e2e/features/structureAdmin/carnet/appointments.feature
@@ -1,0 +1,37 @@
+#language: fr
+
+Fonctionnalité: Gestion des RDV bénéficiaires
+	En tant qu'admin de structure
+	Je veux consulter et gérer les RDV de mes bénéficiaires
+
+	Scénario: Aucun rendez-vous pour un admin de structure
+		Soit un "administrateur de structures" authentifié avec l'email "jacques.celaire@livry-gargan.fr"
+		Quand je clique sur "Centre Communal d'action social Livry-Gargan"
+		Alors je clique sur "Bénéficiaires non accompagnés"
+		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
+		Quand je clique sur "Voir le carnet de Myrna Henderson"
+		Quand je vais sur l'onglet suivant
+		Alors j'attends que le texte "Myrna Henderson" apparaisse
+		Quand je clique sur la ligne du tableau contenant le texte "Giulia Diaby"
+		Alors je vois "Aucun rendez-vous n'a été pris avec cet accompagnateur." dans le tableau "Liste des rendez-vous"
+
+
+
+	Scénario: Ajout de RDV par un admin de structure
+		Soit un "administrateur de structures" authentifié avec l'email "jacques.celaire@livry-gargan.fr"
+		Quand je clique sur "Centre Communal d'action social Livry-Gargan"
+		Alors je clique sur "Bénéficiaires non accompagnés"
+		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
+		Quand je clique sur "Voir le carnet de Myrna Henderson"
+		Quand je vais sur l'onglet suivant
+		Alors j'attends que le texte "Myrna Henderson" apparaisse
+		Quand je clique sur la ligne du tableau contenant le texte "Giulia Diaby"
+		Quand je clique sur "Ajouter un rendez-vous"
+		Quand je renseigne "15/05/2020" dans le champ "Date de rendez-vous"
+		Quand je sélectionne l'option "15" dans la liste "Heures"
+		Quand je sélectionne l'option "45" dans la liste "Minutes"
+		Quand je sélectionne l'option "Présent" dans la liste "Statut du rendez-vous"
+		Quand je clique sur "Valider"
+		Alors je ne vois pas "Valider"
+		Alors je vois "15/05/2020 à 15:45"
+		Alors je vois "Présent"

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_appointment.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_appointment.yaml
@@ -22,6 +22,30 @@ object_relationships:
     using:
       foreign_key_constraint_on: notebook_id
 insert_permissions:
+  - role: admin_structure
+    permission:
+      check:
+        notebook:
+          members:
+            _and:
+              - active:
+                  _eq: true
+              - account:
+                  professional:
+                    structure:
+                      admins:
+                        admin_structure_id:
+                          _eq: X-Hasura-AdminStructure-Id
+      columns:
+        - id
+        - notebook_id
+        - account_id
+        - date
+        - status
+        - created_at
+        - updated_at
+        - deleted_by
+        - deleted_at
   - role: orientation_manager
     permission:
       check:
@@ -66,6 +90,30 @@ select_permissions:
         - id
         - notebook_id
       filter: {}
+  - role: admin_structure
+    permission:
+      columns:
+        - status
+        - date
+        - created_at
+        - deleted_at
+        - updated_at
+        - account_id
+        - deleted_by
+        - id
+        - notebook_id
+      filter:
+        notebook:
+          members:
+            _and:
+              - active:
+                  _eq: true
+              - account:
+                  professional:
+                    structure:
+                      admins:
+                        admin_structure_id:
+                          _eq: X-Hasura-AdminStructure-Id
   - role: orientation_manager
     permission:
       columns:

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_appointment.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_appointment.yaml
@@ -37,15 +37,10 @@ insert_permissions:
                         admin_structure_id:
                           _eq: X-Hasura-AdminStructure-Id
       columns:
-        - id
-        - notebook_id
         - account_id
         - date
+        - notebook_id
         - status
-        - created_at
-        - updated_at
-        - deleted_by
-        - deleted_at
   - role: orientation_manager
     permission:
       check:
@@ -148,6 +143,26 @@ select_permissions:
               - active:
                   _eq: true
 update_permissions:
+  - role: admin_structure
+    permission:
+      columns:
+        - date
+        - deleted_at
+        - deleted_by
+        - status
+      filter:
+        notebook:
+          members:
+            _and:
+              - active:
+                  _eq: true
+              - account:
+                  professional:
+                    structure:
+                      admins:
+                        admin_structure_id:
+                          _eq: X-Hasura-AdminStructure-Id
+      check: null
   - role: orientation_manager
     permission:
       columns:

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_appointment.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_appointment.yaml
@@ -24,23 +24,17 @@ object_relationships:
 insert_permissions:
   - role: admin_structure
     permission:
-      check:
-        notebook:
-          members:
-            _and:
-              - active:
-                  _eq: true
-              - account:
-                  professional:
-                    structure:
-                      admins:
-                        admin_structure_id:
-                          _eq: X-Hasura-AdminStructure-Id
+      check: {}
       columns:
         - account_id
+        - created_at
         - date
+        - deleted_at
+        - deleted_by
+        - id
         - notebook_id
         - status
+        - updated_at
   - role: orientation_manager
     permission:
       check:
@@ -97,18 +91,7 @@ select_permissions:
         - deleted_by
         - id
         - notebook_id
-      filter:
-        notebook:
-          members:
-            _and:
-              - active:
-                  _eq: true
-              - account:
-                  professional:
-                    structure:
-                      admins:
-                        admin_structure_id:
-                          _eq: X-Hasura-AdminStructure-Id
+      filter: {}
   - role: orientation_manager
     permission:
       columns:
@@ -150,18 +133,7 @@ update_permissions:
         - deleted_at
         - deleted_by
         - status
-      filter:
-        notebook:
-          members:
-            _and:
-              - active:
-                  _eq: true
-              - account:
-                  professional:
-                    structure:
-                      admins:
-                        admin_structure_id:
-                          _eq: X-Hasura-AdminStructure-Id
+      filter: {}
       check: null
   - role: orientation_manager
     permission:

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_appointment.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_appointment.yaml
@@ -110,6 +110,23 @@ select_permissions:
             account:
               id:
                 _eq: X-Hasura-User-Id
+  - role: manager
+    permission:
+      columns:
+        - id
+        - notebook_id
+        - account_id
+        - date
+        - status
+        - created_at
+        - updated_at
+        - deleted_by
+        - deleted_at
+      filter:
+        notebook:
+          beneficiary:
+            deployment_id:
+              _eq: X-Hasura-Deployment-Id
   - role: orientation_manager
     permission:
       columns:

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_appointment.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_appointment.yaml
@@ -92,6 +92,24 @@ select_permissions:
         - id
         - notebook_id
       filter: {}
+  - role: beneficiary
+    permission:
+      columns:
+        - status
+        - date
+        - created_at
+        - deleted_at
+        - updated_at
+        - account_id
+        - deleted_by
+        - id
+        - notebook_id
+      filter:
+        notebook:
+          beneficiary:
+            account:
+              id:
+                _eq: X-Hasura-User-Id
   - role: orientation_manager
     permission:
       columns:


### PR DESCRIPTION
## :wrench: Problème

En tant que gestionnaire de structure, en particulier lorsque j'ai un profil de secrétariat, j'ai besoin de pouvoir modifier certaines informations suite à une action de ma part (vérification manuelle, convocation, ....) ou un contact avec l'usager et je dois notamment pourvoir saisir un rendez-vous et actualiser l'état de présence pour un professionnel de ma structure.

Fixes #1766 

## :cake: Solution

On réutilise le composant d'édition des RDV des professionnels pour les admins de structure.


## :desert_island: Comment tester

Se connecter avec un compte « Admin de structure », `jacques.celaire` par exemple. Cliquer sur « Centre Communal d'action social Livry-Gargan », puis sur « 1 Bénéficiaire accompagné », puis sur « Voir le carnet » de Sophie Tifour. S'assurer que la gestion des RDV est bien ce qui est attendu.

![Screenshot from 2023-06-05 15-50-43](https://github.com/gip-inclusion/carnet-de-bord/assets/154904/831cb5ad-14cb-4bca-9aa1-e3236a724e97)
