### PR TITLE
fix: suppression de l'icone pour vider le champ dans chrome

### DIFF
--- a/app/src/app.css
+++ b/app/src/app.css
@@ -17,3 +17,9 @@
 	--background-active-blue-france-active: var(--vert-cdb-active);
 	--border-plain-blue-france: var(--vert-cdb);
 }
+
+
+/* Remove chrome clear icon */
+input[type='search']::-webkit-search-cancel-button {
+	-webkit-appearance: none;
+}

--- a/app/src/lib/ui/base/SearchBar.svelte
+++ b/app/src/lib/ui/base/SearchBar.svelte
@@ -38,10 +38,3 @@
 		</button>
 	</div>
 </form>
-
-<style>
-	/* Remove chrome clear icon */
-	input[type='search']::-webkit-search-cancel-button {
-		-webkit-appearance: none;
-	}
-</style>

--- a/app/src/lib/ui/base/SearchBar.svelte
+++ b/app/src/lib/ui/base/SearchBar.svelte
@@ -38,3 +38,10 @@
 		</button>
 	</div>
 </form>
+
+<style>
+	/* Remove chrome clear icon */
+	input[type='search']::-webkit-search-cancel-button {
+		-webkit-appearance: none;
+	}
+</style>


### PR DESCRIPTION
fix: #1765

## :wrench: Problème

Lorsqu'on saisie du texte dans une barre de recherche, alors une icône "supprimer" (croix) de couleur bleu est affichée dans les navigateur basé sur chromium pour effacer la saisie de texte.

## :cake: Solution

On surcharge la classe spécifique au navigateur chromium pour supprimer le style du navigateur


## :rotating_light:  Points d'attention / Remarques

Ce comportement n'est pas présent dans Firefox

## :desert_island: Comment tester

Se connecter en tant que `pierre.chevalier`
se rendre du le carnet de sophi tifour
Saisir du texte dans le filtre des évenements dans l'historique de parcours