### PR TITLE
feat: gestion des 429

### DIFF
--- a/backend/cdb/api/core/logging.py
+++ b/backend/cdb/api/core/logging.py
@@ -10,6 +10,7 @@ from cdb.api.core.settings import settings
 
 requests_logger.setLevel(settings.GQL_LOG_LEVEL)
 
+
 # inspired by https://gist.github.com/nymous/f138c7f06062b7c43c060bf03759c29e
 
 
@@ -93,6 +94,9 @@ def setup_logging(json_logs: bool, log_level: str):
     root_logger = logging.getLogger()
     root_logger.addHandler(handler)
     root_logger.setLevel(log_level.upper())
+
+    logging.getLogger("backoff").setLevel(logging.DEBUG)
+    logging.getLogger("backoff").addHandler(handler)
 
     for _log in ["uvicorn", "uvicorn.error"]:
         # Clear the log handlers for uvicorn loggers, and enable propagation

--- a/backend/cdb/api/v1/exception_handler.py
+++ b/backend/cdb/api/v1/exception_handler.py
@@ -2,6 +2,7 @@ import logging
 
 from fastapi import HTTPException, Request
 from gql.transport.exceptions import TransportQueryError
+from httpx import HTTPError, HTTPStatusError
 from starlette.responses import JSONResponse
 
 logger = logging.getLogger(__name__)
@@ -44,8 +45,12 @@ async def gql_transport_exception_handler(_: Request, exception: TransportQueryE
     )
 
 
-def httpx_exception_handler(_: Request, exception: Exception):
-    logger.exception(exception)
+def httpx_exception_handler(_: Request, exception: HTTPError):
+    extra = None
+    if isinstance(exception, HTTPStatusError):
+        extra = {"response": exception.response.text}
+
+    logger.exception(exception, extra=extra)
     error_message = "Une erreur interne est survenue"
     return JSONResponse(
         status_code=400,

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2231,4 +2231,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "40665f304a4cca870cbf12a14325ce7b454fb7f8db15ab82a0f5062fabd634f5"
+content-hash = "c10b63c9848d63dae8fc7e70019a143f9c350a28ff77fd2dbbf5b43f81a2442a"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,7 @@ typer = "0.7.0"
 uvicorn = "0.21.1"
 xlrd = "^2.0.1"
 lxml = "^4.9.2"
+backoff = "^2.2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.1"


### PR DESCRIPTION
## :wrench: Problème

On ne gere pas les erreurs 429 

## :cake: Solution

On branche un utilitaire pour gérer le réessayer les requetes qui renvoient un code 429

## :rotating_light:  Points d'attention / Remarques

on a brancher le logger de backoff dans l'application pour suivre les rejeux de requetes

## :desert_island: Comment tester
```
while true; do curl 'https://cdb-hasura-review-pr1875.osc-fr1.scalingo.io/v1/graphql' -X POST  -H 'content-type: application/json' -H 'x-hasura-admin-secret: admin'   --data-raw '{"query":"mutation MyMutation {   update_notebook(    where: {id: {_eq:\"879a25f0-e10c-4081-bde3-4aef77826d1a\" }}    _set: {diagnosticFetchedAt: null }   ) {     affected_rows   }   refresh_notebook_situations_from_pole_emploi(notebookId: \"879a25f0-e10c-4081-bde3-4aef77826d1a\"){    has_pe_diagnostic }}"}'; done
```
