### PR TITLE
fix: remove pe sync alerts

### DIFF
--- a/app/elm/Diagnostic/PersonalSituation.elm
+++ b/app/elm/Diagnostic/PersonalSituation.elm
@@ -148,7 +148,7 @@ viewRefreshState : RefreshState -> Html msg
 viewRefreshState state =
     case state of
         Started ->
-            UI.Spinner.view "Récupération des information Pôle emploi en cours"
+            UI.Spinner.view "Récupération des informations Pôle emploi en cours"
 
         _ ->
             Html.text ""

--- a/app/elm/Diagnostic/PersonalSituation.elm
+++ b/app/elm/Diagnostic/PersonalSituation.elm
@@ -1,6 +1,5 @@
 module Diagnostic.PersonalSituation exposing (DisplayTheme, Model, Msg(..), RefreshState(..), Theme, init, update, view)
 
-import BetaGouv.DSFR.Alert as Alert
 import Diagnostic.AllSituations as AllSituations exposing (DataSyncInfo, PersonalSituation)
 import Domain.Account
 import Domain.Theme
@@ -150,25 +149,6 @@ viewRefreshState state =
     case state of
         Started ->
             UI.Spinner.view "Récupération des information Pôle emploi en cours"
-
-        Failed ->
-            Html.div []
-                [ Alert.small
-                    { title = Nothing
-                    , description =
-                        "Échec de la synchronisation avec Pôle Emploi, "
-                            ++ "les informations ci-dessous peuvent être obsolètes. "
-                            ++ "Nos équipes ont été notifiées. "
-                    }
-                    |> Alert.alert Nothing Alert.error
-                , Alert.small
-                    { title = Nothing
-                    , description =
-                        "Vous pouvez tenter de rafraîchir la page. "
-                            ++ "Si le problème persiste, contactez le support."
-                    }
-                    |> Alert.alert Nothing Alert.info
-                ]
 
         _ ->
             Html.text ""


### PR DESCRIPTION
## :wrench: Problème

Actuellement, on affiche des erreurs de liés à une tache de fond et qui perturbent l'utilisation

## :cake: Solution

on propose de supprimer ces alertes.

## :rotating_light:  Points d'attention / Remarques

> _Précisez si il y a des cas particuliers ou des sujets connexes à partager ?_

## :desert_island: Comment tester

ces alertes n'etant pas testées, aucun tests à été modifiés
