### PR TITLE
feat: Permettre l'ajout d'actions en double

### DIFF
--- a/e2e/features/orientationManager/carnet/focus.feature
+++ b/e2e/features/orientationManager/carnet/focus.feature
@@ -33,7 +33,7 @@ Scénario: Ajout d'une action
 	Alors je vois "Aucune action entreprise pour le moment." dans le volet
 	Quand je clique sur "Sélectionner une action"
 	Quand je renseigne "Atelier cv" dans le champ "Rechercher une action"
-	Quand je clique sur le texte "Atelier CV"
+	Quand je clique sur la suggestion "Atelier CV"
 	Quand je renseigne la date "30/05/2023" dans le champ "Date de début"
 	Quand je clique sur "Ajouter"
 	Alors je vois "Atelier CV" dans le tableau "Actions en cours"
@@ -50,7 +50,7 @@ Scénario: Ajout d'une action en double
 	Alors je vois "Aucune action entreprise pour le moment." dans le volet
 	Quand je clique sur "Sélectionner une action"
 	Quand je renseigne "Atelier cv" dans le champ "Rechercher une action"
-	Quand je clique sur le texte "Atelier CV"
+	Quand je clique sur la suggestion "Atelier CV"
 	Quand je renseigne la date "30/05/2023" dans le champ "Date de début"
 	Quand je clique sur "Ajouter"
 	Alors je vois "Atelier CV" dans le tableau "Actions en cours"
@@ -62,7 +62,7 @@ Scénario: Ajout d'une action en double
 	Alors j'attends que le texte "Action" apparaisse
 	Quand je clique sur "Sélectionner une action"
 	Quand je renseigne "Atelier cv" dans le champ "Rechercher une action"
-	Quand je clique sur le texte "Atelier CV"
+	Quand je clique sur la suggestion "Atelier CV"
 	Quand je renseigne la date "30/05/2023" dans le champ "Date de début"
 	Quand je clique sur "Ajouter"
 	Alors je vois "Atelier CV" dans le tableau "Actions en cours"

--- a/e2e/features/orientationManager/carnet/focus.feature
+++ b/e2e/features/orientationManager/carnet/focus.feature
@@ -39,3 +39,32 @@ Scénario: Ajout d'une action
 	Alors je vois "Atelier CV" dans le tableau "Actions en cours"
 	Quand je ferme le volet
 	Alors je vois "1 action" dans la tuile "Formation"
+
+
+Scénario: Ajout d'une action en double
+	Soit le chargé d'orientation assigné "giulia.diaby@cd93.fr" sur le carnet de "Aguilar"
+	Alors je clique sur "Formation" dans la tuile "Formation"
+	Alors j'attends que le texte "Trouver sa formation" apparaisse
+	Quand je clique sur "Trouver sa formation"
+	Alors j'attends que le texte "Action" apparaisse
+	Alors je vois "Aucune action entreprise pour le moment." dans le volet
+	Quand je clique sur "Sélectionner une action"
+	Quand je renseigne "Atelier cv" dans le champ "Rechercher une action"
+	Quand je clique sur le texte "Atelier CV"
+	Quand je renseigne la date "30/05/2023" dans le champ "Date de début"
+	Quand je clique sur "Ajouter"
+	Alors je vois "Atelier CV" dans le tableau "Actions en cours"
+	Quand je ferme le volet
+	Alors je vois "1 action" dans la tuile "Formation"
+	Alors je clique sur "Formation" dans la tuile "Formation"
+	Alors j'attends que le texte "Trouver sa formation" apparaisse
+	Quand je clique sur "Trouver sa formation"
+	Alors j'attends que le texte "Action" apparaisse
+	Quand je clique sur "Sélectionner une action"
+	Quand je renseigne "Atelier cv" dans le champ "Rechercher une action"
+	Quand je clique sur le texte "Atelier CV"
+	Quand je renseigne la date "30/05/2023" dans le champ "Date de début"
+	Quand je clique sur "Ajouter"
+	Alors je vois "Atelier CV" dans le tableau "Actions en cours"
+	Quand je ferme le volet
+	Alors je vois "2 actions" dans la tuile "Formation"

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -181,6 +181,10 @@ Quand("j'attends que les suggestions apparaissent", () => {
 	I.waitForElement("//ul[@role='listbox']", 3);
 });
 
+Quand('je clique sur la suggestion {string}', (suggestion) => {
+	I.click(locate("//ul[@role='listbox']//li").withText(suggestion));
+});
+
 Quand("j'attends que les résultats de recherche apparaissent", () => {
 	I.waitForElement("[aria-label^='Résultats de recherche']", 10);
 });

--- a/hasura/migrations/carnet_de_bord/1687180495589_alter_table_public_notebook_action_drop_constraint_notebook_action_target_id_action_key/down.sql
+++ b/hasura/migrations/carnet_de_bord/1687180495589_alter_table_public_notebook_action_drop_constraint_notebook_action_target_id_action_key/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."notebook_action" add constraint "notebook_action_action_target_id_key" unique ("action", "target_id");

--- a/hasura/migrations/carnet_de_bord/1687180495589_alter_table_public_notebook_action_drop_constraint_notebook_action_target_id_action_key/up.sql
+++ b/hasura/migrations/carnet_de_bord/1687180495589_alter_table_public_notebook_action_drop_constraint_notebook_action_target_id_action_key/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."notebook_action" drop constraint "notebook_action_target_id_action_key";


### PR DESCRIPTION
## :wrench: Problème

fix #1779 

Le référent a besoin de pouvoir ajouter plusieurs fois une même action comme "Candidater à une offre" car le bénéficiaire peut candidater à plusieurs offres d'emploi et ça permet de tracer le nombre d'offres différentes aux quelles il a répondu. De plus il est déjà arrivé qu'un accompagnateur appel plusieurs fois le 115. Actuellement le système affiche un message d'erreur lorsque l'utilisateur ajoute une action déjà présente dans le tableau des actions.

## :cake: Solution

On enlève la contrainte d'unicité entre le nom de l'action et la target.


## :desert_island: Comment tester

Ajouter des actions avec le même nom et s'assurer que cela fonctionne comme prévu.
