### PR TITLE
feat: Prise en compte de l'augmentation du montant du SMIC horaire.

### DIFF
--- a/app/elm/DiagnosticEdit/Main.elm
+++ b/app/elm/DiagnosticEdit/Main.elm
@@ -111,7 +111,7 @@ professionalProjetsMaxCount =
 
 smicHourlyValue : Decimal
 smicHourlyValue =
-    Decimal.fromIntWithExponent 1127 -2
+    Decimal.fromIntWithExponent 1152 -2
 
 
 inputIsLowerThanSmic : String -> Bool

--- a/hasura/migrations/carnet_de_bord/1685994546326_smic-hourly-rate-raise/down.sql
+++ b/hasura/migrations/carnet_de_bord/1685994546326_smic-hourly-rate-raise/down.sql
@@ -1,0 +1,2 @@
+-- This migration is non reversible, we cannot guess what was the hourly_rate
+-- for impacted rows.

--- a/hasura/migrations/carnet_de_bord/1685994546326_smic-hourly-rate-raise/up.sql
+++ b/hasura/migrations/carnet_de_bord/1685994546326_smic-hourly-rate-raise/up.sql
@@ -1,0 +1,1 @@
+UPDATE professional_project SET hourly_rate=1152 WHERE hourly_rate < 1152;


### PR DESCRIPTION
## :wrench: Problème

Le SMIC a été revalorisé au 1er mai 2023, passant de 11,27 € à 11,52 €.
Il faut donc prendre en compte cette valeur lors de l'affichage de l'avertissement en cas de saisie d'un salaire horaire inférieur au SMIC horaire dans la création / modification d'un projet progessionel.

## :cake: Solution

On modifie la seule occurence de la valeur 1127 en 1152 dans la partie front (ELM) qui conditionne l'affichage de l'avertissement.

On migre les données pour modifier toutes les valeurs inférieures à la nouvelle valeur du SMIC horaire (11,52 €) pour correspondre à cette nouvelle valeur.

## :rotating_light:  Points d'attention / Remarques

Attention, aujourd'hui on n'empêche pas d'enregistrer une valeur inférieure au SMIC horaire.
On ne fait qu'afficher un avertissement si la valeur est inférieure au SMIC horaire.
Par chance, nous n'avons aucun projet professionnels dont le salaire horaire renseigné est inférieur à la valeur du SMIC horaire.

## :desert_island: Comment tester

Modifier un projet professionnel.
Saisir un salaire horaire inférieur à 11,52 €.
Vérifier que l'avertissement est affiché.
Saisir un salaire horaire égal ou supérieur à 11,52 €.
Vérifier que l'avertissement n'est pas affiché.


fix #1784
