### PR TITLE
fix: supprime l'ancienne contrainte d'unicite

### DIFF
--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -8695,11 +8695,6 @@ enum notebook_action_constraint {
   unique or primary key constraint on columns "id"
   """
   notebook_action_pkey
-
-  """
-  unique or primary key constraint on columns "action", "target_id"
-  """
-  notebook_action_target_id_action_key
 }
 
 """


### PR DESCRIPTION



## :wrench: Problème

Lors de la pr #1836, la mise à jour du schema graphql n'a pas été mis à jour.

## :cake: Solution

supprimer l'ancienne contrainte sur les actions
qui évitait d'ajouter plusieurs fois la même action

@see #1836


## :rotating_light:  Points d'attention / Remarques

ras

## :desert_island: Comment tester
 les tests au verts
