### PR TITLE
fix: rend le champ dateDeModification facultatif

### DIFF
--- a/backend/cdb/pe/models/dossier_individu_api.py
+++ b/backend/cdb/pe/models/dossier_individu_api.py
@@ -44,7 +44,7 @@ class Contrainte(BaseModel):
 
 class ContraintesIndividu(BaseModel):
     conseiller: str | None
-    dateDeModification: str
+    dateDeModification: str | None
     code: str
     libelle: str | None
     contraintes: list[Contrainte]


### PR DESCRIPTION
## :wrench: Problème

Le type du payload renvoyé par dossier individu génére une erreur. en effet le champ contrainteIndividuDta.dateDeModification est marqué comme obligatoire or ce dernier est parfois vide.

## :cake: Solution

On indique que le champs est facultatif dans le modele

## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester
 Pas de test (à voir si on a des exemple dans les données de recette)
