### PR TITLE
chore: Ajout d'un precommit hook pour éviter de commiter sur la branche principale.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,9 @@ jobs:
           npm run sync --prefix app
           npm ci --prefix e2e
           pip install pre-commit
+
       - name: Run linting
-        # TODO: precommit does not run svelte-check
-        run: pre-commit run --all-files
+        run: SKIP=no-commit-to-branch pre-commit run --all-files
 
   ##############################################################################
   ## Python backend tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,9 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
         exclude: /__snapshots__/
+      - id: no-commit-to-branch
+        name: "don't commit to main"
+        args: [--branch, main]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.257
@@ -31,13 +34,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: no-commit-on-main-branch
-        name: no direct commit on main branch
-        language: system
-        always_run: true
-        entry: |
-          ./scripts/no-commit-on-main-branch.sh
-
       - id: app-prettier
         name: run prettier (app)
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: no-commit-on-main-branch
+        name: no direct commit on main branch
+        language: system
+        always_run: true
+        entry: |
+          ./scripts/no-commit-on-main-branch.sh
+
       - id: app-prettier
         name: run prettier (app)
         language: system

--- a/scripts/no-commit-on-main-branch.sh
+++ b/scripts/no-commit-on-main-branch.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-branch=$(git rev-parse --abbrev-ref HEAD)
-
-if [ $branch = 'main' ] && [ ! $CI  ]; then
-	echo "Committing on main is forbidden."
-	exit 1
-fi

--- a/scripts/no-commit-on-main-branch.sh
+++ b/scripts/no-commit-on-main-branch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+if [ $branch = 'main' ] && [ ! $CI  ]; then
+	echo "Committing on main is forbidden."
+	exit 1
+fi


### PR DESCRIPTION
## :wrench: Problème

Malgré le réglage de protection de la branche `main` il est possible de commiter sur celle-ci car tous les dev ont un rôle offrant suffisamment de privilèges pour le faire.

## :cake: Solution

On active le hook de `pre-commit` nommé `no-commit-to-branch` qui contrôle qu'aucun commit n'est fait sur une branche nommée `main`.

On désactive explicitement ce hook avec la variable d'environnement `SKIP=no-commit-to-branch` lors de l'exécution de `pre-commit` dans le workflow `test.yml`, qui peut s'exécuter sur `main` mais ne fait pas de commit.

Noter que le worfklow `release.yml` effectue un commit de release sur `main` mais `pre-commit` ne s'exécute pas dans ce contexte.

## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Essayer de commiter sur `main`: pour tester la configuration de cette PR avant qu'elle soit présente sur `main`, on peut temporairement faire pointer sa branche `main` locale dessus avec :

```
$ git checkout -B main origin/chore/no-commit-on-main
```

Puis faire une modification quelconque et tenter un commit. Confirmer que le commit est rejeté.

```
$ git commit -m "chore: test"
check for case conflicts.................................................Passed
check yaml...........................................(no files to check)Skipped
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
don't commit to main.....................................................Failed
- hook id: no-commit-to-branch
- exit code: 1
ruff.................................................(no files to check)Skipped
black................................................(no files to check)Skipped
run prettier (app)...................................(no files to check)Skipped
run svelte-check (app)...............................(no files to check)Skipped
run eslint (app).....................................(no files to check)Skipped
run elm make on all Main.elm.........................(no files to check)Skipped
run elm-review (app).................................(no files to check)Skipped
run prettier (e2e)...................................(no files to check)Skipped
run eslint (e2e).....................................(no files to check)Skipped
ensure hasura version consistency........................................Passed
```

Vérifier que l'exécution de `pre-commit` est possible sans erreur sur `main` en désactivant le test `no-commit-on-branch`, comme on le fait dans le workflow `test.yaml` :

```
$ SKIP=no-commit-to-branch pre-commit run --all-files
check for case conflicts.................................................Passed
check yaml...............................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
don't commit to main....................................................Skipped
ruff.....................................................................Passed
black....................................................................Passed
run prettier (app).......................................................Passed
run svelte-check (app)...................................................
Passed
run eslint (app).........................................................Passed
run elm make on all Main.elm.............................................Passed
run elm-review (app).....................................................Passed
run prettier (e2e).......................................................Passed
run eslint (e2e).........................................................Passed
ensure hasura version consistency........................................Passed
```

Enfin, restaurer la branche `main` locale :

```
$ git checkout -B main origin/main
```
