### PR TITLE
ci: ne pas abandonner un déploiement en cours

### DIFF
--- a/.github/workflows/deploy_demo.yml
+++ b/.github/workflows/deploy_demo.yml
@@ -14,6 +14,7 @@ jobs:
     name: Deploy to demo
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         environment: ["preproduction"]
         service: ["app", "backend", "hasura"]

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -5,13 +5,14 @@ on:
 
 concurrency:
   group: deploy_to_prod
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:
     name: Deploy to production
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         environment: ["production"]
         service: ["app", "backend", "hasura"]


### PR DESCRIPTION
## :wrench: Problème

Une fois qu'un déploiement Scalingo est lancé, il ne peut pas être arrêté. Il ne sert donc à rien d'arrêter les tâches de déploiement en cours si un autre déploiement est demandé — au contraire, il vaut mieux attendre la fin du déploiement Scalingo avant d'en demander un autre.

De même, si le déploiement d'un des services échoue, il n'est pas utile d'abandonner les tâches de déploiement des autres puisque celles-ci sont de toute façon en cours.

## :cake: Solution

On désactive l'annulation d'exécutions en cours (`cancel-in-progress: false`) et l'annulation de jobs parallèles dans la matrice (`fail-fast: false`).


