### PR TITLE
fix: alias postalCode dans l'action CreateNotebookInput

### DIFF
--- a/app/src/routes/api/notebooks/notebook.test.ts
+++ b/app/src/routes/api/notebooks/notebook.test.ts
@@ -243,6 +243,7 @@ describe('notebook api endpoint', () => {
 					nir: '12345678901234',
 					firstname: 'lionel',
 					lastname: 'breduillieard',
+					postalCode: '23234',
 				},
 			}
 		);

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -441,6 +441,7 @@ Soit(
 				firstname: firstname,
 				lastname: lastname,
 				nir: '1781299212296',
+				postalCode: '12345',
 			},
 			rdviUserEmail: manager,
 		});

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -1,13 +1,9 @@
 type Mutation {
-  create_notebook(
-    notebook: CreateNotebookInput!
-  ): CreateNotebookOutput
+  create_notebook(notebook: CreateNotebookInput!): CreateNotebookOutput
 }
 
 type Mutation {
-  create_nps_rating(
-    score: Int!
-  ): NPSRatingOutput
+  create_nps_rating(score: Int!): NPSRatingOutput
 }
 
 type Mutation {
@@ -34,19 +30,49 @@ type Mutation {
 }
 
 enum UpdateSocioProContractTypeEnum {
-  """ Apprentissage """ apprentissage
-  """ CDD """ cdd
-  """ CDI """ cdi
-  """ Contrat de professionnalisation """ contrat_professionnalisation
-  """ Interim """ interim
-  """ Libéral """ liberal
-  """ Portage salarial """ portage_salarial
-  """ Saisonnier """ saisonnier
+  """
+  Apprentissage
+  """
+  apprentissage
+  """
+  CDD
+  """
+  cdd
+  """
+  CDI
+  """
+  cdi
+  """
+  Contrat de professionnalisation
+  """
+  contrat_professionnalisation
+  """
+  Interim
+  """
+  interim
+  """
+  Libéral
+  """
+  liberal
+  """
+  Portage salarial
+  """
+  portage_salarial
+  """
+  Saisonnier
+  """
+  saisonnier
 }
 
 enum UpdateSocioProEmploymentTypeEnum {
-  """ Temps plein """ full_time
-  """ Temps partiel """ part_time
+  """
+  Temps plein
+  """
+  full_time
+  """
+  Temps partiel
+  """
+  part_time
 }
 
 input UpdateSocioProProfessionalProjectInsertInput {
@@ -83,7 +109,7 @@ input CreateNotebookInput {
   email: String
   address: String
   address2: String
-  postal_code: String
+  postalCode: String
   city: String
   cafNumber: String
 }

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -44,7 +44,7 @@ input CreateNotebookInput {
   lastname: String!
   mobileNumber: String
   nir: String!
-  postal_code: String
+  postalCode: String
 }
 
 type CreateNotebookOutput {


### PR DESCRIPTION
## :wrench: Problème

amine a remonter un probleme lors de l'envoi de donnée sur l'action `create_notebook`. L'envoi d'un champ postalCode genere un erreur coté hasura. En effet le nom du champ est `postal_code`

## :cake: Solution

On alias  le nom du champ pour qu'il reflete la doc et soit cohérent avec les autres propriétés

 
## :desert_island: Comment tester

les tests au vert ! 
