### PR TITLE
fix: ne pas demander les scopes PE inutiles

### DIFF
--- a/backend/cdb/api/v1/routers/refresh_situations.py
+++ b/backend/cdb/api/v1/routers/refresh_situations.py
@@ -61,11 +61,8 @@ class RealDossierPEClient(DossierPEClient):
                 [
                     "api_rechercher-usagerv1",
                     "api_diagnosticargumentev1",
-                    "api_metiers-profil-competencesv1",
-                    "ciblepro",
-                    "api_projet-creation-entreprisev1",
                 ]
-            ),  # noqa: E501
+            ),
         )
         beneficiary = await pe_client.search_beneficiary(
             nir=query.nir, date_of_birth=query.birth_date

--- a/backend/cdb/pe/pole_emploi_client.py
+++ b/backend/cdb/pe/pole_emploi_client.py
@@ -26,7 +26,7 @@ class PoleEmploiApiClient:
     client_secret: str
     scope: str
     tz: str = "Europe/Paris"
-    token: str | None = None
+    auth_header: str | None = None
     expires_at: datetime | None = None
 
     @property
@@ -75,12 +75,12 @@ class PoleEmploiApiClient:
             )
             response.raise_for_status()
         auth_data = response.json()
-        self.token = f"{auth_data['token_type']} {auth_data['access_token']}"
+        self.auth_header = f"{auth_data['token_type']} {auth_data['access_token']}"
         self.expires_at = at + timedelta(seconds=auth_data["expires_in"])
 
     @property
     def _headers(self) -> dict:
-        return {"Authorization": self.token, "Content-Type": "application/json"}
+        return {"Authorization": self.auth_header, "Content-Type": "application/json"}
 
     async def _post_request(self, url: str, params: dict):
         await self._refresh_token()

--- a/backend/tests/pe/test_pole_emploi_client.py
+++ b/backend/tests/pe/test_pole_emploi_client.py
@@ -47,7 +47,7 @@ async def test_get_token_nominal():
 
     await api_client._refresh_token(at=now)
 
-    assert api_client.token == "foo batman"
+    assert api_client.auth_header == "foo batman"
     assert api_client.expires_at, now + timedelta(seconds=3600)
 
 


### PR DESCRIPTION
## :wrench: Problème

L'authentification à l'API Pôle Emploi de diagnostic échoue en production parce que nous demandons l'accès à des API qui ne nous sont pas ouvertes en production. Or nous n'utilisons pas encore les API en question.

## :cake: Solution

Ne pas demander ces API inutilisées lors de la création du jeton.

## :desert_island: Comment tester

Malheureusement c'est uniquement en ciblant la production de pole-emploi.io que l'on peut voir l'effet de ce changement.

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
