### PR TITLE
fix(Makefile): ajout de hasura-console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ test-app: ## Lance les tests de l'app frontend
 # -------------------------------------
 # Other
 # -------------------------------------
+hasura-console: ## Lance la console hasura
+	hasura --project ./hasura/ console
+
 seed-database: ## Ajoute les données de test dans la base de donnée
 	hasura --project ./hasura seed apply --database-name carnet_de_bord
 


### PR DESCRIPTION
## :wrench: Problème

La target `make start` ne démarre pas la console comme elle est censée le faire

## :cake: Solution

Ajouter la target hasura-console dont dépend le script start.sh

## :desert_island: Comment tester
```bash
make start
```