### PR TITLE
fix: permettre le refus du sondage NPS

### DIFF
--- a/app/elm/NPSRating/GraphQL.gql
+++ b/app/elm/NPSRating/GraphQL.gql
@@ -23,6 +23,6 @@ mutation createNpsRating($score: Int!) {
 
 mutation dismissNPS {
   insert_nps_rating_dismissal_one(object: {}) {
-    id
+    dismissedAt
   }
 }

--- a/e2e/features/orientationManager/nps_rating.feature
+++ b/e2e/features/orientationManager/nps_rating.feature
@@ -13,3 +13,12 @@ Fonctionnalité: Modale de séléction du NPS
 
 		Quand je rafraichis la page
 		Alors je ne vois pas "Quelle est la probabilité que vous recommandiez Carnet de Bord à un collègue ?"
+
+	Scénario: Refus du sondage NPS
+		Soit un "chargé d'orientation" authentifié avec l'email "laure.loge@cd51.fr"
+		Alors je vois "Quelle est la probabilité que vous recommandiez Carnet de Bord à un collègue ?"
+		Quand je clique sur "Fermer"
+		Alors je ne vois pas "Quelle est la probabilité que vous recommandiez Carnet de Bord à un collègue ?"
+
+		Quand je rafraichis la page
+		Alors je ne vois pas "Quelle est la probabilité que vous recommandiez Carnet de Bord à un collègue ?"


### PR DESCRIPTION
## :wrench: Problème

Le refus de répondre au sondage NPS n'est pas enregistrable, voir #1846.

## :cake: Solution

On corrige la requête GraphQL effectuée pour ne pas demander en retour le champ `id` de la table `nps_rating_dismissal` qui n'est plus exposé aux utilisateurs.

## :desert_island: Comment tester

Se connecter avec `laure.loge`, cliquer `Fermer` sur la popup NPS. Constater qu'elle disparaît correctement.

fix #1846
<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
