### PR TITLE
fix: réparer la vidéo de présentation sur la page de login

### DIFF
--- a/app/src/routes/auth/login/+layout.svelte
+++ b/app/src/routes/auth/login/+layout.svelte
@@ -4,28 +4,12 @@
 	const videoOptions = {
 		sources: [
 			/**
-			 * Video with neither subtitles nor voiceover
-			 * {
-			 *   url: 'https://nextcloud.fabrique.social.gouv.fr/s/TtM2A7KkD55MqZ3/download/intro-cdb.mp4',
-			 *   type: 'video/mp4',
-			 * },
-			 */
-
-			/**
 			 * Video with voiceover
 			 */
 			{
-				url: 'https://nextcloud.fabrique.social.gouv.fr/s/KjFZxq4CFE76fyD/download/intro-cdb-voiceover.mp4',
+				url: '/videos/intro-cdb.mp4',
 				type: 'video/mp4',
 			},
-
-			/**
-			 * Video with embedded subtitles
-			 * {
-			 *   url: 'https://nextcloud.fabrique.social.gouv.fr/s/Nx3wbt6LTMrNqGE/download/intro-cdb-with-subs.mp4',
-			 *   type: 'video/mp4',
-			 * },
-			 */
 		],
 		tracks: [
 			{


### PR DESCRIPTION
## :wrench: Problème

La vidéo de présentation sur la page de connexion n'est plus fonctionnelle. Il semble que le service Nextcloud de la Fabrique Numérique des ministères sociaux ait cessé de l'héberger, ou que le lien soit devenu invalide comma ça avait déjà été le cas par le passé (#1241).

## :cake: Solution

La vidéo est maintenant intégrée dans les assets du projet, évitant la dépendance à un hébergement externe.

## :rotating_light:  Points d'attention / Remarques

Le poids de la vidéo dans le dépôt Git n'est pas négligeable (15-20 Mo) mais cela devrait rester gérable.

## :desert_island: Comment tester

Aller sur la _review app_, essayer de lire la vidéo sur la page de connexion.
