### PR TITLE
chore(nix): passage de node de 16 à 20

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
             pkg-config
           ];
           packages = with pkgs; [
-            nodejs-16_x
+            nodejs_20
             python311
             pre-commit
             poetry


### PR DESCRIPTION
## :wrench: Problème

Dans nix la version de node était 16, elle est arrivée en fin de vie.

## :cake: Solution

Mise à jour vers la version 20.


## :rotating_light:  Points d'attention / Remarques
RAS

## :desert_island: Comment tester
Dans un shell nix, lancer les tests