### PR TITLE
feat: initialise la date de début de l'action à la date du jour

### DIFF
--- a/app/elm/Effect.elm
+++ b/app/elm/Effect.elm
@@ -1,41 +1,66 @@
-module Effect exposing (Atomic(..), Effect(..), fromCmd, map, none, perform)
+module Effect exposing (Atomic(..), Effect(..), batch, fromCmd, map, none, now, perform)
+
+import Task
+import Time
 
 
 type Effect msg
     = Atomic (Atomic msg)
+    | Batch (List (Atomic msg))
 
 
 type Atomic msg
     = None
     | FromCmd (Cmd msg)
+    | Now (Time.Posix -> msg)
 
 
 batch : List (Effect a) -> Effect a
 batch effects =
-    --no-idea
+    effects
+        |> List.concatMap
+            (\effect ->
+                case effect of
+                    Atomic atomic ->
+                        [ atomic ]
 
+                    Batch atomics ->
+                        atomics
+            )
+        |> Batch
 
 
 map : (a -> b) -> Effect a -> Effect b
-map f effect =
+map mapFunction effect =
     case effect of
         Atomic atomic ->
-            Atomic <| mapAtomic f atomic
+            Atomic <| mapAtomic mapFunction atomic
+
+        Batch atomics ->
+            atomics |> List.map (mapAtomic mapFunction) |> Batch
 
 
 mapAtomic : (a -> b) -> Atomic a -> Atomic b
-mapAtomic f effect =
+mapAtomic toB effect =
     case effect of
         None ->
             None
 
         FromCmd command ->
-            FromCmd <| Cmd.map f command
+            FromCmd <| Cmd.map toB command
+
+        Now msg ->
+            Now (msg >> toB)
 
 
 none : Effect msg
 none =
     Atomic None
+
+
+now : (Time.Posix -> msg) -> Effect msg
+now =
+    Atomic << Now
 
 
 fromCmd : Cmd msg -> Effect msg
@@ -53,6 +78,9 @@ perform effect =
         Atomic atomic ->
             performAtomic atomic
 
+        Batch atomics ->
+            atomics |> List.map performAtomic |> Cmd.batch
+
 
 performAtomic : Atomic msg -> Cmd msg
 performAtomic effect =
@@ -62,3 +90,6 @@ performAtomic effect =
 
         FromCmd command ->
             command
+
+        Now msg ->
+            Task.perform msg Time.now

--- a/app/elm/Effect.elm
+++ b/app/elm/Effect.elm
@@ -1,4 +1,4 @@
-module Effect exposing (Atomic(..), Effect(..), fromCmd, perform, map, none)
+module Effect exposing (Atomic(..), Effect(..), fromCmd, map, none, perform)
 
 
 type Effect msg
@@ -8,6 +8,12 @@ type Effect msg
 type Atomic msg
     = None
     | FromCmd (Cmd msg)
+
+
+batch : List (Effect a) -> Effect a
+batch effects =
+    --no-idea
+
 
 
 map : (a -> b) -> Effect a -> Effect b

--- a/app/elm/Pages/Pro/Carnet/Action/List/AddForm.elm
+++ b/app/elm/Pages/Pro/Carnet/Action/List/AddForm.elm
@@ -11,6 +11,7 @@ import Html.Events as Evts
 import Pages.Pro.Carnet.Action.List.ActionSelect as ActionSelect
 import Process
 import Task
+import Time
 import UI.SearchSelect.SearchSelect as SearchSelect
 
 
@@ -77,6 +78,7 @@ init { targetId, theme, actionSearchApi } =
       , targetId = targetId
       }
     , actionCommand |> Effect.fromCmd |> Effect.map ActionMsg
+      -- handle batch here
     )
 
 
@@ -90,6 +92,7 @@ type Msg
     | Submit
     | HasSubmitSucceeded Bool
     | DiscardSubmitError
+    | GotTime Time.Posix
 
 
 update : Msg -> Model -> ( Model, Effect Msg )
@@ -144,6 +147,9 @@ update msg model =
 
         DiscardSubmitError ->
             ( { model | submitFailed = False }, Effect.none )
+
+        GotTime time ->
+            ( { model | startingAt = time |> Date.fromPosix Time.utc |> Date.format "YYYY-MM-DD" }, Effect.none )
 
 
 

--- a/app/elm/Pages/Pro/Carnet/Action/List/AddForm.elm
+++ b/app/elm/Pages/Pro/Carnet/Action/List/AddForm.elm
@@ -77,8 +77,10 @@ init { targetId, theme, actionSearchApi } =
       , submitFailed = False
       , targetId = targetId
       }
-    , actionCommand |> Effect.fromCmd |> Effect.map ActionMsg
-      -- handle batch here
+    , Effect.batch
+        [ actionCommand |> Effect.fromCmd |> Effect.map ActionMsg
+        , Effect.now GotTime
+        ]
     )
 
 
@@ -149,7 +151,7 @@ update msg model =
             ( { model | submitFailed = False }, Effect.none )
 
         GotTime time ->
-            ( { model | startingAt = time |> Date.fromPosix Time.utc |> Date.format "YYYY-MM-DD" }, Effect.none )
+            ( { model | startingAt = time |> Date.fromPosix Time.utc |> Date.format "YYYY-MM-dd" }, Effect.none )
 
 
 

--- a/app/elm/Pages/Pro/Carnet/Action/List/AddForm.elm
+++ b/app/elm/Pages/Pro/Carnet/Action/List/AddForm.elm
@@ -136,10 +136,13 @@ update msg model =
                     ( nextSelect, selectCmd ) =
                         ActionSelect.reset model.action
                 in
-                ( { model | startingAt = "", action = nextSelect }
-                , selectCmd
-                    |> Effect.fromCmd
-                    |> Effect.map ActionMsg
+                ( { model | action = nextSelect }
+                , Effect.batch
+                    [ selectCmd
+                        |> Effect.fromCmd
+                        |> Effect.map ActionMsg
+                    , Effect.now GotTime
+                    ]
                 )
 
             else

--- a/app/tests/Pages/Pro/Carnet/Action/List/AddForm_Tests.elm
+++ b/app/tests/Pages/Pro/Carnet/Action/List/AddForm_Tests.elm
@@ -9,11 +9,14 @@ import Extra.Test.SearchSelect
 import Html.Attributes as Attr
 import Pages.Pro.Carnet.Action.List.AddForm as AddForm
 import ProgramTest
+import SimulatedEffect.Cmd
+import SimulatedEffect.Task
+import SimulatedEffect.Time
 import Test exposing (..)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector exposing (text)
-import UI.SearchSelect.SearchSelect as SearchSelect
 import UI.SearchSelect.Fixtures
+import UI.SearchSelect.SearchSelect as SearchSelect
 
 
 suite : Test
@@ -156,8 +159,20 @@ startForm =
         , update = AddForm.update
         , view = AddForm.view
         }
+        |> ProgramTest.withSimulatedEffects simulateEffects
         |> ProgramTest.start
             { targetId = "targetId"
             , actionSearchApi = UI.SearchSelect.Fixtures.fakeSearchApi
             , theme = "a theme"
             }
+        |> ProgramTest.advanceTime 100
+
+
+simulateEffects : Effect AddForm.Msg -> ProgramTest.SimulatedEffect AddForm.Msg
+simulateEffects effect =
+    case effect of
+        Effect.Atomic (Effect.Now msg) ->
+            SimulatedEffect.Time.now |> SimulatedEffect.Task.perform msg
+
+        _ ->
+            SimulatedEffect.Cmd.none

--- a/app/tests/Pages/Pro/Carnet/Action/List/AddForm_Tests.elm
+++ b/app/tests/Pages/Pro/Carnet/Action/List/AddForm_Tests.elm
@@ -75,12 +75,12 @@ suite =
                             [ expectSubmitButton { disabled = False } ]
             , test "resets the form" <|
                 \_ ->
-                    startForm
+                    startFormWithParams { today = "2019-06-06" }
                         |> fillStartingAt "2023-04-11"
                         |> selectAction "an action"
                         |> submit { willSucceed = True }
                         |> Extra.ProgramTest.expectView
-                            [ expectStartingDateToBe ""
+                            [ expectStartingDateToBe "2019-06-06"
                             , expectActionToBe "Sélectionner une action"
                             ]
             , test "does not reset the form when submit failed" <|


### PR DESCRIPTION
## :wrench: Problème

Les utilisateurs doivent sélectionner une date de début à chaque fois qu'ils souhaitent ajouter une action. Si la date est celle du jour, elle doit être sélectionnée et fait perdre du temps aux utilisateurs.

## :cake: Solution

Présélectionner par défaut la date du jour.


## :rotating_light:  Points d'attention / Remarques

Pas de test elm :(

## :desert_island: Comment tester

Ouvrir le carnet de sophie tifour 
Ouvrir l’accordéon d'un objectif 
Valider que la date de l'action est pré-remplie à la date du jour  

fix #1780
