### PR TITLE
fix: déplacer la popup de consentement aux cookies vers la droite

### DIFF
--- a/app/src/dsfr-theme-tac.css
+++ b/app/src/dsfr-theme-tac.css
@@ -243,7 +243,7 @@ body #tarteaucitronRoot div#tarteaucitronAlertBig {
   flex-wrap: wrap;
   justify-content: flex-end;
   bottom: 0;
-  left: 0;
+  right: 0;
   width: 100%;
   padding: 1rem;
   color: var(--g700);
@@ -270,7 +270,7 @@ body #tarteaucitronRoot div#tarteaucitronAlertBig {
    #tarteaucitronRoot #tarteaucitronAlertBig {
     width: 40rem !important;
     bottom: 2.5rem !important;
-    left: 2.5rem !important;
+    right: 2.5rem !important;
     padding: 2rem !important;
     margin: auto;
     top: auto !important;

--- a/app/static/tarteaucitron.init.js
+++ b/app/static/tarteaucitron.init.js
@@ -39,7 +39,6 @@ tarteaucitron.init({
 	groupServices: false,
 });
 
-tarteaucitron.lang.alertBigPrivacy = 'toto';
 tarteaucitronForceLanguage = 'fr';
 
 tarteaucitron.services.matomocustom = {

--- a/app/static/tarteaucitron.init.js
+++ b/app/static/tarteaucitron.init.js
@@ -1,7 +1,5 @@
 /* global tarteaucitron */
 
-tarteaucitronForceLanguage = 'fr';
-
 tarteaucitron.init({
 	mandatory: true /* Show a message about mandatory cookies */,
 	/* General */
@@ -40,6 +38,9 @@ tarteaucitron.init({
 		'BottomLeft' /* Position du Bouton sticky BottomRight, BottomLeft, TopRight and TopLeft */,
 	groupServices: false,
 });
+
+tarteaucitron.lang.alertBigPrivacy = 'toto';
+tarteaucitronForceLanguage = 'fr';
 
 tarteaucitron.services.matomocustom = {
 	key: 'matomocustom',

--- a/app/static/tarteaucitron.js-1.11.0/lang/tarteaucitron.fr.js
+++ b/app/static/tarteaucitron.js-1.11.0/lang/tarteaucitron.fr.js
@@ -1,86 +1,96 @@
 /*global tarteaucitron */
 tarteaucitron.lang = {
+	middleBarHead: '☝ 🍪',
+	adblock:
+		'Bonjour! Ce site joue la transparence et vous donne le choix des services tiers à activer.',
+	adblock_call: 'Merci de désactiver votre adblocker pour commencer la personnalisation.',
+	reload: 'Recharger la page',
 
-    "middleBarHead": "☝ 🍪",
-    "adblock": "Bonjour! Ce site joue la transparence et vous donne le choix des services tiers à activer.",
-    "adblock_call": "Merci de désactiver votre adblocker pour commencer la personnalisation.",
-    "reload": "Recharger la page",
+	alertBigScroll: 'En continuant de défiler,',
+	alertBigClick: 'En poursuivant votre navigation,',
+	alertBig: "vous acceptez l'utilisation de services tiers pouvant installer des cookies",
 
-    "alertBigScroll": "En continuant de défiler,",
-    "alertBigClick": "En poursuivant votre navigation,",
-    "alertBig": "vous acceptez l'utilisation de services tiers pouvant installer des cookies",
+	alertBigPrivacy:
+		"Ce site utilise des cookies pour offrir une expérience optimale de support et vous donne le contrôle si vous souhaitez l'activer",
+	alertSmall: 'Gestion des services',
+	acceptAll: 'Tout accepter',
+	personalize: 'Personnaliser',
+	close: 'Fermer',
 
-    "alertBigPrivacy": "Ce site utilise des cookies et vous donne le contrôle sur ceux que vous souhaitez activer",
-    "alertSmall": "Gestion des services",
-    "acceptAll": "Tout accepter",
-    "personalize": "Personnaliser",
-    "close": "Fermer",
+	privacyUrl: 'Politique de confidentialité',
 
-    "privacyUrl": "Politique de confidentialité",
+	all: 'Préférences pour tous les services',
 
-    "all": "Préférences pour tous les services",
+	info: 'Protection de votre vie privée',
+	disclaimer:
+		"En autorisant ces services tiers, vous acceptez le dépôt et la lecture de cookies et l'utilisation de technologies de suivi nécessaires à leur bon fonctionnement.",
+	allow: 'Autoriser',
+	deny: 'Interdire',
+	noCookie: 'Ce service ne dépose aucun cookie.',
+	useCookie: 'Ce service peut déposer',
+	useCookieCurrent: 'Ce service a déposé',
+	useNoCookie: "Ce service n'a déposé aucun cookie.",
+	more: 'En savoir plus',
+	source: 'Voir le site officiel',
+	credit: 'Gestion des cookies par tarteaucitron.js',
+	noServices: "Ce site n'utilise aucun cookie nécessitant votre consentement.",
 
-    "info": "Protection de votre vie privée",
-    "disclaimer": "En autorisant ces services tiers, vous acceptez le dépôt et la lecture de cookies et l'utilisation de technologies de suivi nécessaires à leur bon fonctionnement.",
-    "allow": "Autoriser",
-    "deny": "Interdire",
-    "noCookie": "Ce service ne dépose aucun cookie.",
-    "useCookie": "Ce service peut déposer",
-    "useCookieCurrent": "Ce service a déposé",
-    "useNoCookie": "Ce service n'a déposé aucun cookie.",
-    "more": "En savoir plus",
-    "source": "Voir le site officiel",
-    "credit": "Gestion des cookies par tarteaucitron.js",
-    "noServices": "Ce site n'utilise aucun cookie nécessitant votre consentement.",
+	toggleInfoBox: 'Afficher/masquer les informations sur le stockage des cookies',
+	title: 'Panneau de gestion des cookies',
+	cookieDetail: 'Détail des cookies',
+	ourSite: 'sur notre site',
+	modalWindow: '(fenêtre modale)',
+	newWindow: '(nouvelle fenêtre)',
+	allowAll: 'Tout accepter',
+	denyAll: 'Tout refuser',
 
-    "toggleInfoBox": "Afficher/masquer les informations sur le stockage des cookies",
-    "title": "Panneau de gestion des cookies",
-    "cookieDetail": "Détail des cookies",
-    "ourSite": "sur notre site",
-    "modalWindow": "(fenêtre modale)",
-    "newWindow": "(nouvelle fenêtre)",
-    "allowAll": "Tout accepter",
-    "denyAll": "Tout refuser",
+	icon: 'Cookies',
 
-    "icon": "Cookies",
+	fallback: 'est désactivé.',
+	allowed: 'autorisé',
+	disallowed: 'interdit',
 
-    "fallback": "est désactivé.",
-    "allowed": "autorisé",
-    "disallowed": "interdit",
+	ads: {
+		title: 'Régies publicitaires',
+		details:
+			'Les régies publicitaires permettent de générer des revenus en commercialisant les espaces publicitaires du site.',
+	},
+	analytic: {
+		title: "Mesure d'audience",
+		details:
+			"Les services de mesure d'audience permettent de générer des statistiques de fréquentation utiles à l'amélioration du site.",
+	},
+	social: {
+		title: 'Réseaux sociaux',
+		details:
+			"Les réseaux sociaux permettent d'améliorer la convivialité du site et aident à sa promotion via les partages.",
+	},
+	video: {
+		title: 'Vidéos',
+		details:
+			"Les services de partage de vidéo permettent d'enrichir le site de contenu multimédia et augmentent sa visibilité.",
+	},
+	comment: {
+		title: 'Commentaires',
+		details:
+			'Les gestionnaires de commentaires facilitent le dépôt de vos commentaires et luttent contre le spam.',
+	},
+	support: {
+		title: 'Support',
+		details:
+			"Les services de support vous permettent d'entrer en contact avec l'équipe du site et d'aider à son amélioration.",
+	},
+	api: {
+		title: 'APIs',
+		details:
+			'Les APIs permettent de charger des scripts : géolocalisation, moteurs de recherche, traductions, ...',
+	},
+	other: {
+		title: 'Autre',
+		details: 'Services visant à afficher du contenu web.',
+	},
 
-    "ads": {
-        "title": "Régies publicitaires",
-        "details": "Les régies publicitaires permettent de générer des revenus en commercialisant les espaces publicitaires du site."
-    },
-    "analytic": {
-        "title": "Mesure d'audience",
-        "details": "Les services de mesure d'audience permettent de générer des statistiques de fréquentation utiles à l'amélioration du site."
-    },
-    "social": {
-        "title": "Réseaux sociaux",
-        "details": "Les réseaux sociaux permettent d'améliorer la convivialité du site et aident à sa promotion via les partages."
-    },
-    "video": {
-        "title": "Vidéos",
-        "details": "Les services de partage de vidéo permettent d'enrichir le site de contenu multimédia et augmentent sa visibilité."
-    },
-    "comment": {
-        "title": "Commentaires",
-        "details": "Les gestionnaires de commentaires facilitent le dépôt de vos commentaires et luttent contre le spam."
-    },
-    "support": {
-        "title": "Support",
-        "details": "Les services de support vous permettent d'entrer en contact avec l'équipe du site et d'aider à son amélioration."
-    },
-    "api": {
-        "title": "APIs",
-        "details": "Les APIs permettent de charger des scripts : géolocalisation, moteurs de recherche, traductions, ..."
-    },
-    "other": {
-        "title": "Autre",
-        "details": "Services visant à afficher du contenu web."
-    },
-
-    "mandatoryTitle": "Cookies obligatoires",
-    "mandatoryText": "Ce site utilise des cookies nécessaires à son bon fonctionnement. Ils ne peuvent pas être désactivés."
+	mandatoryTitle: 'Cookies obligatoires',
+	mandatoryText:
+		'Ce site utilise des cookies nécessaires à son bon fonctionnement. Ils ne peuvent pas être désactivés.',
 };

--- a/e2e/features/home.feature
+++ b/e2e/features/home.feature
@@ -12,14 +12,14 @@ Scénario: Home CdB
 
 Scénario: Demande de consentement
 	Soit un utilisateur sur la page d'accueil
-	Alors je vois "Ce site utilise des cookies et vous donne le contrôle sur ceux que vous souhaitez activer"
+	Alors je vois "Ce site utilise des cookies pour offrir une expérience optimale de support et vous donne le contrôle si vous souhaitez l'activer"
  	Quand je clique sur "Personnaliser"
 	# Pour une raison inconnue, on doit faire une deuxiement click
 	# dans codecept pour que la fenetre s'ouvre.
  	Quand je clique sur "Personnaliser"
 	Alors je vois "Préférences pour tous les services"
 	Alors je clique sur "Tout accepter"
-	Alors je ne vois pas "Ce site utilise des cookies et vous donne le contrôle sur ceux que vous souhaitez activer"
+	Alors je ne vois pas "Ce site utilise des cookies pour offrir une expérience optimale de support et vous donne le contrôle si vous souhaitez l'activer"
 	Soit un "pro" authentifié pour la première fois avec l'email "pierre.chevalier@livry-gargan.fr"
 	Quand je clique sur "Ouvrir le chat"
 	Alors je vois "Comment puis-je vous aider"

--- a/e2e/integration/manager/orientationImport.js
+++ b/e2e/integration/manager/orientationImport.js
@@ -1,8 +1,9 @@
 const { I } = inject();
-const { loginStub, onBoardingSetup } = require('../../step_definitions/fixtures');
+const { loginStub, onBoardingSetup, rejectConsent } = require('../../step_definitions/fixtures');
 const assert = require('assert');
 
 async function importOrientationFile(filename) {
+	rejectConsent();
 	await onBoardingSetup(
 		'administrateur de territoire',
 		'contact+cd93@carnetdebord.inclusion.beta.gouv.fr',

--- a/e2e/step_definitions/fixtures.js
+++ b/e2e/step_definitions/fixtures.js
@@ -85,7 +85,14 @@ async function onBoardingSetup(userType, email, onBoardingDone) {
 		}`
 	);
 }
-
+function rejectConsent() {
+	I.setCookie({
+		domain: 'localhost',
+		name: 'tarteaucitron',
+		path: '/',
+		value: '!matomocustom=false!crispcustom=false',
+	});
+}
 const goToNotebookForLastName = async (lastname) => {
 	const result = await I.sendQuery(
 		`
@@ -105,5 +112,6 @@ module.exports = {
 	goToNotebookForLastName,
 	loginStub,
 	onBoardingSetup,
+	rejectConsent,
 	removeMember,
 };

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -1,4 +1,10 @@
-const { loginStub, onBoardingSetup, goToNotebookForLastName, addMember } = require('./fixtures');
+const {
+	loginStub,
+	onBoardingSetup,
+	goToNotebookForLastName,
+	addMember,
+	rejectConsent,
+} = require('./fixtures');
 const { Alors, Quand, Soit } = require('./fr');
 
 const { I } = inject();
@@ -15,14 +21,7 @@ function plainGoto(url) {
 		await page.goto(`${options.url}${url}`);
 	});
 }
-function rejectConsent() {
-	I.setCookie({
-		domain: 'localhost',
-		name: 'tarteaucitron',
-		path: '/',
-		value: '!matomocustom=false!crispcustom=false',
-	});
-}
+
 Soit('je rafraichis la page', async () => {
 	return I.usePlaywrightTo('reload page', async ({ page }) => {
 		return await page.reload();


### PR DESCRIPTION
## :wrench: Problème

La popup de consentement est positionnée sur la popup du nps

## :cake: Solution

on déplace la popup de consentement à droite

## :rotating_light:  Points d'attention / Remarques

 ras

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
 
se connecter en tant que laure.loge