### PR TITLE
fix: passe dateMiseAjour en facultatif

### DIFF
--- a/backend/cdb/pe/models/dossier_individu_api.py
+++ b/backend/cdb/pe/models/dossier_individu_api.py
@@ -29,7 +29,7 @@ class Metier(BaseModel):
     typologie: str | None
     statut: str
     estPrioritaire: bool
-    dateMiseAJour: str
+    dateMiseAJour: str | None
     besoins: list[Besoin]
 
 
@@ -46,7 +46,7 @@ class ContraintesIndividu(BaseModel):
     conseiller: str
     dateDeModification: str
     code: str
-    libelle: str
+    libelle: str | None
     contraintes: list[Contrainte]
 
 

--- a/backend/cdb/pe/models/dossier_individu_api.py
+++ b/backend/cdb/pe/models/dossier_individu_api.py
@@ -43,7 +43,7 @@ class Contrainte(BaseModel):
 
 
 class ContraintesIndividu(BaseModel):
-    conseiller: str
+    conseiller: str | None
     dateDeModification: str
     code: str
     libelle: str | None


### PR DESCRIPTION
## :wrench: Problème

L'api dossier individu renvoi un payload avec des champ `dateMiseAJour` et `conseiller` facultatifs or on s'attend la présence du champ comme indiqué dans la documentation (toujours fourni)

## :cake: Solution

On met à jour notre modèle pour accepté des dates facultative


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Pas de procédure actuellement.