### PR TITLE
Fix/1833 parentheses nom famille

### DIFF
--- a/app/src/lib/ui/Manager/errorMessage.ts
+++ b/app/src/lib/ui/Manager/errorMessage.ts
@@ -38,6 +38,9 @@ export function translateError(error = ''): string {
 	if (/allowed value/i.test(error)) {
 		return 'Valeur non supportée';
 	}
+	if (/Les parenthèses ne sont pas autorisées dans les noms/i.test(error)) {
+		return error;
+	}
 	console.error('unhandle import error message', error);
 	return `Une erreur s'est produite lors de la lecture du fichier.`;
 }

--- a/backend/cdb/api/core/exceptions.py
+++ b/backend/cdb/api/core/exceptions.py
@@ -1,10 +1,4 @@
-class InsertFailError(Exception):
+class ImportFailError(Exception):
     """
     utility class when insert goes wrong
-    """
-
-
-class UpdateFailError(Exception):
-    """
-    utility class when update goes wrong
     """

--- a/backend/cdb/api/db/models/beneficiary.py
+++ b/backend/cdb/api/db/models/beneficiary.py
@@ -112,6 +112,7 @@ class BeneficiaryImport(BaseModel):
     class Config:
         anystr_strip_whitespace = True
         allow_population_by_field_name = True
+        validate_assignment = True
 
     _phone_validator = phone_validator("mobile_number")
     _postal_code_validator = postal_code_validator("postal_code")
@@ -134,6 +135,12 @@ class BeneficiaryImport(BaseModel):
         ]:
             raise ValueError("value unknown")
         return right_rsa
+
+    @validator("firstname", "lastname")
+    def forbid_parens(cls, value):
+        if "(" in value or ")" in value:
+            raise ValueError("Les parenthèses ne sont pas autorisées dans les noms")
+        return value
 
     @validator("work_situation")
     def parse_work_situation(cls, work_situation):

--- a/backend/cdb/api/v1/routers/beneficiaries.py
+++ b/backend/cdb/api/v1/routers/beneficiaries.py
@@ -230,9 +230,8 @@ async def try_to_import_one(line: LineImport, io: IO):
         return await fail_for_conflicting_personal_data(line, matching_beneficiaries)
 
     raise ImportFailError(
-        "Erreur inconnue, on a trouvé un bénéficiaire "
-        "mais ni les données personnelles ni les SI IDs "
-        "ne correspondent"
+        "Un bénéficiaire existe déjà avec ce NIR sur le territoire. "
+        "Mais ni ses données personnelles ni son identifiant SI ne correspondent."
     )
 
 

--- a/backend/cdb/api/v1/routers/beneficiaries.py
+++ b/backend/cdb/api/v1/routers/beneficiaries.py
@@ -1,20 +1,30 @@
 import logging
+from functools import partial
+from typing import Awaitable, Callable, List
 from uuid import UUID
 
 from asyncpg.connection import Connection
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, Request, UploadFile
+from mypy_extensions import Arg
 from pydantic import BaseModel
 
-from cdb.api.core.exceptions import InsertFailError, UpdateFailError
+from cdb.api.core.exceptions import ImportFailError
 from cdb.api.core.init import connection
 from cdb.api.db.crud.beneficiary import (
-    create_beneficiary_with_notebook_and_referent,
+    add_beneficiary_to_structure,
     get_beneficiaries_like,
+    insert_beneficiary,
     update_beneficiary,
 )
-from cdb.api.db.crud.notebook import update_notebook
+from cdb.api.db.crud.notebook import (
+    insert_notebook,
+    insert_notebook_member,
+    update_notebook,
+)
 from cdb.api.db.crud.notebook_info import insert_or_update_need_orientation
+from cdb.api.db.crud.professional import get_professional_by_email
 from cdb.api.db.crud.professional_project import insert_professional_projects
+from cdb.api.db.crud.structure import get_structure_by_name
 from cdb.api.db.models.beneficiary import (
     Beneficiary,
     BeneficiaryCsvRowResponse,
@@ -22,7 +32,10 @@ from cdb.api.db.models.beneficiary import (
     is_same_name,
 )
 from cdb.api.db.models.csv import CsvFieldError
+from cdb.api.db.models.notebook_member import NotebookMember, NotebookMemberInsert
+from cdb.api.db.models.professional import Professional
 from cdb.api.db.models.role import RoleEnum
+from cdb.api.db.models.structure import Structure
 from cdb.api.v1.dependencies import (
     Account,
     allowed_jwt_roles,
@@ -60,20 +73,6 @@ class BeneficiariesImportInput(BaseModel):
     beneficiaries: list[BeneficiaryImport]
 
 
-@router.post("/bulk", response_model=list[BeneficiaryCsvRowResponse])
-async def import_beneficiaries(
-    data: BeneficiariesImportInput,
-    request: Request,
-    db=Depends(connection),
-) -> list[BeneficiaryCsvRowResponse]:
-    deployment_id: UUID = UUID(request.state.deployment_id)
-    result = [
-        await import_beneficiary(db, beneficiary, deployment_id, data.need_orientation)
-        for beneficiary in data.beneficiaries
-    ]
-    return result
-
-
 @router.post("/update-from-caf-msa", status_code=201)
 async def import_caf_msa_xml(
     upload_file: UploadFile,
@@ -91,145 +90,297 @@ async def import_caf_msa_xml(
     )
 
 
+class LineImport(BaseModel):
+    beneficiary: BeneficiaryImport
+    deployment_id: UUID
+    need_orientation: bool
+
+
+class IO(BaseModel):
+    get_beneficiaries_like: Callable[
+        [BeneficiaryImport, Arg(UUID, "deployment_id")], Awaitable[List[Beneficiary]]
+    ]
+    insert_beneficiary: Callable[
+        [BeneficiaryImport, Arg(UUID, "deployment_id")], Awaitable[UUID | None]
+    ]
+    insert_notebook: Callable[
+        [Arg(UUID, "notebook_id"), BeneficiaryImport], Awaitable[UUID | None]
+    ]
+    insert_or_update_need_orientation: Callable[
+        [
+            Arg(UUID, "notebook_id"),
+            Arg(UUID, "orientation_system_id") | None,
+            Arg(bool, "need_orientation"),
+        ],
+        Awaitable[None],
+    ]
+    insert_professional_projects: Callable[
+        [Arg(UUID, "notebook_id"), BeneficiaryImport], Awaitable[None]
+    ]
+    get_structure_by_name: Callable[
+        [str, Arg(UUID, "deployment_id")], Awaitable[Structure | None]
+    ]
+    get_professional_by_email: Callable[[str], Awaitable[Professional | None]]
+    add_beneficiary_to_structure: Callable[
+        [Arg(UUID, "beneficiary_id"), Arg(UUID, "structure_id"), Arg(str, "status")],
+        Awaitable[UUID | None],
+    ]
+    insert_notebook_member: Callable[
+        [NotebookMemberInsert], Awaitable[NotebookMember | None]
+    ]
+    update_beneficiary: Callable[
+        [BeneficiaryImport, Arg(UUID, "beneficiary_id")], UUID | None
+    ]
+    update_notebook: Callable[
+        [BeneficiaryImport, Arg(UUID, "beneficiary_id")], UUID | None
+    ]
+
+
+@router.post("/bulk", response_model=list[BeneficiaryCsvRowResponse])
+async def import_beneficiaries(
+    data: BeneficiariesImportInput,
+    request: Request,
+    db=Depends(connection),
+) -> list[BeneficiaryCsvRowResponse]:
+    deployment_id: UUID = UUID(request.state.deployment_id)
+    io = create_io(db)
+    create_line_import = partial(to_line_import, data.need_orientation, deployment_id)
+    result = [
+        await import_beneficiary(db, create_line_import(beneficiary), io)
+        for beneficiary in data.beneficiaries
+    ]
+    return result
+
+
+def to_line_import(
+    need_orientation: bool, deployment_id: UUID, beneficiary: BeneficiaryImport
+):
+    return LineImport(
+        beneficiary=beneficiary,
+        deployment_id=deployment_id,
+        need_orientation=need_orientation,
+    )
+
+
+def create_io(db):
+    return IO(
+        get_beneficiaries_like=partial(get_beneficiaries_like, db),
+        insert_beneficiary=partial(insert_beneficiary, db),
+        insert_notebook=partial(insert_notebook, db),
+        insert_or_update_need_orientation=partial(
+            insert_or_update_need_orientation, db
+        ),
+        insert_professional_projects=partial(insert_professional_projects, db),
+        get_structure_by_name=partial(get_structure_by_name, db),
+        get_professional_by_email=partial(get_professional_by_email, db),
+        add_beneficiary_to_structure=partial(add_beneficiary_to_structure, db),
+        insert_notebook_member=partial(insert_notebook_member, db),
+        update_beneficiary=partial(update_beneficiary, db),
+        update_notebook=partial(update_notebook, db),
+    )
+
+
 async def import_beneficiary(
-    db: Connection,
-    beneficiary: BeneficiaryImport,
-    deployment_id: UUID,
-    need_orientation: bool,
+    db: Connection, line: LineImport, io: IO
 ) -> BeneficiaryCsvRowResponse:
     async with db.transaction():
-        try:
-            records: list[Beneficiary] = await get_beneficiaries_like(
-                db, beneficiary, deployment_id
+        return await handle_line_in_transaction(io, line)
+
+
+async def handle_line_in_transaction(
+    io: IO, line: LineImport
+) -> BeneficiaryCsvRowResponse:
+    try:
+        return await try_to_import_one(line, io)
+
+    except ImportFailError as error:
+        logging.error(error)
+        return to_error_response(line.beneficiary, error)
+    except Exception as error:
+        logging.exception("unhandled exception %s", error)
+        return to_error_response(line.beneficiary, "erreur_inconnue")
+
+
+async def try_to_import_one(line: LineImport, io: IO):
+    matching_beneficiaries: list[Beneficiary] = await io.get_beneficiaries_like(
+        line.beneficiary, line.deployment_id
+    )
+
+    if len(matching_beneficiaries) > 1:
+        return fail_for_more_than_one_match(line, matching_beneficiaries)
+
+    if len(matching_beneficiaries) == 0:
+        beneficiary_id = await create_beneficiary_with_notebook_and_referent(line, io)
+        logger.info("inserted new beneficiary %s", beneficiary_id)
+        return BeneficiaryCsvRowResponse(valid=True, data=line.beneficiary)
+
+    match = matching_beneficiaries[0]
+
+    if eq_personal_data(line.beneficiary, match) and eq_si_id(
+        line.beneficiary, line.deployment_id, match
+    ):
+        return await try_to_update_one(
+            line.beneficiary, line.need_orientation, match.id, io
+        )
+
+    if eq_si_id(line.beneficiary, line.deployment_id, match):
+        return await fail_for_conflicting_si_id(line, matching_beneficiaries)
+
+    if eq_personal_data(line.beneficiary, match):
+        return await fail_for_conflicting_personal_data(line, matching_beneficiaries)
+
+    raise ImportFailError(
+        "Erreur inconnue, on a trouvé un bénéficiaire "
+        "mais ni les données personnelles ni les SI IDs "
+        "ne correspondent"
+    )
+
+
+async def fail_for_conflicting_personal_data(line, matching_beneficiaries):
+    # same user info but different si_id
+    logger.info(
+        "block beneficiary creation as it is conflicting with existing "
+        "beneficiaries(same lastname / firstname / date of birth): %s",
+        [beneficiary.id for beneficiary in matching_beneficiaries],
+    )
+    return to_error_response(
+        line.beneficiary,
+        (
+            "Un bénéficiaire existe déjà avec ce nom/prénom/date "
+            "de naissance sur le territoire."
+        ),
+    )
+
+
+async def fail_for_conflicting_si_id(line, matching_beneficiaries):
+    logger.info(
+        "block beneficiary creation as it is conflicting with existing "
+        "beneficiaries(same id): %s",
+        [beneficiary.id for beneficiary in matching_beneficiaries],
+    )
+    return to_error_response(
+        line.beneficiary,
+        ("Un bénéficiaire existe déjà avec cet identifiant SI " "sur le territoire."),
+    )
+
+
+def fail_for_more_than_one_match(line, matching_beneficiaries):
+    logger.info(
+        "block beneficiary import, multiple beneficiaries found: %s",
+        [beneficiary.id for beneficiary in matching_beneficiaries],
+    )
+    return to_error_response(
+        line.beneficiary,
+        (
+            "Plusieurs bénéficiaires existent déjà avec ce nom/prénom/date "
+            "de naissance sur le territoire."
+        ),
+    )
+
+
+def contains_parens(value):
+    return "(" in value or ")" in value
+
+
+async def create_beneficiary_with_notebook_and_referent(
+    line: LineImport, io: IO
+) -> UUID:
+    beneficiary_id: UUID | None = await io.insert_beneficiary(
+        line.beneficiary, line.deployment_id
+    )
+
+    if not beneficiary_id:
+        raise ImportFailError("insert beneficiary failed")
+
+    new_notebook_id: UUID | None = await io.insert_notebook(
+        beneficiary_id, line.beneficiary
+    )
+
+    if not new_notebook_id:
+        raise ImportFailError("insert notebook failed")
+
+    await io.insert_or_update_need_orientation(
+        new_notebook_id, None, line.need_orientation
+    )
+
+    await io.insert_professional_projects(new_notebook_id, line.beneficiary)
+    await add_referent_and_structure_to_beneficiary(
+        beneficiary_id, new_notebook_id, line.beneficiary, line.deployment_id, io
+    )
+    logger.info("inserted new beneficiary %s", beneficiary_id)
+    return beneficiary_id
+
+
+async def add_referent_and_structure_to_beneficiary(
+    beneficiary_id: UUID,
+    notebook_id: UUID,
+    beneficiary: BeneficiaryImport,
+    deployment_id: UUID,
+    io: IO,
+):
+    structure = None
+    if beneficiary.structure_name:
+        structure = await io.get_structure_by_name(
+            beneficiary.structure_name, deployment_id
+        )
+        if structure is None:
+            logger.info(
+                "Trying to associate structure with beneficiary: "
+                'structure "%s" does not exist',
+                beneficiary.structure_name,
             )
-            if no_matching_beneficiary(records):
-                beneficiary_id = await create_beneficiary_with_notebook_and_referent(
-                    connection=db,
-                    beneficiary=beneficiary,
-                    deployment_id=deployment_id,
-                    need_orientation=need_orientation,
-                )
+            return
+    referent = None
+    if beneficiary.advisor_email:
+        referent: Professional | None = await io.get_professional_by_email(
+            beneficiary.advisor_email.strip()
+        )
+    if structure:
+        await io.add_beneficiary_to_structure(beneficiary_id, structure.id, "current")
+    elif referent:
+        await io.add_beneficiary_to_structure(
+            beneficiary_id, referent.structure_id, "current"
+        )
 
-                if not beneficiary_id:
-                    raise UpdateFailError(
-                        f"failed to insert beneficiary {records[0].id}"
-                    )
-
-                logger.info("inserted new beneficiary %s", beneficiary_id)
-                return BeneficiaryCsvRowResponse(valid=True, data=beneficiary)
-
-            elif one_matching_beneficiary(records, beneficiary, deployment_id):
-                beneficiary_id = await update_beneficiary(
-                    db, beneficiary, records[0].id
-                )
-                if not beneficiary_id:
-                    raise UpdateFailError(
-                        f"failed to insert beneficiary {records[0].id}"
-                    )
-                notebook_id: UUID | None = await update_notebook(
-                    db, beneficiary, beneficiary_id
-                )
-                if notebook_id:
-                    await insert_or_update_need_orientation(
-                        db, notebook_id, None, need_orientation
-                    )
-                    await insert_professional_projects(db, notebook_id, beneficiary)
-                logger.info("updated existing beneficiary %s", beneficiary_id)
-
-                return BeneficiaryCsvRowResponse(
-                    valid=True, update=True, data=beneficiary
-                )
-
-            elif same_si_id_but_different_user_info(
-                records, beneficiary, deployment_id
-            ):
-                logger.info(
-                    "block beneficiary creation as it is conflicting with existing "
-                    "beneficiaries(same id): %s",
-                    [beneficiary.id for beneficiary in records],
-                )
-                return BeneficiaryCsvRowResponse(
-                    row=beneficiary.dict(by_alias=True),
-                    errors=[
-                        CsvFieldError(
-                            error=(
-                                "Un bénéficiaire existe déjà avec cet identifiant SI "
-                                "sur le territoire."
-                            )
-                        )
-                    ],
-                    valid=False,
-                )
-            else:
-                # same user info but different si_id
-                logger.info(
-                    "block beneficiary creation as it is conflicting with existing "
-                    "beneficiaries(same lastname / firstname / date of birth): %s",
-                    [beneficiary.id for beneficiary in records],
-                )
-
-                return BeneficiaryCsvRowResponse(
-                    row=beneficiary.dict(by_alias=True),
-                    errors=[
-                        CsvFieldError(
-                            error=(
-                                "Un bénéficiaire existe déjà avec ce nom/prénom/date "
-                                "de naissance sur le territoire."
-                            )
-                        )
-                    ],
-                    valid=False,
-                )
-
-        except InsertFailError as error:
-            logging.error(error)
-            return BeneficiaryCsvRowResponse(
-                row=beneficiary.dict(by_alias=True),
-                errors=[
-                    CsvFieldError(
-                        error=f"import beneficiary {beneficiary.external_id}: {error}"
-                    )
-                ],
-                valid=False,
+    if referent and referent.account_id:
+        # Si on a pu récupérer le compte du référent fourni, on l'ajoute dans le
+        # groupe de suivi en tant que référent.
+        if not structure or structure.id == referent.structure_id:
+            referent_member = NotebookMemberInsert(
+                notebook_id=notebook_id,
+                account_id=referent.account_id,
+                member_type="referent",
             )
-        except UpdateFailError as error:
-            logging.error(error)
-            return BeneficiaryCsvRowResponse(
-                row=beneficiary.dict(by_alias=True),
-                errors=[
-                    CsvFieldError(
-                        error=f"import beneficiary {beneficiary.external_id}: {error}"
-                    )
-                ],
-                valid=False,
-            )
-        except Exception as error:
-            logging.error("unhandled exception %s", error)
-            return BeneficiaryCsvRowResponse(
-                row=beneficiary.dict(by_alias=True),
-                errors=[
-                    CsvFieldError(
-                        error=(
-                            f"import beneficiary {beneficiary.external_id}:"
-                            "erreur inconnue"
-                        )
-                    )
-                ],
-                valid=False,
-            )
+            await io.insert_notebook_member(referent_member)
+    else:
+        # Si un référent est fourni mais qu'on ne le connaît pas, on ne fait rien.
+        logger.info(
+            "trying to create referent: no account with email: %s",
+            beneficiary.advisor_email,
+        )
 
 
-def no_matching_beneficiary(records: list[Beneficiary]) -> bool:
-    return len(records) == 0
+def to_error_response(beneficiary, error):
+    return BeneficiaryCsvRowResponse(
+        row=beneficiary.dict(by_alias=True),
+        errors=[CsvFieldError(error=str(error))],
+        valid=False,
+    )
 
 
-def one_matching_beneficiary(
-    records: list[Beneficiary], beneficiary: BeneficiaryImport, deployment_id: UUID
-) -> bool:
-    if len(records) != 1:
-        return False
-    matching_beneficiary = records[0]
+async def try_to_update_one(beneficiary, need_orientation, target_id, io):
+    beneficiary_id = await io.update_beneficiary(beneficiary, target_id)
+    if not beneficiary_id:
+        raise ImportFailError(f"failed to update beneficiary {target_id}")
+    notebook_id: UUID | None = await io.update_notebook(beneficiary, beneficiary_id)
+    if notebook_id:
+        await io.insert_or_update_need_orientation(notebook_id, None, need_orientation)
+        await io.insert_professional_projects(notebook_id, beneficiary)
+    logger.info("updated existing beneficiary %s", beneficiary_id)
+    return BeneficiaryCsvRowResponse(valid=True, update=True, data=beneficiary)
 
+
+def eq_personal_data(beneficiary, matching_beneficiary):
     return (
         is_same_name(
             matching_beneficiary.firstname,
@@ -238,25 +389,11 @@ def one_matching_beneficiary(
             beneficiary.lastname,
         )
         and matching_beneficiary.date_of_birth == beneficiary.date_of_birth
-        and matching_beneficiary.external_id == beneficiary.external_id
-        and matching_beneficiary.deployment_id == deployment_id
     )
 
 
-def same_si_id_but_different_user_info(
-    records: list[Beneficiary], beneficiary: BeneficiaryImport, deployment_id: UUID
-) -> bool:
-    matching_beneficiary = records[0]
+def eq_si_id(beneficiary, deployment_id, matching_beneficiary):
     return (
         matching_beneficiary.external_id == beneficiary.external_id
         and matching_beneficiary.deployment_id == deployment_id
-        and not (
-            is_same_name(
-                matching_beneficiary.firstname,
-                beneficiary.firstname,
-                matching_beneficiary.lastname,
-                beneficiary.lastname,
-            )
-            and matching_beneficiary.date_of_birth == beneficiary.date_of_birth
-        )
     )

--- a/backend/cdb/api/v1/routers/structures.py
+++ b/backend/cdb/api/v1/routers/structures.py
@@ -4,7 +4,7 @@ from typing import Tuple
 from fastapi import APIRouter, BackgroundTasks, Depends, Request
 from pydantic import BaseModel, Field
 
-from cdb.api.core.exceptions import InsertFailError
+from cdb.api.core.exceptions import ImportFailError
 from cdb.api.core.init import connection
 from cdb.api.db.crud.admin_structure import (
     create_admin_structure_with_account,
@@ -62,7 +62,7 @@ async def create_structures(
                         map_input_row_to_structure_insert(structure_row, deployment_id),
                     )
                 if not structure:
-                    raise InsertFailError("insert structure failed")
+                    raise ImportFailError("insert structure failed")
 
                 # 2 Create admin structure if not exist
                 admin_structure: AdminStructure | None = (
@@ -90,7 +90,7 @@ async def create_structures(
                         ),
                     )
                     if not account_admin_tuple:
-                        raise InsertFailError("insert structure admin failed")
+                        raise ImportFailError("insert structure admin failed")
 
                     account, admin_structure = account_admin_tuple
                     if data.send_account_email:
@@ -115,10 +115,10 @@ async def create_structures(
                     structure_id=structure.id,
                 )
                 if not uuid:
-                    raise InsertFailError("add admin structure to structure failed")
+                    raise ImportFailError("add admin structure to structure failed")
 
                 response_row = StructureCsvRowResponse(valid=True, data=structure_row)
-        except InsertFailError as error:
+        except ImportFailError as error:
             logging.error(error)
             response_row = StructureCsvRowResponse(
                 row=structure_row.dict(),

--- a/backend/cdb/api/v1/routers/uploads.py
+++ b/backend/cdb/api/v1/routers/uploads.py
@@ -20,7 +20,7 @@ from pandas.core.series import Series
 from pydantic import ValidationError
 
 from cdb.api.core.emails import send_invitation_email
-from cdb.api.core.exceptions import InsertFailError
+from cdb.api.core.exceptions import ImportFailError
 from cdb.api.core.init import connection
 from cdb.api.db.crud.orientation_manager import create_orientation_manager_with_account
 from cdb.api.db.models.account import AccountDBWithAccessKey
@@ -97,7 +97,7 @@ async def create_upload_file(
             )
 
             if not account_manager_tuple:
-                raise InsertFailError("imsert orientation manager failed")
+                raise ImportFailError("insert orientation manager failed")
 
             account, _ = account_manager_tuple
             response_row: OrientationManagerResponseModel = map_row_response(
@@ -126,7 +126,7 @@ async def create_upload_file(
             response_row: OrientationManagerResponseModel = map_row_response(
                 row, valid=False, error=re.sub(r"\nDETAIL.*$", "", str(err))
             )
-        except InsertFailError as err:
+        except ImportFailError as err:
             logging.error("Import error: %s %s", type(err).__name__, err.args)
             response_row: OrientationManagerResponseModel = map_row_response(
                 row, valid=False, error="erreur inconnue"

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -628,6 +628,7 @@ test = ["pytest (>=6)"]
 name = "faker"
 version = "18.13.0"
 description = "Faker is a Python package that generates fake data for you."
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2176,4 +2177,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "581f2eccce24bbc4a1c6cb0992ac56a8a099ae8ceedbe436ca652b90c0b992a3"
+content-hash = "9aff202e26552fca491393e6c007e915756253b55eca8dfe54b7ce6d896efc5d"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,7 +47,7 @@ pytest-mock = "^3.7.0"
 pytest-testmon = "2.0.6"
 pytest-watch = "^4.2.0"
 approvaltests = "^8.2.5"
-faker = "^18.11.2"
+faker = "^18.13.0"
 
 [tool.ruff]
 select = [

--- a/backend/tests/api/test_beneficiaries.py
+++ b/backend/tests/api/test_beneficiaries.py
@@ -749,8 +749,8 @@ async def test_fails_when_the_matched_beneficiary_does_not_match_after_all():
 
     # Then
     assert response == error_response_with(
-        "Erreur inconnue, on a trouvé un bénéficiaire mais ni les données personnelles "
-        "ni les SI IDs ne correspondent",
+        "Un bénéficiaire existe déjà avec ce NIR sur le territoire. "
+        "Mais ni ses données personnelles ni son identifiant SI ne correspondent.",
         line,
     )
 

--- a/backend/tests/api/test_beneficiaries.py
+++ b/backend/tests/api/test_beneficiaries.py
@@ -226,7 +226,6 @@ async def test_update_beneficiary_with_different_capitalization_and_spacing(
             )
         )
 
-        assert "updated existing beneficiary" in caplog.text
         assert beneficiary_in_db is not None
         assert beneficiary_in_db.external_id == sophie_tifour_bad_caps.external_id
 

--- a/backend/tests/api/test_beneficiaries.py
+++ b/backend/tests/api/test_beneficiaries.py
@@ -1,14 +1,15 @@
 import json
 import logging
+import uuid
 from datetime import date
-from typing import List
 from unittest import mock
+from unittest.mock import AsyncMock
 
 import pytest
 from asyncpg import Record
 from asyncpg.connection import Connection
+from faker import Faker
 from httpx import AsyncClient
-from pydantic import BaseModel
 
 from cdb.api.db.crud.beneficiary import (
     get_beneficiary_from_personal_information,
@@ -16,7 +17,13 @@ from cdb.api.db.crud.beneficiary import (
 )
 from cdb.api.db.crud.professional import get_professional_by_email
 from cdb.api.db.crud.rome_code import get_rome_code_by_id
-from cdb.api.db.models.beneficiary import Beneficiary, BeneficiaryImport
+from cdb.api.db.models.beneficiary import (
+    Beneficiary,
+    BeneficiaryCsvRowResponse,
+    BeneficiaryImport,
+)
+from cdb.api.db.models.csv import CsvFieldError
+from cdb.api.v1.routers.beneficiaries import IO, LineImport, handle_line_in_transaction
 
 
 async def import_beneficiaries(
@@ -200,8 +207,8 @@ async def test_do_not_update_beneficiary_with_same_si_id_but_different_name(
     )
     assert beneficiary_in_db.mobile_number is None
     assert (
-        response.json()[0]["errors"][0]["error"]
-        == "Un bénéficiaire existe déjà avec cet identifiant SI sur le territoire."
+        "Un bénéficiaire existe déjà avec cet identifiant SI sur le territoire."
+        in response.json()[0]["errors"][0]["error"]
     )
 
 
@@ -587,8 +594,257 @@ async def test_no_structure_non_existing_referent(
     assert not beneficiary_in_db.notebook.members
 
 
-class ListOf(BaseModel):
-    __root__: List[BeneficiaryImport]
+def fake_io():
+    value = []
+    return IO(
+        get_beneficiaries_like=AsyncMock(return_value=value),
+        insert_beneficiary=AsyncMock(return_value=uuid.uuid4()),
+        insert_notebook=AsyncMock(return_value=uuid.uuid4()),
+        insert_or_update_need_orientation=AsyncMock(return_value=None),
+        insert_professional_projects=AsyncMock(return_value=None),
+        get_structure_by_name=AsyncMock(return_value=None),
+        get_professional_by_email=AsyncMock(return_value=None),
+        add_beneficiary_to_structure=AsyncMock(return_value=None),
+        insert_notebook_member=AsyncMock(return_value=None),
+        update_beneficiary=AsyncMock(AsyncMock(return_value=uuid.uuid4())),
+        update_notebook=AsyncMock(AsyncMock(return_value=uuid.uuid4())),
+    )
+
+
+class FakeBeneficiaryImport(BeneficiaryImport):
+    def __init__(
+        self,
+        external_id: str = "123",
+        firstname: str = "Harry",
+        lastname: str = "Covert",
+    ):
+        super().__init__(
+            external_id=external_id,
+            firstname=firstname,
+            lastname=lastname,
+            date_of_birth=date(1985, 7, 23),
+            place_of_birth="Paris",
+            mobile_number="0657912322",
+            email="harry.covert@caramail.fr",
+            address1="1 Rue des Champs",
+            address2="1er étage",
+            postal_code="12345",
+            city="Paris",
+            work_situation="recherche_emploi",
+            caf_number="1234567",
+            pe_number="654321L",
+            right_rsa="rsa_droit_ouvert_versable",
+            right_are="Oui",
+            right_ass="Non",
+            right_bonus="Non",
+            right_rqth="Non",
+            rome_code_description="Pontier élingueur / Pontière élingueuse (N1104)",
+            education_level="NV1",
+            structure_name="Pole Emploi Agence Livry-Gargnan",
+            advisor_email="dunord@pole-emploi.fr",
+            nir="185077505612323",
+        )
+
+
+async def test_fails_when_some_io_fails():
+    # Given
+    line = fake_line()
+    line.beneficiary.external_id = "my_external_id"
+
+    io = fake_io()
+    io.insert_beneficiary = AsyncMock(side_effect=Exception("oops"))
+
+    # When
+    response = await handle_line_in_transaction(io, line)
+
+    # Then
+    assert response == BeneficiaryCsvRowResponse(
+        row=line.beneficiary.dict(by_alias=True),
+        errors=[CsvFieldError(error="erreur_inconnue")],
+        valid=False,
+    )
+
+
+async def test_fails_when_inserting_the_new_beneficiary_returns_none():
+    # Given
+    line = fake_line()
+    line.beneficiary.external_id = "my_external_id"
+
+    io = fake_io()
+    io.insert_beneficiary = AsyncMock(return_value=None)
+
+    # When
+    response = await handle_line_in_transaction(io, line)
+
+    # Then
+    assert response == error_response_with("insert beneficiary failed", line)
+
+
+async def test_fails_when_inserting_the_new_notebook_returns_none():
+    # Given
+    line = fake_line()
+    line.beneficiary.external_id = "my_external_id"
+
+    io = fake_io()
+    io.insert_notebook = AsyncMock(return_value=None)
+
+    # When
+    response = await handle_line_in_transaction(io, line)
+
+    # Then
+    assert response == error_response_with("insert notebook failed", line)
+
+
+fake = Faker()
+
+
+def fake_beneficiary() -> Beneficiary:
+    return Beneficiary(
+        id=uuid.uuid4(),
+        email=None,
+        lastname=fake.last_name(),
+        firstname=fake.first_name(),
+        caf_number=None,
+        pe_number=None,
+        postal_code=None,
+        city=None,
+        address1=None,
+        address2=None,
+        mobile_number=None,
+        date_of_birth=fake.date_object(),
+        place_of_birth=None,
+        deployment_id=uuid.uuid4(),
+        deployment=None,
+        created_at=fake.date_time(),
+        updated_at=fake.date_time(),
+        external_id=None,
+        notebook=None,
+        # BRSA users may not have an account,
+        # (account is created on the first login attempt),
+        account_id=None,
+        nir=None,
+        pe_unique_import_id=None,
+        right_rsa=None,
+        right_are=False,
+        right_ass=False,
+        right_bonus=False,
+        rsa_closure_reason=None,
+        rsa_closure_date=None,
+        rsa_suspension_reason=None,
+        is_homeless=None,
+        subject_to_right_and_duty=None,
+    )
+
+
+async def test_fails_when_the_matched_beneficiary_does_not_match_after_all():
+    # Given
+    line = fake_line()
+    line.beneficiary.external_id = "my_external_id"
+
+    io = fake_io()
+    io.get_beneficiaries_like = AsyncMock(return_value=[fake_beneficiary()])
+
+    # When
+    response = await handle_line_in_transaction(io, line)
+
+    # Then
+    assert response == error_response_with(
+        "Erreur inconnue, on a trouvé un bénéficiaire mais ni les données personnelles "
+        "ni les SI IDs ne correspondent",
+        line,
+    )
+
+
+async def test_fails_when_another_beneficiary_exist_with_the_same_personal_data():
+    # Given
+    line = fake_line()
+    line.beneficiary.external_id = "my_external_id"
+
+    io = fake_io()
+    existing_beneficiary = a_beneficiary_matching_line(line)
+    existing_beneficiary.external_id = None
+    existing_beneficiary.deployment_id = uuid.uuid4()
+    io.get_beneficiaries_like = AsyncMock(return_value=[existing_beneficiary])
+
+    # When
+    response = await handle_line_in_transaction(io, line)
+
+    # Then
+    assert response == error_response_with(
+        "Un bénéficiaire existe déjà avec ce nom/prénom/date "
+        "de naissance sur le territoire.",
+        line,
+    )
+
+
+def a_beneficiary_matching_line(line):
+    existing_beneficiary = fake_beneficiary()
+    existing_beneficiary.lastname = line.beneficiary.lastname
+    existing_beneficiary.firstname = line.beneficiary.firstname
+    existing_beneficiary.date_of_birth = line.beneficiary.date_of_birth
+    existing_beneficiary.external_id = line.beneficiary.external_id
+    existing_beneficiary.deployment_id = line.deployment_id
+    return existing_beneficiary
+
+
+async def test_fails_when_updating_the_beneficiary_returns_none():
+    # Given
+    line = fake_line()
+    line.beneficiary.external_id = "my_external_id"
+
+    io = fake_io()
+    existing_beneficiary = a_beneficiary_matching_line(line)
+    io.get_beneficiaries_like = AsyncMock(return_value=[existing_beneficiary])
+
+    io.update_beneficiary = AsyncMock(return_value=None)
+
+    # When
+    response = await handle_line_in_transaction(io, line)
+
+    # Then
+    assert response == error_response_with(
+        f"failed to update " f"beneficiary {existing_beneficiary.id}", line
+    )
+
+
+async def test_fails_when_multiple_beneficiaries_matched():
+    # Given
+    line = fake_line()
+    line.beneficiary.external_id = "my_external_id"
+
+    io = fake_io()
+    existing_beneficiary = a_beneficiary_matching_line(line)
+    io.get_beneficiaries_like = AsyncMock(
+        return_value=[existing_beneficiary, fake_beneficiary()]
+    )
+
+    io.update_beneficiary = AsyncMock(return_value=None)
+
+    # When
+    response = await handle_line_in_transaction(io, line)
+
+    # Then
+    assert response == error_response_with(
+        "Plusieurs bénéficiaires existent déjà avec ce nom/prénom/date de naissance "
+        "sur le territoire.",
+        line,
+    )
+
+
+def error_response_with(error, line):
+    return BeneficiaryCsvRowResponse(
+        row=line.beneficiary.dict(by_alias=True),
+        errors=[CsvFieldError(error=str(error))],
+        valid=False,
+    )
+
+
+def fake_line():
+    return LineImport(
+        beneficiary=(FakeBeneficiaryImport()),
+        deployment_id=uuid.uuid4(),
+        need_orientation=False,
+    )
 
 
 sophie_tifour_bad_caps = BeneficiaryImport(
@@ -598,33 +854,7 @@ sophie_tifour_bad_caps = BeneficiaryImport(
     date_of_birth=date(1982, 2, 1),
 )
 
-
-harry_covert = BeneficiaryImport(
-    external_id="123",
-    firstname="Harry",
-    lastname="Covert",
-    date_of_birth=date(1985, 7, 23),
-    place_of_birth="Paris",
-    mobile_number="0657912322",
-    email="harry.covert@caramail.fr",
-    address1="1 Rue des Champs",
-    address2="1er étage",
-    postal_code="12345",
-    city="Paris",
-    work_situation="recherche_emploi",
-    caf_number="1234567",
-    pe_number="654321L",
-    right_rsa="rsa_droit_ouvert_versable",
-    right_are="Oui",
-    right_ass="Non",
-    right_bonus="Non",
-    right_rqth="Non",
-    rome_code_description="Pontier élingueur / Pontière élingueuse (N1104)",
-    education_level="NV1",
-    structure_name="Pole Emploi Agence Livry-Gargnan",
-    advisor_email="dunord@pole-emploi.fr",
-    nir="185077505612323",
-)
+harry_covert = FakeBeneficiaryImport()
 
 harry_covert_reimport = BeneficiaryImport(
     external_id="123",
@@ -675,7 +905,6 @@ harry_covert_with_caps_and_space = BeneficiaryImport(
     date_of_birth=date(1985, 7, 23),
     mobile_number="0657912322",
 )
-
 
 betty_bois = BeneficiaryImport(
     external_id="1234",

--- a/backend/tests/api/test_csv2json.py
+++ b/backend/tests/api/test_csv2json.py
@@ -1,4 +1,8 @@
+import os
+
 from httpx import AsyncClient
+
+from tests.conftest import test_dir
 
 
 async def test_parse_csv(
@@ -41,7 +45,8 @@ async def test_parse_csv_errors(
     test_client: AsyncClient,
     get_manager_jwt_93: str,
 ):
-    with open("tests/fixtures/import_beneficiaires_buggy.csv", "rb") as file:
+    path = os.path.join(test_dir, "fixtures", "import_beneficiaires_buggy.csv")
+    with open(path, "rb") as file:
         response = await test_client.post(
             "/v1/convert-file/beneficiaries",
             files={"upload_file": ("filename", file, "text/csv")},


### PR DESCRIPTION
## :wrench: Problème

Fixes #1833 

Les noms qui comportent des parenthèses (souvent pour des noms de jeune fille) empêchent la modification du carnet.

## :cake: Solution

Interdire les parenthèses lors de l'import. 


## :rotating_light:  Points d'attention / Remarques

Pas de migration, car les données en production ne comportent pas de parenthèses.

## :desert_island: Comment tester

Avec l'import excel, mettre des parenthèses dans un nom. La ligne est rejetée par l'import.

![image](https://github.com/gip-inclusion/carnet-de-bord/assets/2572543/f704423c-78d3-4fb7-804e-17d53ad61318)
