### PR TITLE
feat: synchroniser les situations et les objectifs PE

### DIFF
--- a/backend/cdb/pe/models/contrainte.py
+++ b/backend/cdb/pe/models/contrainte.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import List
 
 from pydantic import BaseModel
+from strenum import StrEnum
 
 
 class Situation(BaseModel):
@@ -17,3 +18,37 @@ class Contrainte(BaseModel):
     # WARNING la date est parfois null, ca ne correspond pas à la doc
     date: datetime | None
     situations: List[Situation]
+
+
+class ContrainteValeurEnum(StrEnum):
+    NON_ABORDEE = "NON_ABORDEE"
+    OUI = "OUI"
+    CLOTUREE = "CLOTUREE"
+
+
+class SituationValeurEnum(StrEnum):
+    NON_ABORDEE = "NON_ABORDEE"
+    OUI = "OUI"
+    NON = "NON"
+
+
+class ObjectifValeurEnum(StrEnum):
+    NON_ABORDEE = "NON_ABORDEE"
+    EN_COURS = "EN_COURS"
+    REALISE = "REALISE"
+    ABANDONNE = "ABANDONNE"
+
+
+class SituationInput(BaseModel):
+    code: str
+    valeur: SituationValeurEnum
+
+
+class ContrainteInput(BaseModel):
+    code: str
+    valeur: ContrainteValeurEnum
+
+
+class ObjectifInput(BaseModel):
+    code: str
+    valeur: ObjectifValeurEnum


### PR DESCRIPTION
## :wrench: Problème

Actuellement lorsqu'on modifie les situations et les objectifs liés à des contraintes personnelles, celle-ci ne sont pas persistés dans le SI de pole emploi

## :cake: Solution

Persister les informations de contraintes (situations personnelles et objectifs) dans le SI de pole emploi 


## :rotating_light:  Points d'attention / Remarques

Seules les situations et les objectifs liés au thème emploi / formation / numérique ne sont pas persistés.

## :desert_island: Comment tester

... TODO
