### PR TITLE
fix: Remplacer la couleur bleu sur la popup des cookies par le vert CDB.

### DIFF
--- a/app/src/dsfr-theme-tac.css
+++ b/app/src/dsfr-theme-tac.css
@@ -202,7 +202,7 @@ button#tarteaucitronPrivacyUrl {
 }
 
 #tarteaucitronIcon #tarteaucitronManager {
-  background: var(--bf500);
+  background: var(--vert-cdb);
   color: var(--w);
   padding: 0.5rem 1.5rem;
   line-height: 1.5rem;
@@ -312,7 +312,7 @@ body #tarteaucitronRoot div#tarteaucitronAlertBig {
 #tarteaucitronRoot #tarteaucitronCloseCross {
   position: relative;
   background-color: var(--t-plain);
-  color: var(--bf500);
+  color: var(--vert-cdb);
   padding: .25rem .75rem;
   display: block;
   line-height: 1.5rem;
@@ -353,7 +353,7 @@ body #tarteaucitronRoot div#tarteaucitronAlertBig {
 #tarteaucitronRoot #tarteaucitronAlertBig .tarteaucitronCTAButton {
   font-size: inherit;
   cursor: pointer;
-  background: var(--bf500);
+  background: var(--vert-cdb);
   color: var(--w);
   padding: 0.5rem 1.5rem;
   line-height: 1.5rem;
@@ -364,8 +364,8 @@ body #tarteaucitronRoot div#tarteaucitronAlertBig {
 
 #tarteaucitronRoot #tarteaucitronAlertBig #tarteaucitronCloseAlert {
   background-color: var(--t-plain);
-  color: var(--bf500);
-  box-shadow: inset 0 0 0 1px var(--bf500);
+  color: var(--vert-cdb);
+  box-shadow: inset 0 0 0 1px var(--vert-cdb);
   order: 5;
   margin-bottom: 0;
 }
@@ -455,7 +455,7 @@ body #tarteaucitronRoot div#tarteaucitronAlertBig {
 /*** Bouton pour fermer le gestionnaire ***/
 #tarteaucitronRoot #tarteaucitronClosePanel {
   background: var(--tplain);
-  color: var(--bf500);
+  color: var(--vert-cdb);
   padding: .25rem .75rem;
   line-height: 1.5rem;
   min-height: 2rem;
@@ -660,7 +660,7 @@ body #tarteaucitronRoot div#tarteaucitronAlertBig {
 
 #tarteaucitronRoot .tarteaucitronAllow.tarteaucitronIsSelected::before,
 #tarteaucitronRoot .tarteaucitronDeny.tarteaucitronIsSelected::before {
-  border: 1px solid var(--bf500);
+  border: 1px solid var(--vert-cdb);
 }
 
 #tarteaucitronRoot .tarteaucitronAllow:not(.tarteaucitronCTAButton)::before,
@@ -679,7 +679,7 @@ body #tarteaucitronRoot div#tarteaucitronAlertBig {
 #tarteaucitronRoot .tarteaucitronDeny:not(.tarteaucitronCTAButton)::after {
   content: "";
   display: block;
-  background: var(--bf500);
+  background: var(--vert-cdb);
   border-radius: 50%;
   width: .75rem;
   height: .75rem;
@@ -885,7 +885,7 @@ ul[style="display: block;"] .tarteaucitronLine{
   position: relative;
   font-size: inherit;
   cursor: pointer;
-  background: var(--bf500);
+  background: var(--vert-cdb);
   color: var(--w);
   padding: 0.5rem 1.5rem!important;
   line-height: 1.5rem;
@@ -1013,7 +1013,7 @@ ul[style="display: block;"] .tarteaucitronLine{
 /*** Bouton pour fermer le gestionnaire ***/
 #tarteaucitronAlertSmall #tarteaucitronCookiesListContainer #tarteaucitronClosePanelCookie {
   background: var(--tplain);
-  color: var(--bf500);
+  color: var(--vert-cdb);
   padding: .25rem .75rem;
   line-height: 1.5rem;
   min-height: 2rem;
@@ -1049,7 +1049,7 @@ ul[style="display: block;"] .tarteaucitronLine{
   font-size: 0.875rem;
   line-height: 1.5rem;
   min-height: 2rem;
-  background-color: var(--bf500);
+  background-color: var(--vert-cdb);
   color: var(--w-bf500);
   flex-shrink: 0;
   margin-right: .25rem;
@@ -1112,7 +1112,7 @@ ul[style="display: block;"] .tarteaucitronLine{
   border: none;
   font-size: inherit;
   cursor: pointer;
-  background: var(--bf500);
+  background: var(--vert-cdb);
   color: var(--w);
   padding: 0.5rem 1.5rem;
   line-height: 1.5rem;


### PR DESCRIPTION
## :wrench: Problème

La popup de validation des Cookies comporte plusieurs composants de couleur bleu qui ne respectent pas la couleur principale de la nouvelle charte CDB.

## :cake: Solution

On remplace l'usage de la couleur bleu france (`--bf500`) dans la feuille de style de tarteaucitron par la couleur principale du thème Carnet de Bord (`--vert-cdb`).


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Se rendre sur la review app.
Constater que les couleurs de la popup des cookies est aux couleurs de Carnet de Bord.


fix #1802
