### PR TITLE
perf(pe): évite d'appeler l'api PE trop souvent

### DIFF
--- a/backend/cdb/api/db/crud/beneficiary.py
+++ b/backend/cdb/api/db/crud/beneficiary.py
@@ -438,24 +438,35 @@ def get_beneficiary_by_notebook_id_query() -> DocumentNode:
     return gql(
         """
         query GetBeneficiaryQuery($notebook_id:uuid!) {
-            beneficiaries: beneficiary(where: {
-                notebook: {
-                    id: { _eq: $notebook_id }
-                    }
-                }) {
-                    id
-                    nir
-                    dateOfBirth
+            notebook_by_pk(id: $notebook_id) {
+                beneficiary {
+                    id nir dateOfBirth
                     externalDataInfos(where: {
-                        externalData: { source: { _eq: peio }  } }
-                        order_by: {created_at: desc}
+                        externalData: { source: { _eq: peio } } }
+                        order_by: { created_at: desc }
                         limit: 1
                     ) {
                         externalData { hash }
-                        created_at
-                        updated_at
+                    }
                 }
+                diagnosticFetchedAt
             }
         }
+        """
+    )
+
+
+def update_diagnostic_fetch_date() -> DocumentNode:
+    return gql(
+        """
+        mutation update_notebook_by_pk($notebook_id: uuid!) {
+            update_notebook_by_pk(
+                pk_columns: {id: $notebook_id}
+                _set: {diagnosticFetchedAt: now}
+            ){
+                diagnosticFetchedAt
+            }
+        }
+
         """
     )

--- a/backend/cdb/api/v1/routers/beneficiary_repository.py
+++ b/backend/cdb/api/v1/routers/beneficiary_repository.py
@@ -1,67 +1,80 @@
 from __future__ import annotations
 
 import abc
-import datetime
 from abc import ABC
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
+from xmlrpc.client import Boolean
 
-import dateutil.parser
+from dateutil.parser import isoparse
 from pydantic import BaseModel
 
-from cdb.api.db.crud.beneficiary import get_beneficiary_by_notebook_id_query
+from cdb.api.db.crud.beneficiary import (
+    get_beneficiary_by_notebook_id_query,
+    update_diagnostic_fetch_date,
+)
 from cdb.api.db.graphql.get_client import gql_client_backend_only
 
 
-class Beneficiary(BaseModel):
-    class ExternalDataInfo(BaseModel):
-        external_data_hash: str
-        created_at: str
-        updated_at: str
-
-        def is_fresh(self):
-            creation_date = dateutil.parser.isoparse(self.created_at)
-            expiry_date = creation_date + datetime.timedelta(hours=1)
-            now = datetime.datetime.now(tz=datetime.timezone.utc)
-            return now <= expiry_date
-
-    id: UUID
-    nir: str
+class BeneficiaryResponse(BaseModel):
+    diagnostic_fetched_at: str | None
+    beneficiary_id: UUID
+    nir: str | None
     date_of_birth: str
-    latest_external_data: Beneficiary.ExternalDataInfo | None
+    last_diagnostic_hash: str | None
+
+    def diagnostic_shoub_be_fetched(self) -> Boolean:
+        if not self.diagnostic_fetched_at:
+            return True
+        creation_date = isoparse(self.diagnostic_fetched_at)
+        expiry_date = creation_date + timedelta(hours=1)
+        now = datetime.now(tz=timezone.utc)
+        return now > expiry_date
+
+    def has_pe_diagnostic(self) -> Boolean:
+        return self.last_diagnostic_hash is not None
 
 
 class BeneficiaryRepository(ABC):
     @abc.abstractmethod
-    async def find_by_notebook_id(self, notebook_id: UUID) -> Beneficiary | None:
+    async def find_by_notebook_id(
+        self, notebook_id: UUID
+    ) -> BeneficiaryResponse | None:
         pass
 
 
-class DbBeneficiaryRepository(BeneficiaryRepository):
-    async def find_by_notebook_id(self, notebook_id: UUID) -> Beneficiary | None:
+class DbNotebookRepository(BeneficiaryRepository):
+    async def save_diagnostic_fetched_date(self, notebook_id: UUID):
+        async with gql_client_backend_only() as session:
+            await session.execute(
+                update_diagnostic_fetch_date(), {"notebook_id": notebook_id}
+            )
+
+    async def find_by_notebook_id(
+        self, notebook_id: UUID
+    ) -> BeneficiaryResponse | None:
         async with gql_client_backend_only() as session:
             response = await session.execute(
                 get_beneficiary_by_notebook_id_query(), {"notebook_id": notebook_id}
             )
-            beneficiaries = response["beneficiaries"]
-            if not isinstance(beneficiaries, list) or len(beneficiaries) != 1:
+            notebook = response["notebook_by_pk"]
+            if not notebook:
                 return None
-            beneficiary = beneficiaries[0]
-            return Beneficiary(
-                id=beneficiary["id"],
-                nir=beneficiary["nir"],
-                date_of_birth=beneficiary["dateOfBirth"],
-                latest_external_data=(self.extract_external_data(beneficiary)),
+            return BeneficiaryResponse(
+                diagnostic_fetched_at=notebook["diagnosticFetchedAt"],
+                beneficiary_id=notebook["beneficiary"]["id"],
+                nir=notebook["beneficiary"]["nir"],
+                date_of_birth=notebook["beneficiary"]["dateOfBirth"],
+                last_diagnostic_hash=self.extract_external_data_hash(
+                    notebook["beneficiary"]
+                ),
             )
 
     @staticmethod
-    def extract_external_data(beneficiary: dict):
+    def extract_external_data_hash(beneficiary: dict) -> str | None:
         infos = beneficiary["externalDataInfos"]
         if isinstance(infos, list) and len(infos) == 1:
             info = infos[0]
-            return Beneficiary.ExternalDataInfo(
-                external_data_hash=info["externalData"]["hash"],
-                created_at=info["created_at"],
-                updated_at=info["updated_at"],
-            )
+            return info["externalData"]["hash"]
         else:
             return None

--- a/backend/cdb/api/v1/routers/beneficiary_repository.py
+++ b/backend/cdb/api/v1/routers/beneficiary_repository.py
@@ -4,7 +4,6 @@ import abc
 from abc import ABC
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
-from xmlrpc.client import Boolean
 
 from dateutil.parser import isoparse
 from pydantic import BaseModel
@@ -23,7 +22,7 @@ class BeneficiaryResponse(BaseModel):
     date_of_birth: str
     last_diagnostic_hash: str | None
 
-    def diagnostic_shoub_be_fetched(self) -> Boolean:
+    def diagnostic_should_be_fetched(self) -> bool:
         if not self.diagnostic_fetched_at:
             return True
         creation_date = isoparse(self.diagnostic_fetched_at)
@@ -31,7 +30,7 @@ class BeneficiaryResponse(BaseModel):
         now = datetime.now(tz=timezone.utc)
         return now > expiry_date
 
-    def has_pe_diagnostic(self) -> Boolean:
+    def has_pe_diagnostic(self) -> bool:
         return self.last_diagnostic_hash is not None
 
 

--- a/backend/cdb/api/v1/routers/refresh_situations.py
+++ b/backend/cdb/api/v1/routers/refresh_situations.py
@@ -102,7 +102,7 @@ async def refresh_notebook_situations_from_pole_emploi(
     notebook = await notebook_repository.find_by_notebook_id(notebook_id)
     if not notebook:
         return None
-    if notebook.diagnostic_shoub_be_fetched():
+    if notebook.diagnostic_should_be_fetched():
         if not notebook.nir:
             return None
 
@@ -111,7 +111,6 @@ async def refresh_notebook_situations_from_pole_emploi(
         )
 
         await notebook_repository.save_diagnostic_fetched_date(notebook_id)
-        print("++++++++", notebook.diagnostic_fetched_at)
 
         if dossier is None:
             return {

--- a/backend/cdb/api/v1/routers/refresh_situations.py
+++ b/backend/cdb/api/v1/routers/refresh_situations.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import abc
-import datetime
 import json
 import logging
 from abc import ABC
 from typing import List
 from uuid import UUID
 
-import dateutil.parser
 from fastapi import APIRouter, Depends
 from gql.client import AsyncClientSession
 from pydantic import BaseModel
@@ -29,8 +27,7 @@ from cdb.api.v1.dependencies import verify_secret_token
 from cdb.api.v1.payloads.notebook import NotebookSituationInputPayload
 from cdb.api.v1.payloads.socio_pro import SituationToAdd
 from cdb.api.v1.routers.beneficiary_repository import (
-    Beneficiary,
-    DbBeneficiaryRepository,
+    DbNotebookRepository,
 )
 from cdb.cdb_csv.json_encoder import CustomEncoder
 from cdb.pe.models.dossier_individu_api import Contrainte, DossierIndividuData
@@ -40,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(dependencies=[Depends(verify_secret_token)])
 
-beneficiary_repository = DbBeneficiaryRepository()
+notebook_repository = DbNotebookRepository()
 
 
 class DossierPEClient(ABC):
@@ -102,32 +99,28 @@ async def refresh_notebook_situations_from_pole_emploi(
 
     notebook_id = payload.input.notebook_id
 
-    beneficiary = await beneficiary_repository.find_by_notebook_id(notebook_id)
-    if not beneficiary:
+    notebook = await notebook_repository.find_by_notebook_id(notebook_id)
+    if not notebook:
         return None
+    if notebook.diagnostic_shoub_be_fetched():
+        if not notebook.nir:
+            return None
 
-    if (
-        not beneficiary.latest_external_data
-        or not beneficiary.latest_external_data.is_fresh()
-    ):
-        dossier = await dossier_pe_client.find(
-            DossierPEClient.Query(
-                nir=beneficiary.nir, birth_date=beneficiary.date_of_birth
-            )
+        dossier: DossierIndividuData | None = await dossier_pe_client.find(
+            DossierPEClient.Query(nir=notebook.nir, birth_date=notebook.date_of_birth)
         )
+
+        await notebook_repository.save_diagnostic_fetched_date(notebook_id)
+        print("++++++++", notebook.diagnostic_fetched_at)
+
         if dossier is None:
-            # TODO save empty external data
             return {
                 "data_has_been_updated": False,
                 "external_data_has_been_updated": False,
                 "has_pe_diagnostic": False,
             }
 
-        if (
-            beneficiary.latest_external_data
-            and beneficiary.latest_external_data.external_data_hash == dossier.hash()
-        ):
-            # TODO Update the updated_at ts
+        if notebook.last_diagnostic_hash == dossier.hash():
             return {
                 "data_has_been_updated": False,
                 "external_data_has_been_updated": False,
@@ -135,7 +128,7 @@ async def refresh_notebook_situations_from_pole_emploi(
             }
 
         async with gql_client_backend_only() as session:
-            await save_dossier(dossier, beneficiary.id, session)
+            await save_dossier(dossier, notebook.beneficiary_id, session)
 
             if settings.ENABLE_SYNC_CONTRAINTES:
                 differences = await get_differences(
@@ -155,32 +148,11 @@ async def refresh_notebook_situations_from_pole_emploi(
             "external_data_has_been_updated": True,
             "has_pe_diagnostic": True,
         }
-
     return {
         "data_has_been_updated": False,
         "external_data_has_been_updated": False,
-        "has_pe_diagnostic": True,
+        "has_pe_diagnostic": notebook.has_pe_diagnostic(),
     }
-
-
-async def get_single_beneficiary_of_notebook(notebook_id: UUID) -> Beneficiary | None:
-    return await DbBeneficiaryRepository().find_by_notebook_id(notebook_id)
-
-
-def are_data_fresh(beneficiary: dict) -> bool:
-    external_data_infos: List[dict] | None = beneficiary.get("externalDataInfos")
-    if external_data_infos:
-        for data in external_data_infos:
-            if is_fresh(data):
-                return True
-    return False
-
-
-def is_fresh(external_data):
-    creation_date = dateutil.parser.isoparse(external_data["created_at"])
-    expiry_date = creation_date + datetime.timedelta(hours=1)
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-    return now <= expiry_date
 
 
 async def save_dossier(
@@ -204,31 +176,6 @@ async def get_differences(
     return merge_contraintes_to_situations(
         contraintes, ref_situations, notebook_situations
     )
-
-
-async def get_dossier_individu_pe(
-    beneficiary: Beneficiary,
-) -> DossierIndividuData | None:
-    pe_client = PoleEmploiApiClient(
-        auth_base_url=settings.PE_AUTH_BASE_URL,
-        base_url=settings.PE_BASE_URL,
-        client_id=settings.PE_CLIENT_ID,
-        client_secret=settings.PE_CLIENT_SECRET,
-        scope=" ".join(
-            [
-                "api_rechercher-usagerv1",
-                "api_diagnosticargumentev1",
-                "api_metiers-profil-competencesv1",
-                "ciblepro",
-                "api_projet-creation-entreprisev1",
-            ]
-        ),  # noqa: E501
-    )
-    beneficiary = await pe_client.search_beneficiary(
-        nir=beneficiary.nir, date_of_birth=beneficiary.date_of_birth
-    )
-    if beneficiary and beneficiary.identifiant:
-        return await pe_client.get_dossier_individu(beneficiary.identifiant)
 
 
 async def save_differences(differences: SituationDifferences, notebook_id, session):

--- a/backend/cdb/api/v1/routers/refresh_situations.py
+++ b/backend/cdb/api/v1/routers/refresh_situations.py
@@ -104,11 +104,7 @@ async def refresh_notebook_situations_from_pole_emploi(
 
     beneficiary = await beneficiary_repository.find_by_notebook_id(notebook_id)
     if not beneficiary:
-        return {
-            "data_has_been_updated": False,
-            "external_data_has_been_updated": False,
-            "has_pe_diagnostic": False,
-        }
+        return None
 
     if (
         not beneficiary.latest_external_data

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -1,13 +1,19 @@
 type Mutation {
-  create_notebook(notebook: CreateNotebookInput!): CreateNotebookOutput
+  create_notebook(
+    notebook: CreateNotebookInput!
+  ): CreateNotebookOutput
 }
 
 type Mutation {
-  create_nps_rating(score: Int!): NPSRatingOutput
+  create_nps_rating(
+    score: Int!
+  ): NPSRatingOutput
 }
 
 type Query {
-  diagnostic_pole_emploi(notebookId: uuid!): PoleEmploiDossierIndividu
+  diagnostic_pole_emploi(
+    notebookId: uuid!
+  ): PoleEmploiDossierIndividu
 }
 
 type Mutation {
@@ -34,49 +40,44 @@ type Mutation {
 }
 
 enum UpdateSocioProContractTypeEnum {
-  """
-  Apprentissage
-  """
-  apprentissage
-  """
-  CDD
-  """
-  cdd
-  """
-  CDI
-  """
-  cdi
-  """
-  Contrat de professionnalisation
-  """
-  contrat_professionnalisation
-  """
-  Interim
-  """
-  interim
-  """
-  Libéral
-  """
-  liberal
-  """
-  Portage salarial
-  """
-  portage_salarial
-  """
-  Saisonnier
-  """
-  saisonnier
+  """ Apprentissage """ apprentissage
+  """ CDD """ cdd
+  """ CDI """ cdi
+  """ Contrat de professionnalisation """ contrat_professionnalisation
+  """ Interim """ interim
+  """ Libéral """ liberal
+  """ Portage salarial """ portage_salarial
+  """ Saisonnier """ saisonnier
 }
 
 enum UpdateSocioProEmploymentTypeEnum {
-  """
-  Temps plein
-  """
-  full_time
-  """
-  Temps partiel
-  """
-  part_time
+  """ Temps plein """ full_time
+  """ Temps partiel """ part_time
+}
+
+enum PoleEmploiBesoinValeurEnum {
+  POINT_FORT
+  BESOIN
+  NON_EXPLORE
+}
+
+enum PoleEmploiContrainteValeurEnum {
+  NON_ABORDEE
+  OUI
+  CLOTUREE
+}
+
+enum PoleEmploiSituationValeurEnum {
+  NON_ABORDEE
+  OUI
+  NON
+}
+
+enum PoleEmploiObjectifValeurEnum {
+  NON_ABORDE
+  EN_COURS
+  REALISE
+  ABANDONNE
 }
 
 input UpdateSocioProProfessionalProjectInsertInput {
@@ -184,37 +185,4 @@ type PoleEmploiDossierIndividuSituations {
   code: String!
   libelle: String!
   valeur: PoleEmploiSituationValeurEnum!
-}
-
-enum PoleEmploiBesoinValeurEnum {
-  POINT_FORT
-
-  BESOIN
-
-  NON_EXPLORE
-}
-
-enum PoleEmploiContrainteValeurEnum {
-  NON_ABORDEE
-
-  OUI
-
-  CLOTUREE
-}
-
-enum PoleEmploiSituationValeurEnum {
-  NON_ABORDEE
-
-  OUI
-
-  NON
-}
-enum PoleEmploiObjectifValeurEnum {
-  NON_ABORDE
-
-  EN_COURS
-
-  REALISE
-
-  ABANDONNE
 }

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -94,6 +94,53 @@ custom_types:
         - description: Temps partiel
           is_deprecated: null
           value: part_time
+    - name: PoleEmploiBesoinValeurEnum
+      values:
+        - description: null
+          is_deprecated: null
+          value: POINT_FORT
+        - description: null
+          is_deprecated: null
+          value: BESOIN
+        - description: null
+          is_deprecated: null
+          value: NON_EXPLORE
+    - name: PoleEmploiContrainteValeurEnum
+      values:
+        - description: null
+          is_deprecated: null
+          value: NON_ABORDEE
+        - description: null
+          is_deprecated: null
+          value: OUI
+        - description: null
+          is_deprecated: null
+          value: CLOTUREE
+    - name: PoleEmploiSituationValeurEnum
+      values:
+        - description: null
+          is_deprecated: null
+          value: NON_ABORDEE
+        - description: null
+          is_deprecated: null
+          value: OUI
+        - description: null
+          is_deprecated: null
+          value: NON
+    - name: PoleEmploiObjectifValeurEnum
+      values:
+        - description: null
+          is_deprecated: null
+          value: NON_ABORDE
+        - description: null
+          is_deprecated: null
+          value: EN_COURS
+        - description: null
+          is_deprecated: null
+          value: REALISE
+        - description: null
+          is_deprecated: null
+          value: ABANDONNE
   input_objects:
     - name: UpdateSocioProProfessionalProjectInsertInput
     - name: UpdateSocioProProfessionalProjectSetInput
@@ -104,11 +151,11 @@ custom_types:
     - name: UpdateSocioProOutput
     - name: CreateNotebookOutput
     - name: RefreshNotebookSituationsFromPoleEmploiOutput
-    - name: PoleEmploiDossierIndividuBesoins
-    - name: PoleEmploiDossierIndividuBesoinsParDiagnosticIndividu
-    - name: PoleEmploiDossierIndividuContraintes
-    - name: PoleEmploiDossierIndividuContraintesIndividus
-    - name: PoleEmploiDossierIndividuObjectifs
     - name: PoleEmploiDossierIndividu
+    - name: PoleEmploiDossierIndividuBesoinsParDiagnosticIndividu
+    - name: PoleEmploiDossierIndividuBesoins
+    - name: PoleEmploiDossierIndividuContraintesIndividus
+    - name: PoleEmploiDossierIndividuContraintes
+    - name: PoleEmploiDossierIndividuObjectifs
     - name: PoleEmploiDossierIndividuSituations
   scalars: []

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook.yaml
@@ -15,6 +15,8 @@ configuration:
       custom_name: contractType
     created_at:
       custom_name: createdAt
+    diagnostic_fetched_at:
+      custom_name: diagnosticFetchedAt
     education_level:
       custom_name: educationLevel
     last_job_ended_at:
@@ -36,6 +38,7 @@ configuration:
     contract_start_date: contractStartDate
     contract_type: contractType
     created_at: createdAt
+    diagnostic_fetched_at: diagnosticFetchedAt
     education_level: educationLevel
     last_job_ended_at: lastJobEndedAt
     right_rqth: rightRqth

--- a/hasura/migrations/carnet_de_bord/1688421552435_alter_table_public_notebook_add_column_diagnostic_fetched_date/down.sql
+++ b/hasura/migrations/carnet_de_bord/1688421552435_alter_table_public_notebook_add_column_diagnostic_fetched_date/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."notebook" drop column "diagnostic_fetched_at";

--- a/hasura/migrations/carnet_de_bord/1688421552435_alter_table_public_notebook_add_column_diagnostic_fetched_date/up.sql
+++ b/hasura/migrations/carnet_de_bord/1688421552435_alter_table_public_notebook_add_column_diagnostic_fetched_date/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."notebook" add column "diagnostic_fetched_at" timestamptz
+ null;

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -8485,6 +8485,7 @@ type notebook {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz!
+  diagnosticFetchedAt: timestamp
   educationLevel: String
 
   """An array relationship"""
@@ -9340,6 +9341,7 @@ input notebook_bool_exp {
   contractStartDate: date_comparison_exp
   contractType: String_comparison_exp
   createdAt: timestamptz_comparison_exp
+  diagnosticFetchedAt: timestamp_comparison_exp
   educationLevel: String_comparison_exp
   events: notebook_event_bool_exp
   events_aggregate: notebook_event_aggregate_bool_exp
@@ -10530,6 +10532,7 @@ input notebook_insert_input {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz
+  diagnosticFetchedAt: timestamp
   educationLevel: String
   events: notebook_event_arr_rel_insert_input
   focuses: notebook_focus_arr_rel_insert_input
@@ -10554,6 +10557,7 @@ type notebook_max_fields {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz
+  diagnosticFetchedAt: timestamp
   educationLevel: String
   id: uuid
   lastJobEndedAt: date
@@ -10968,6 +10972,7 @@ type notebook_min_fields {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz
+  diagnosticFetchedAt: timestamp
   educationLevel: String
   id: uuid
   lastJobEndedAt: date
@@ -11017,6 +11022,7 @@ input notebook_order_by {
   contractStartDate: order_by
   contractType: order_by
   createdAt: order_by
+  diagnosticFetchedAt: order_by
   educationLevel: order_by
   events_aggregate: notebook_event_aggregate_order_by
   focuses_aggregate: notebook_focus_aggregate_order_by
@@ -11258,6 +11264,9 @@ enum notebook_select_column {
   createdAt
 
   """column name"""
+  diagnosticFetchedAt
+
+  """column name"""
   educationLevel
 
   """column name"""
@@ -11292,6 +11301,7 @@ input notebook_set_input {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz
+  diagnosticFetchedAt: timestamp
   educationLevel: String
   id: uuid
   lastJobEndedAt: date
@@ -11628,6 +11638,7 @@ input notebook_stream_cursor_value_input {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz
+  diagnosticFetchedAt: timestamp
   educationLevel: String
   id: uuid
   lastJobEndedAt: date
@@ -12003,6 +12014,9 @@ enum notebook_update_column {
 
   """column name"""
   createdAt
+
+  """column name"""
+  diagnosticFetchedAt
 
   """column name"""
   educationLevel

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -8485,7 +8485,7 @@ type notebook {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz!
-  diagnosticFetchedAt: timestamp
+  diagnosticFetchedAt: timestamptz
   educationLevel: String
 
   """An array relationship"""
@@ -9341,7 +9341,7 @@ input notebook_bool_exp {
   contractStartDate: date_comparison_exp
   contractType: String_comparison_exp
   createdAt: timestamptz_comparison_exp
-  diagnosticFetchedAt: timestamp_comparison_exp
+  diagnosticFetchedAt: timestamptz_comparison_exp
   educationLevel: String_comparison_exp
   events: notebook_event_bool_exp
   events_aggregate: notebook_event_aggregate_bool_exp
@@ -10532,7 +10532,7 @@ input notebook_insert_input {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz
-  diagnosticFetchedAt: timestamp
+  diagnosticFetchedAt: timestamptz
   educationLevel: String
   events: notebook_event_arr_rel_insert_input
   focuses: notebook_focus_arr_rel_insert_input
@@ -10557,7 +10557,7 @@ type notebook_max_fields {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz
-  diagnosticFetchedAt: timestamp
+  diagnosticFetchedAt: timestamptz
   educationLevel: String
   id: uuid
   lastJobEndedAt: date
@@ -10972,7 +10972,7 @@ type notebook_min_fields {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz
-  diagnosticFetchedAt: timestamp
+  diagnosticFetchedAt: timestamptz
   educationLevel: String
   id: uuid
   lastJobEndedAt: date
@@ -11301,7 +11301,7 @@ input notebook_set_input {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz
-  diagnosticFetchedAt: timestamp
+  diagnosticFetchedAt: timestamptz
   educationLevel: String
   id: uuid
   lastJobEndedAt: date
@@ -11638,7 +11638,7 @@ input notebook_stream_cursor_value_input {
   contractStartDate: date
   contractType: String
   createdAt: timestamptz
-  diagnosticFetchedAt: timestamp
+  diagnosticFetchedAt: timestamptz
   educationLevel: String
   id: uuid
   lastJobEndedAt: date


### PR DESCRIPTION
## :wrench: Problème

Le rate limit de l'api PE etant assez, il est frequent d'arriver au plafond, ce qui bloque la récupération de diagnostic.

## :cake: Solution

On limite les appels à l'api a 1 par heure pour chaque carnet.


## :rotating_light:  Points d'attention / Remarques

ras

## :desert_island: Comment tester

rafrachir plusieur fois la page d'un carnet 
ne pas voir d'alerte sur la page