### PR TITLE
refactor: ajout d'une action Hasura pour les notebook_focus et notebook_target

### DIFF
--- a/app/__tests__/triggers/lastModifiedAt.test.ts
+++ b/app/__tests__/triggers/lastModifiedAt.test.ts
@@ -42,14 +42,14 @@ describe('lastModified trigger', () => {
 
 		// clean created focus
 		const mutation = `mutation deleteFocus {
-			delete_notebook_focus_by_pk(id: "${addFocusPayload.data.insert_notebook_focus_one.id}") { id }
+			delete_notebook_focus_by_pk(id: "${addFocusPayload.data.create_notebook_focus.id}") { id }
 		}`;
 		await graphqlAdmin(mutation);
 	});
 
 	it('should update notebook_member.lastModified when a target is added', async () => {
 		const addTargetMutation = fs.readFileSync(
-			path.join(__dirname, '../../src/lib/ui/ProNotebookTarget/', '_mutation.gql'),
+			path.join(__dirname, '../../src/lib/ui/ProNotebookTarget/', 'AddNotebookTarget.gql'),
 			'utf8'
 		);
 		const addTargetPayload = await graphqlPro(addTargetMutation, {
@@ -62,7 +62,7 @@ describe('lastModified trigger', () => {
 
 		// clean created target
 		const mutation = `mutation deleteTarget {
-			delete_notebook_target_by_pk(id: "${addTargetPayload.data.insert_notebook_target_one.id}") { id }
+			delete_notebook_target_by_pk(id: "${addTargetPayload.data.create_notebook_target.id}") { id }
 			delete_notebook_event(where: {event: {_contains: {event_label: "test"}}}) { affected_rows }
 		}`;
 		await graphqlAdmin(mutation);

--- a/app/__tests__/triggers/notebookEvent.test.ts
+++ b/app/__tests__/triggers/notebookEvent.test.ts
@@ -17,7 +17,7 @@ beforeAll(async () => {
 describe('notebook_event trigger', () => {
 	it('should create a new event when a target is added', async () => {
 		const addTargetMutation = fs.readFileSync(
-			path.join(__dirname, '../../src/lib/ui/ProNotebookTarget/', '_mutation.gql'),
+			path.join(__dirname, '../../src/lib/ui/ProNotebookTarget/', 'AddNotebookTarget.gql'),
 			'utf8'
 		);
 		const addTargetPayload = await graphqlPro(addTargetMutation, {
@@ -38,7 +38,7 @@ describe('notebook_event trigger', () => {
 		// clean created target
 		const mutation = `mutation deleteTarget {
 			delete_notebook_event_by_pk(id: "${id}") { id }
-		delete_notebook_target_by_pk(id: "${addTargetPayload.data.insert_notebook_target_one.id}") { id }
+			delete_notebook_target_by_pk(id: "${addTargetPayload.data.create_notebook_target.id}") { id }
 	}`;
 		await graphqlAdmin(mutation);
 	});

--- a/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusCreate.svelte
+++ b/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusCreate.svelte
@@ -14,8 +14,9 @@
 		openComponent.close();
 	}
 
-	const addNotebookFocusStore = operationStore(AddNotebookFocusDocument);
-	const addNotebookFocus = mutation(addNotebookFocusStore);
+	const addNotebookFocus = mutation(
+		operationStore(AddNotebookFocusDocument, null, { additionalTypenames: ['notebook_focus'] })
+	);
 
 	function initFormData() {
 		return {

--- a/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusDetails.svelte
+++ b/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusDetails.svelte
@@ -32,8 +32,12 @@
 		}
 	);
 	query(focusStore);
-	const deleteFocusStore = operationStore(DeleteNotebookFocusByIdDocument);
-	const deleteFocusMutation = mutation(deleteFocusStore);
+
+	const deleteFocusMutation = mutation(
+		operationStore(DeleteNotebookFocusByIdDocument, null, {
+			additionalTypenames: ['notebook_focus'],
+		})
+	);
 
 	$: focus = $focusStore.data?.focus;
 	$: targets = focus?.targets || [];

--- a/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusDetails.svelte
+++ b/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusDetails.svelte
@@ -55,8 +55,9 @@
 		});
 	}
 
-	const updateNotebookTargetStatusResult = operationStore(UpdateTargetStatusDocument);
-	const updateNotebookTargetStatus = mutation(updateNotebookTargetStatusResult);
+	const updateNotebookTargetStatus = mutation(
+		operationStore(UpdateTargetStatusDocument, null, { additionalTypenames: ['notebook_target'] })
+	);
 	let updateResult: OperationStore<UpdateTargetStatusMutation>;
 
 	let error: string;

--- a/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusUpdate.svelte
+++ b/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusUpdate.svelte
@@ -11,8 +11,9 @@
 
 	export let focus: Pick<NotebookFocus, 'id' | 'theme' | 'linkedTo'>;
 
-	const updateNotebookFocusStore = operationStore(UpdateNotebookFocusDocument);
-	const updateNotebookFocus = mutation(updateNotebookFocusStore);
+	const updateNotebookFocus = mutation(
+		operationStore(UpdateNotebookFocusDocument, null, { additionalTypenames: ['notebook_focus'] })
+	);
 
 	function initFormData() {
 		return {

--- a/app/src/lib/ui/ProNotebookFocus/_addNotebookFocus.gql
+++ b/app/src/lib/ui/ProNotebookFocus/_addNotebookFocus.gql
@@ -1,7 +1,5 @@
 mutation AddNotebookFocus($notebookId: uuid!, $theme: String!, $linkedTo: String!) {
-  insert_notebook_focus_one(
-    object: { notebookId: $notebookId, theme: $theme, linkedTo: $linkedTo }
-  ) {
+  create_notebook_focus(notebookId: $notebookId, theme: $theme, linkedTo: $linkedTo) {
     id
   }
 }

--- a/app/src/lib/ui/ProNotebookFocus/_deleteNotebookFocus.gql
+++ b/app/src/lib/ui/ProNotebookFocus/_deleteNotebookFocus.gql
@@ -1,5 +1,5 @@
 mutation DeleteNotebookFocusById($id: uuid!) {
-  delete_notebook_focus_by_pk(id: $id) {
+  remove_notebook_focus(id: $id) {
     id
   }
 }

--- a/app/src/lib/ui/ProNotebookFocus/_updateNotebookFocus.gql
+++ b/app/src/lib/ui/ProNotebookFocus/_updateNotebookFocus.gql
@@ -1,5 +1,5 @@
 mutation UpdateNotebookFocus($id: uuid!, $linkedTo: String!) {
-  update_notebook_focus_by_pk(pk_columns: { id: $id }, _set: { linkedTo: $linkedTo }) {
+  update_notebook_focus_link(id: $id, linkedTo: $linkedTo) {
     id
   }
 }

--- a/app/src/lib/ui/ProNotebookFocus/_updateTargetStatus.gql
+++ b/app/src/lib/ui/ProNotebookFocus/_updateTargetStatus.gql
@@ -1,5 +1,5 @@
 mutation UpdateTargetStatus($status: String!, $id: uuid!) {
-  updateStatus: update_notebook_target_by_pk(_set: { status: $status }, pk_columns: { id: $id }) {
+  update_notebook_target_status(status: $status, id: $id) {
     id
   }
 }

--- a/app/src/lib/ui/ProNotebookTarget/AddNotebookTarget.gql
+++ b/app/src/lib/ui/ProNotebookTarget/AddNotebookTarget.gql
@@ -1,0 +1,5 @@
+mutation AddNotebookTarget($focusId: uuid!, $target: String!) {
+  create_notebook_target(focusId: $focusId, target: $target) {
+    id
+  }
+}

--- a/app/src/lib/ui/ProNotebookTarget/ProNotebookTargetCreate.svelte
+++ b/app/src/lib/ui/ProNotebookTarget/ProNotebookTargetCreate.svelte
@@ -37,10 +37,11 @@
 	});
 	query(refTargetStore);
 
-	const addNotebookTargetStore = operationStore(AddNotebookTargetDocument, null, {
-		additionalTypenames: ['notebook_event'],
-	});
-	const addNotebookTarget = mutation(addNotebookTargetStore);
+	const addNotebookTarget = mutation(
+		operationStore(AddNotebookTargetDocument, null, {
+			additionalTypenames: ['notebook_event', 'notebook_target'],
+		})
+	);
 
 	function initFormData() {
 		return {

--- a/app/src/lib/ui/ProNotebookTarget/_mutation.gql
+++ b/app/src/lib/ui/ProNotebookTarget/_mutation.gql
@@ -1,5 +1,0 @@
-mutation AddNotebookTarget($focusId: uuid!, $target: String) {
-  insert_notebook_target_one(object: { focusId: $focusId, target: $target }) {
-    id
-  }
-}

--- a/backend/cdb/api/db/crud/notebook_focus.py
+++ b/backend/cdb/api/db/crud/notebook_focus.py
@@ -4,16 +4,19 @@ from datetime import datetime
 from typing import List
 from uuid import UUID
 
-from cdb.api.domain.contraintes import FocusDifferences, FocusToAdd
-from cdb.api.v1.payloads.notebook_focus import (CreatedNotebookFocus,
-                                                CreateNotebookFocusInput,
-                                                DeletedNotebookFocus,
-                                                DeleteNotebookFocusInput,
-                                                UpdatedNotebookFocus,
-                                                UpdateNotebookFocusInput)
 from gql import gql
 from gql.client import AsyncClientSession
 from pydantic import BaseModel
+
+from cdb.api.domain.contraintes import FocusDifferences, FocusToAdd
+from cdb.api.v1.payloads.notebook_focus import (
+    CreatedNotebookFocus,
+    CreateNotebookFocusInput,
+    DeletedNotebookFocus,
+    DeleteNotebookFocusInput,
+    UpdatedNotebookFocus,
+    UpdateNotebookFocusInput,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/cdb/api/db/crud/notebook_focus.py
+++ b/backend/cdb/api/db/crud/notebook_focus.py
@@ -8,7 +8,9 @@ from cdb.api.domain.contraintes import FocusDifferences, FocusToAdd
 from cdb.api.v1.payloads.notebook_focus import (CreatedNotebookFocus,
                                                 CreateNotebookFocusInput,
                                                 DeletedNotebookFocus,
-                                                DeleteNotebookFocusInput)
+                                                DeleteNotebookFocusInput,
+                                                UpdatedNotebookFocus,
+                                                UpdateNotebookFocusInput)
 from gql import gql
 from gql.client import AsyncClientSession
 from pydantic import BaseModel
@@ -148,3 +150,26 @@ async def delete_notebook_focus(
         },
     )
     return DeletedNotebookFocus(id=result["notebook_focus"]["id"])
+
+
+async def update_notebook_focus(
+    client: AsyncClientSession,
+    notebook_focus: UpdateNotebookFocusInput,
+) -> UpdatedNotebookFocus:
+    result = await client.execute(
+        gql(
+            """
+        mutation($id: uuid!, $linkedTo: String!) {
+          notebook_focus: update_notebook_focus_by_pk(
+                pk_columns: { id: $id },
+                _set: { linkedTo: $linkedTo }) {
+            id
+          }
+        }"""
+        ),
+        variable_values={
+            "id": notebook_focus.id,
+            "linkedTo": notebook_focus.linked_to,
+        },
+    )
+    return UpdatedNotebookFocus(id=result["notebook_focus"]["id"])

--- a/backend/cdb/api/db/crud/notebook_focus.py
+++ b/backend/cdb/api/db/crud/notebook_focus.py
@@ -6,7 +6,9 @@ from uuid import UUID
 
 from cdb.api.domain.contraintes import FocusDifferences, FocusToAdd
 from cdb.api.v1.payloads.notebook_focus import (CreatedNotebookFocus,
-                                                CreateNotebookFocusInput)
+                                                CreateNotebookFocusInput,
+                                                DeletedNotebookFocus,
+                                                DeleteNotebookFocusInput)
 from gql import gql
 from gql.client import AsyncClientSession
 from pydantic import BaseModel
@@ -126,3 +128,23 @@ async def insert_notebook_focus(
         },
     )
     return CreatedNotebookFocus(id=result["notebook_focus"]["id"])
+
+
+async def delete_notebook_focus(
+    client: AsyncClientSession,
+    notebook_focus: DeleteNotebookFocusInput,
+) -> DeletedNotebookFocus:
+    result = await client.execute(
+        gql(
+            """
+        mutation($notebookId: uuid!) {
+          notebook_focus: delete_notebook_focus_by_pk(id: $notebookId) {
+            id
+          }
+        }"""
+        ),
+        variable_values={
+            "notebookId": notebook_focus.id,
+        },
+    )
+    return DeletedNotebookFocus(id=result["notebook_focus"]["id"])

--- a/backend/cdb/api/db/crud/notebook_focus.py
+++ b/backend/cdb/api/db/crud/notebook_focus.py
@@ -1,13 +1,17 @@
 import json
+import logging
 from datetime import datetime
 from typing import List
 from uuid import UUID
 
+from cdb.api.domain.contraintes import FocusDifferences, FocusToAdd
+from cdb.api.v1.payloads.notebook_focus import CreateNotebookFocusInput
 from gql import gql
 from gql.client import AsyncClientSession
+from gql.dsl import DSLField, DSLSchema
 from pydantic import BaseModel
 
-from cdb.api.domain.contraintes import FocusDifferences, FocusToAdd
+logger = logging.getLogger(__name__)
 
 
 class TargetInsertInput(BaseModel):
@@ -98,3 +102,20 @@ async def add_remove_notebook_focuses(
             "target_ids_to_end": focus_differences.target_differences.target_ids_to_end,
         },
     )
+
+
+def get_insert_notebook_focus_mutation(
+    dsl_schema: DSLSchema,
+    notebook_focus: CreateNotebookFocusInput,
+) -> dict[str, DSLField]:
+    return {
+        "create_notebook_focus": (
+            dsl_schema.mutation_root.insert_notebook_focus_one.args(
+                object={
+                    "notebookId": notebook_focus.notebook_id,
+                    "theme": notebook_focus.theme,
+                    "linkedTo": notebook_focus.linked_to,
+                }
+            ).select(dsl_schema.notebook_focus.id)
+        ),
+    }

--- a/backend/cdb/api/db/crud/notebook_target.py
+++ b/backend/cdb/api/db/crud/notebook_target.py
@@ -6,6 +6,8 @@ from gql.client import AsyncClientSession
 from cdb.api.v1.payloads.notebook_target import (
     CreatedNotebookTarget,
     CreateNotebookTargetInput,
+    UpdatedNotebookTarget,
+    UpdateNotebookTargetStatusInput,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,3 +32,26 @@ async def insert_notebook_target(
         },
     )
     return CreatedNotebookTarget(id=result["notebook_target"]["id"])
+
+
+async def update_notebook_target_status(
+    client: AsyncClientSession,
+    notebook_target: UpdateNotebookTargetStatusInput,
+) -> UpdatedNotebookTarget:
+    result = await client.execute(
+        gql(
+            """
+        mutation($status: String!, $id: uuid!) {
+          notebook_target: update_notebook_target_by_pk(
+            _set: { status: $status },
+            pk_columns: { id: $id }) {
+             id
+            }
+        }"""
+        ),
+        variable_values={
+            "status": notebook_target.status,
+            "id": notebook_target.id,
+        },
+    )
+    return UpdatedNotebookTarget(id=result["notebook_target"]["id"])

--- a/backend/cdb/api/db/crud/notebook_target.py
+++ b/backend/cdb/api/db/crud/notebook_target.py
@@ -1,0 +1,32 @@
+import logging
+
+from gql import gql
+from gql.client import AsyncClientSession
+
+from cdb.api.v1.payloads.notebook_target import (
+    CreatedNotebookTarget,
+    CreateNotebookTargetInput,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def insert_notebook_target(
+    client: AsyncClientSession,
+    notebook_target: CreateNotebookTargetInput,
+) -> CreatedNotebookTarget:
+    result = await client.execute(
+        gql(
+            """
+        mutation($target: notebook_target_insert_input!){
+            notebook_target: insert_notebook_target_one(object:  $target) {id}
+        }"""
+        ),
+        variable_values={
+            "target": {
+                "focusId": notebook_target.focus_id,
+                "target": notebook_target.target,
+            }
+        },
+    )
+    return CreatedNotebookTarget(id=result["notebook_target"]["id"])

--- a/backend/cdb/api/v1/main.py
+++ b/backend/cdb/api/v1/main.py
@@ -6,6 +6,7 @@ from cdb.api.v1.routers import (
     csv2json,
     deployment,
     managers,
+    notebook_focus,
     notebooks_add_members,
     notebooks_create,
     notify_admin_structures,
@@ -68,6 +69,11 @@ api_router.include_router(
 )
 api_router.include_router(
     pe_dossier_individu.router, prefix="/notebooks", tags=["Notebooks"]
+)
+
+
+api_router.include_router(
+    notebook_focus.router, prefix="/notebook_focus", tags=["Notebook focuses"]
 )
 
 api_router.include_router(nps_rating.router, prefix="/nps-rating", tags=["NPS ratings"])

--- a/backend/cdb/api/v1/main.py
+++ b/backend/cdb/api/v1/main.py
@@ -7,6 +7,7 @@ from cdb.api.v1.routers import (
     deployment,
     managers,
     notebook_focus,
+    notebook_target,
     notebooks_add_members,
     notebooks_create,
     notify_admin_structures,
@@ -74,6 +75,10 @@ api_router.include_router(
 
 api_router.include_router(
     notebook_focus.router, prefix="/notebook_focus", tags=["Notebook focuses"]
+)
+
+api_router.include_router(
+    notebook_target.router, prefix="/notebook_target", tags=["Notebook targets"]
 )
 
 api_router.include_router(nps_rating.router, prefix="/nps-rating", tags=["NPS ratings"])

--- a/backend/cdb/api/v1/payloads/notebook_focus.py
+++ b/backend/cdb/api/v1/payloads/notebook_focus.py
@@ -1,0 +1,15 @@
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from cdb.api.v1.payloads.hasura_action import HasuraActionPayload
+
+
+class CreateNotebookFocusInput(BaseModel):
+    notebook_id: UUID = Field(alias="notebookId")
+    theme: str | None
+    linked_to: str | None = Field(alias="linkedTo")
+
+
+class CreateNotebookFocusActionPayload(HasuraActionPayload):
+    input: CreateNotebookFocusInput

--- a/backend/cdb/api/v1/payloads/notebook_focus.py
+++ b/backend/cdb/api/v1/payloads/notebook_focus.py
@@ -29,3 +29,16 @@ class DeleteNotebookFocusActionPayload(HasuraActionPayload):
 
 class DeletedNotebookFocus(BaseModel):
     id: UUID
+
+
+class UpdateNotebookFocusInput(BaseModel):
+    id: UUID
+    linked_to: str | None = Field(alias="linkedTo")
+
+
+class UpdateNotebookFocusActionPayload(HasuraActionPayload):
+    input: UpdateNotebookFocusInput
+
+
+class UpdatedNotebookFocus(BaseModel):
+    id: UUID

--- a/backend/cdb/api/v1/payloads/notebook_focus.py
+++ b/backend/cdb/api/v1/payloads/notebook_focus.py
@@ -13,3 +13,7 @@ class CreateNotebookFocusInput(BaseModel):
 
 class CreateNotebookFocusActionPayload(HasuraActionPayload):
     input: CreateNotebookFocusInput
+
+
+class CreatedNotebookFocus(BaseModel):
+    id: UUID

--- a/backend/cdb/api/v1/payloads/notebook_focus.py
+++ b/backend/cdb/api/v1/payloads/notebook_focus.py
@@ -17,3 +17,15 @@ class CreateNotebookFocusActionPayload(HasuraActionPayload):
 
 class CreatedNotebookFocus(BaseModel):
     id: UUID
+
+
+class DeleteNotebookFocusInput(BaseModel):
+    id: UUID
+
+
+class DeleteNotebookFocusActionPayload(HasuraActionPayload):
+    input: DeleteNotebookFocusInput
+
+
+class DeletedNotebookFocus(BaseModel):
+    id: UUID

--- a/backend/cdb/api/v1/payloads/notebook_target.py
+++ b/backend/cdb/api/v1/payloads/notebook_target.py
@@ -14,5 +14,18 @@ class CreateNotebookTargetActionPayload(HasuraActionPayload):
     input: CreateNotebookTargetInput
 
 
+class UpdateNotebookTargetStatusInput(BaseModel):
+    id: UUID
+    status: str
+
+
 class CreatedNotebookTarget(BaseModel):
+    id: UUID
+
+
+class UpdateNotebookTargetStatusActionPayload(HasuraActionPayload):
+    input: UpdateNotebookTargetStatusInput
+
+
+class UpdatedNotebookTarget(BaseModel):
     id: UUID

--- a/backend/cdb/api/v1/payloads/notebook_target.py
+++ b/backend/cdb/api/v1/payloads/notebook_target.py
@@ -1,0 +1,18 @@
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from cdb.api.v1.payloads.hasura_action import HasuraActionPayload
+
+
+class CreateNotebookTargetInput(BaseModel):
+    focus_id: UUID = Field(alias="focusId")
+    target: str
+
+
+class CreateNotebookTargetActionPayload(HasuraActionPayload):
+    input: CreateNotebookTargetInput
+
+
+class CreatedNotebookTarget(BaseModel):
+    id: UUID

--- a/backend/cdb/api/v1/routers/notebook_focus.py
+++ b/backend/cdb/api/v1/routers/notebook_focus.py
@@ -1,0 +1,45 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Request
+from gql.dsl import DSLMutation, DSLSchema, dsl_gql
+from pydantic import BaseModel
+
+from cdb.api.db.crud.notebook_focus import get_insert_notebook_focus_mutation
+from cdb.api.db.graphql.get_client import gql_client_backend_only
+from cdb.api.schema_gql import schema
+from cdb.api.v1.dependencies import verify_secret_token
+from cdb.api.v1.payloads.notebook_focus import CreateNotebookFocusActionPayload
+
+
+class CreatedNotebookFocus(BaseModel):
+    notebookId: UUID
+
+
+router = APIRouter(dependencies=[Depends(verify_secret_token)])
+
+
+@router.post("", status_code=201)
+async def create_notebook_focus(
+    _: Request,
+    payload: CreateNotebookFocusActionPayload,
+):
+    """
+    This endpoint aims to create a notebook focus
+    """
+    dsl_schema = DSLSchema(schema=schema)
+    """
+        we use and admin client to search a beneficiary from their nir
+        to be sure to find them.
+    """
+    async with gql_client_backend_only(
+        session_variables=payload.session_variables
+    ) as session:
+        mutation = get_insert_notebook_focus_mutation(
+            dsl_schema=dsl_schema,
+            notebook_focus=payload.input,
+        )
+        response = await session.execute(dsl_gql(DSLMutation(**mutation)))
+
+    return CreatedNotebookFocus(
+        notebookId=response["create_notebook_focus"]["notebook_focus"]["id"]
+    )

--- a/backend/cdb/api/v1/routers/notebook_focus.py
+++ b/backend/cdb/api/v1/routers/notebook_focus.py
@@ -1,6 +1,10 @@
 from fastapi import APIRouter, Depends, Request
 
-from cdb.api.db.crud.notebook_focus import delete_notebook_focus, insert_notebook_focus
+from cdb.api.db.crud.notebook_focus import (
+    delete_notebook_focus,
+    insert_notebook_focus,
+    update_notebook_focus,
+)
 from cdb.api.db.graphql.get_client import gql_client_backend_only
 from cdb.api.v1.dependencies import verify_secret_token
 from cdb.api.v1.payloads.notebook_focus import (
@@ -8,6 +12,8 @@ from cdb.api.v1.payloads.notebook_focus import (
     CreateNotebookFocusActionPayload,
     DeletedNotebookFocus,
     DeleteNotebookFocusActionPayload,
+    UpdatedNotebookFocus,
+    UpdateNotebookFocusActionPayload,
 )
 
 router = APIRouter(dependencies=[Depends(verify_secret_token)])
@@ -39,3 +45,17 @@ async def delete_notebook_focus_route(
         session_variables=payload.session_variables
     ) as session:
         return await delete_notebook_focus(session, payload.input)
+
+
+@router.post("/update", status_code=201, response_model=UpdatedNotebookFocus)
+async def update_notebook_focus_route(
+    _: Request,
+    payload: UpdateNotebookFocusActionPayload,
+):
+    """
+    This endpoint aims to update a notebook focus
+    """
+    async with gql_client_backend_only(
+        session_variables=payload.session_variables
+    ) as session:
+        return await update_notebook_focus(session, payload.input)

--- a/backend/cdb/api/v1/routers/notebook_focus.py
+++ b/backend/cdb/api/v1/routers/notebook_focus.py
@@ -1,24 +1,17 @@
-from uuid import UUID
-
 from fastapi import APIRouter, Depends, Request
-from gql.dsl import DSLMutation, DSLSchema, dsl_gql
-from pydantic import BaseModel
 
-from cdb.api.db.crud.notebook_focus import get_insert_notebook_focus_mutation
+from cdb.api.db.crud.notebook_focus import insert_notebook_focus
 from cdb.api.db.graphql.get_client import gql_client_backend_only
-from cdb.api.schema_gql import schema
 from cdb.api.v1.dependencies import verify_secret_token
-from cdb.api.v1.payloads.notebook_focus import CreateNotebookFocusActionPayload
-
-
-class CreatedNotebookFocus(BaseModel):
-    notebookId: UUID
-
+from cdb.api.v1.payloads.notebook_focus import (
+    CreatedNotebookFocus,
+    CreateNotebookFocusActionPayload,
+)
 
 router = APIRouter(dependencies=[Depends(verify_secret_token)])
 
 
-@router.post("", status_code=201)
+@router.post("", status_code=201, response_model=CreatedNotebookFocus)
 async def create_notebook_focus(
     _: Request,
     payload: CreateNotebookFocusActionPayload,
@@ -26,7 +19,6 @@ async def create_notebook_focus(
     """
     This endpoint aims to create a notebook focus
     """
-    dsl_schema = DSLSchema(schema=schema)
     """
         we use and admin client to search a beneficiary from their nir
         to be sure to find them.
@@ -34,12 +26,4 @@ async def create_notebook_focus(
     async with gql_client_backend_only(
         session_variables=payload.session_variables
     ) as session:
-        mutation = get_insert_notebook_focus_mutation(
-            dsl_schema=dsl_schema,
-            notebook_focus=payload.input,
-        )
-        response = await session.execute(dsl_gql(DSLMutation(**mutation)))
-
-    return CreatedNotebookFocus(
-        notebookId=response["create_notebook_focus"]["notebook_focus"]["id"]
-    )
+        return await insert_notebook_focus(session, payload.input)

--- a/backend/cdb/api/v1/routers/notebook_focus.py
+++ b/backend/cdb/api/v1/routers/notebook_focus.py
@@ -1,11 +1,13 @@
 from fastapi import APIRouter, Depends, Request
 
-from cdb.api.db.crud.notebook_focus import insert_notebook_focus
+from cdb.api.db.crud.notebook_focus import delete_notebook_focus, insert_notebook_focus
 from cdb.api.db.graphql.get_client import gql_client_backend_only
 from cdb.api.v1.dependencies import verify_secret_token
 from cdb.api.v1.payloads.notebook_focus import (
     CreatedNotebookFocus,
     CreateNotebookFocusActionPayload,
+    DeletedNotebookFocus,
+    DeleteNotebookFocusActionPayload,
 )
 
 router = APIRouter(dependencies=[Depends(verify_secret_token)])
@@ -19,11 +21,21 @@ async def create_notebook_focus(
     """
     This endpoint aims to create a notebook focus
     """
-    """
-        we use and admin client to search a beneficiary from their nir
-        to be sure to find them.
-    """
     async with gql_client_backend_only(
         session_variables=payload.session_variables
     ) as session:
         return await insert_notebook_focus(session, payload.input)
+
+
+@router.post("/delete", status_code=201, response_model=DeletedNotebookFocus)
+async def delete_notebook_focus_route(
+    _: Request,
+    payload: DeleteNotebookFocusActionPayload,
+):
+    """
+    This endpoint aims to delete a notebook focus
+    """
+    async with gql_client_backend_only(
+        session_variables=payload.session_variables
+    ) as session:
+        return await delete_notebook_focus(session, payload.input)

--- a/backend/cdb/api/v1/routers/notebook_target.py
+++ b/backend/cdb/api/v1/routers/notebook_target.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends, Request
+
+from cdb.api.db.crud.notebook_target import insert_notebook_target
+from cdb.api.db.graphql.get_client import gql_client_backend_only
+from cdb.api.v1.dependencies import verify_secret_token
+from cdb.api.v1.payloads.notebook_target import (
+    CreatedNotebookTarget,
+    CreateNotebookTargetActionPayload,
+)
+
+router = APIRouter(dependencies=[Depends(verify_secret_token)])
+
+
+@router.post("", status_code=201, response_model=CreatedNotebookTarget)
+async def create_notebook_target(
+    _: Request,
+    payload: CreateNotebookTargetActionPayload,
+):
+    """
+    This endpoint aims to create a notebook Target
+    """
+    """
+        we use and admin client to search a beneficiary from their nir
+        to be sure to find them.
+    """
+    async with gql_client_backend_only(
+        session_variables=payload.session_variables
+    ) as session:
+        return await insert_notebook_target(session, payload.input)

--- a/backend/cdb/api/v1/routers/notebook_target.py
+++ b/backend/cdb/api/v1/routers/notebook_target.py
@@ -1,11 +1,16 @@
 from fastapi import APIRouter, Depends, Request
 
-from cdb.api.db.crud.notebook_target import insert_notebook_target
+from cdb.api.db.crud.notebook_target import (
+    insert_notebook_target,
+    update_notebook_target_status,
+)
 from cdb.api.db.graphql.get_client import gql_client_backend_only
 from cdb.api.v1.dependencies import verify_secret_token
 from cdb.api.v1.payloads.notebook_target import (
     CreatedNotebookTarget,
     CreateNotebookTargetActionPayload,
+    UpdatedNotebookTarget,
+    UpdateNotebookTargetStatusActionPayload,
 )
 
 router = APIRouter(dependencies=[Depends(verify_secret_token)])
@@ -19,11 +24,23 @@ async def create_notebook_target(
     """
     This endpoint aims to create a notebook Target
     """
-    """
-        we use and admin client to search a beneficiary from their nir
-        to be sure to find them.
-    """
+
     async with gql_client_backend_only(
         session_variables=payload.session_variables
     ) as session:
         return await insert_notebook_target(session, payload.input)
+
+
+@router.post("/status", status_code=201, response_model=UpdatedNotebookTarget)
+async def update_notebook_target_status_route(
+    _: Request,
+    payload: UpdateNotebookTargetStatusActionPayload,
+):
+    """
+    This endpoint aims to update the status of a notebook Target
+    """
+
+    async with gql_client_backend_only(
+        session_variables=payload.session_variables
+    ) as session:
+        return await update_notebook_target_status(session, payload.input)

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -38,6 +38,12 @@ type Mutation {
 }
 
 type Mutation {
+  remove_notebook_focus(
+    id: uuid!
+  ): RemoveNotebookFocusOutput
+}
+
+type Mutation {
   update_notebook_target_status(
     status: String!
     id: uuid!
@@ -218,5 +224,9 @@ type CreateNotebookTargetOutput {
 }
 
 type UpdateNotebookTargetStatusOutput {
+  id: uuid!
+}
+
+type RemoveNotebookFocusOutput {
   id: uuid!
 }

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -13,6 +13,13 @@ type Mutation {
 }
 
 type Mutation {
+  create_notebook_target(
+    focusId: uuid!
+    target: String!
+  ): CreateNotebookTargetOutput
+}
+
+type Mutation {
   create_nps_rating(
     score: Int!
   ): NPSRatingOutput
@@ -196,5 +203,9 @@ type PoleEmploiDossierIndividuSituations {
 }
 
 type CreateNotebookFocusOutput {
+  id: uuid!
+}
+
+type CreateNotebookTargetOutput {
   id: uuid!
 }

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -44,6 +44,13 @@ type Mutation {
 }
 
 type Mutation {
+  update_notebook_focus_link(
+    id: uuid!
+    linkedTo: String!
+  ): UpdateNotebookFocusLink
+}
+
+type Mutation {
   update_notebook_target_status(
     status: String!
     id: uuid!
@@ -228,5 +235,9 @@ type UpdateNotebookTargetStatusOutput {
 }
 
 type RemoveNotebookFocusOutput {
+  id: uuid!
+}
+
+type UpdateNotebookFocusLink {
   id: uuid!
 }

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -38,6 +38,13 @@ type Mutation {
 }
 
 type Mutation {
+  update_notebook_target_status(
+    status: String!
+    id: uuid!
+  ): UpdateNotebookTargetStatusOutput
+}
+
+type Mutation {
   update_socio_pro(
     id: uuid!
     workSituation: String
@@ -207,5 +214,9 @@ type CreateNotebookFocusOutput {
 }
 
 type CreateNotebookTargetOutput {
+  id: uuid!
+}
+
+type UpdateNotebookTargetStatusOutput {
   id: uuid!
 }

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -5,6 +5,14 @@ type Mutation {
 }
 
 type Mutation {
+  create_notebook_focus(
+    notebookId: uuid!
+    theme: String!
+    linkedTo: String!
+  ): CreateNotebookFocusOutput
+}
+
+type Mutation {
   create_nps_rating(
     score: Int!
   ): NPSRatingOutput
@@ -185,4 +193,8 @@ type PoleEmploiDossierIndividuSituations {
   code: String!
   libelle: String!
   valeur: PoleEmploiSituationValeurEnum!
+}
+
+type CreateNotebookFocusOutput {
+  id: uuid!
 }

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -84,6 +84,18 @@ actions:
       - role: orientation_manager
       - role: admin_cdb
     comment: Remove notebook focus
+  - name: update_notebook_focus_link
+    definition:
+      kind: synchronous
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebook_focus/update'
+      headers:
+        - name: secret-token
+          value_from_env: ACTION_SECRET
+    permissions:
+      - role: professional
+      - role: orientation_manager
+      - role: admin_cdb
+    comment: Update a notebook focus link
   - name: update_notebook_target_status
     definition:
       kind: synchronous
@@ -212,4 +224,5 @@ custom_types:
     - name: CreateNotebookTargetOutput
     - name: UpdateNotebookTargetStatusOutput
     - name: RemoveNotebookFocusOutput
+    - name: UpdateNotebookFocusLink
   scalars: []

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -72,6 +72,17 @@ actions:
       - role: professional
       - role: orientation_manager
       - role: manager
+  - name: update_notebook_target_status
+    definition:
+      kind: synchronous
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebook_target/status'
+      headers:
+        - name: secret-token
+          value_from_env: ACTION_SECRET
+    permissions:
+      - role: professional
+      - role: orientation_manager
+      - role: admin_cdb
   - name: update_socio_pro
     definition:
       kind: synchronous
@@ -186,4 +197,5 @@ custom_types:
     - name: PoleEmploiDossierIndividuSituations
     - name: CreateNotebookFocusOutput
     - name: CreateNotebookTargetOutput
+    - name: UpdateNotebookTargetStatusOutput
   scalars: []

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -21,6 +21,18 @@ actions:
       - role: orientation_manager
       - role: admin_cdb
     comment: create_notebook_focus
+  - name: create_notebook_target
+    definition:
+      kind: synchronous
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebook_target'
+      headers:
+        - name: secret-token
+          value_from_env: ACTION_SECRET
+    permissions:
+      - role: professional
+      - role: orientation_manager
+      - role: admin_cdb
+    comment: create a notebook target
   - name: create_nps_rating
     definition:
       kind: synchronous
@@ -173,4 +185,5 @@ custom_types:
     - name: PoleEmploiDossierIndividuObjectifs
     - name: PoleEmploiDossierIndividuSituations
     - name: CreateNotebookFocusOutput
+    - name: CreateNotebookTargetOutput
   scalars: []

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -72,6 +72,18 @@ actions:
       - role: professional
       - role: orientation_manager
       - role: manager
+  - name: remove_notebook_focus
+    definition:
+      kind: synchronous
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebook_focus/delete'
+      headers:
+        - name: secret-token
+          value_from_env: ACTION_SECRET
+    permissions:
+      - role: professional
+      - role: orientation_manager
+      - role: admin_cdb
+    comment: Remove notebook focus
   - name: update_notebook_target_status
     definition:
       kind: synchronous
@@ -83,6 +95,7 @@ actions:
       - role: professional
       - role: orientation_manager
       - role: admin_cdb
+    comment: update_notebook_target_status
   - name: update_socio_pro
     definition:
       kind: synchronous
@@ -198,4 +211,5 @@ custom_types:
     - name: CreateNotebookFocusOutput
     - name: CreateNotebookTargetOutput
     - name: UpdateNotebookTargetStatusOutput
+    - name: RemoveNotebookFocusOutput
   scalars: []

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -9,6 +9,18 @@ actions:
     permissions:
       - role: manager
     comment: Notebook creation
+  - name: create_notebook_focus
+    definition:
+      kind: synchronous
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebook_focus'
+      headers:
+        - name: secret-token
+          value_from_env: ACTION_SECRET
+    permissions:
+      - role: professional
+      - role: orientation_manager
+      - role: admin_cdb
+    comment: create_notebook_focus
   - name: create_nps_rating
     definition:
       kind: synchronous
@@ -160,4 +172,5 @@ custom_types:
     - name: PoleEmploiDossierIndividuContraintes
     - name: PoleEmploiDossierIndividuObjectifs
     - name: PoleEmploiDossierIndividuSituations
+    - name: CreateNotebookFocusOutput
   scalars: []

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_focus.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_focus.yaml
@@ -46,6 +46,7 @@ insert_permissions:
         - notebook_id
         - created_at
         - linked_to
+      backend_only: true
   - role: orientation_manager
     permission:
       check:
@@ -64,6 +65,7 @@ insert_permissions:
         - linked_to
         - notebook_id
         - theme
+      backend_only: true
   - role: professional
     permission:
       check:
@@ -82,6 +84,7 @@ insert_permissions:
         - linked_to
         - notebook_id
         - theme
+      backend_only: true
 select_permissions:
   - role: admin_cdb
     permission:
@@ -198,6 +201,7 @@ update_permissions:
         - notebook_id
       filter: {}
       check: {}
+      backend_only: true
   - role: orientation_manager
     permission:
       columns:
@@ -212,6 +216,7 @@ update_permissions:
               - active:
                   _eq: true
       check: null
+      backend_only: true
   - role: professional
     permission:
       columns:
@@ -226,14 +231,27 @@ update_permissions:
               - active:
                   _eq: true
       check: null
+      backend_only: true
 delete_permissions:
   - role: orientation_manager
     permission:
       filter:
-        creator_id:
-          _eq: X-Hasura-User-Id
+        notebook:
+          members:
+            _and:
+              - account_id:
+                  _eq: X-Hasura-User-Id
+              - active:
+                  _eq: true
+      backend_only: true
   - role: professional
     permission:
       filter:
-        creator_id:
-          _eq: X-Hasura-User-Id
+        notebook:
+          members:
+            _and:
+              - account_id:
+                  _eq: X-Hasura-User-Id
+              - active:
+                  _eq: true
+      backend_only: true

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_target.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_target.yaml
@@ -41,6 +41,7 @@ insert_permissions:
         - focus_id
         - target
         - created_at
+      backend_only: true
   - role: orientation_manager
     permission:
       check:
@@ -59,6 +60,7 @@ insert_permissions:
         - focus_id
         - status
         - target
+      backend_only: true
   - role: professional
     permission:
       check:
@@ -77,6 +79,7 @@ insert_permissions:
         - focus_id
         - status
         - target
+      backend_only: true
 select_permissions:
   - role: admin_cdb
     permission:
@@ -193,6 +196,7 @@ update_permissions:
         - id
       filter: {}
       check: {}
+      backend_only: true
   - role: orientation_manager
     permission:
       columns:
@@ -207,6 +211,7 @@ update_permissions:
                 - active:
                     _eq: true
       check: null
+      backend_only: true
   - role: professional
     permission:
       columns:
@@ -221,3 +226,4 @@ update_permissions:
                 - active:
                     _eq: true
       check: null
+      backend_only: true

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -55,6 +55,10 @@ type CreateNotebookOutput {
   notebookId: uuid!
 }
 
+type CreateNotebookTargetOutput {
+  id: uuid!
+}
+
 """
 Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'.
 """
@@ -5503,6 +5507,9 @@ type mutation_root {
 
   """create_notebook_focus"""
   create_notebook_focus(linkedTo: String!, notebookId: uuid!, theme: String!): CreateNotebookFocusOutput
+
+  """create a notebook target"""
+  create_notebook_target(focusId: uuid!, target: String!): CreateNotebookTargetOutput
 
   """Create NPS Rating"""
   create_nps_rating(score: Int!): NPSRatingOutput

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -32,6 +32,10 @@ input Boolean_comparison_exp {
   _nin: [Boolean!]
 }
 
+type CreateNotebookFocusOutput {
+  id: uuid!
+}
+
 input CreateNotebookInput {
   address1: String
   address2: String
@@ -5496,6 +5500,9 @@ input manager_updates {
 type mutation_root {
   """Notebook creation"""
   create_notebook(notebook: CreateNotebookInput!): CreateNotebookOutput
+
+  """create_notebook_focus"""
+  create_notebook_focus(linkedTo: String!, notebookId: uuid!, theme: String!): CreateNotebookFocusOutput
 
   """Create NPS Rating"""
   create_nps_rating(score: Int!): NPSRatingOutput

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -153,6 +153,16 @@ enum PoleEmploiSituationValeurEnum {
   OUI
 }
 
+type RefreshNotebookSituationsFromPoleEmploiOutput {
+  data_has_been_updated: Boolean!
+  external_data_has_been_updated: Boolean!
+  has_pe_diagnostic: Boolean!
+}
+
+type RemoveNotebookFocusOutput {
+  id: uuid!
+}
+
 """
 Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'.
 """
@@ -7082,6 +7092,9 @@ type mutation_root {
     on_conflict: structure_orientation_system_on_conflict
   ): structure_orientation_system
 
+  """Remove notebook focus"""
+  remove_notebook_focus(id: uuid!): RemoveNotebookFocusOutput
+
   """
   update data of the table: "account"
   """
@@ -7941,6 +7954,8 @@ type mutation_root {
     """updates to execute, in order"""
     updates: [notebook_target_updates!]!
   ): [notebook_target_mutation_response]
+
+  """update_notebook_target_status"""
   update_notebook_target_status(id: uuid!, status: String!): UpdateNotebookTargetStatusOutput
 
   """

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -212,6 +212,10 @@ type UpdateNotebookFromPoleEmploiOutput {
   has_pe_diagnostic: Boolean!
 }
 
+type UpdateNotebookTargetStatusOutput {
+  id: uuid!
+}
+
 enum UpdateSocioProContractTypeEnum {
   """Apprentissage"""
   apprentissage
@@ -7937,6 +7941,7 @@ type mutation_root {
     """updates to execute, in order"""
     updates: [notebook_target_updates!]!
   ): [notebook_target_mutation_response]
+  update_notebook_target_status(id: uuid!, status: String!): UpdateNotebookTargetStatusOutput
 
   """
   update data of the table: "notebook_visit"

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -222,6 +222,10 @@ type UpdateNotebookFromPoleEmploiOutput {
   has_pe_diagnostic: Boolean!
 }
 
+type UpdateNotebookFocusLink {
+  id: uuid!
+}
+
 type UpdateNotebookTargetStatusOutput {
   id: uuid!
 }
@@ -7806,6 +7810,9 @@ type mutation_root {
     _set: notebook_focus_set_input
     pk_columns: notebook_focus_pk_columns_input!
   ): notebook_focus
+
+  """Update a notebook focus link"""
+  update_notebook_focus_link(id: uuid!, linkedTo: String!): UpdateNotebookFocusLink
 
   """
   update multiples rows of table: "notebook_focus"

--- a/scripts/launch_tests.sh
+++ b/scripts/launch_tests.sh
@@ -133,6 +133,9 @@ function start_backend() {
   >&2 echo ""
   >&2 echo "-> Python backend is up and running on port 8001!"
 }
+if [ "$ACTION" = "all" ] || [ "$ACTION" = "js" ] || [ "$ACTION" = "e2e" ]; then
+	start_backend
+fi
 
 if [ "$ACTION" = "all" ] || [ "$ACTION" = "js" ]; then
   >&2 echo "-> Starting js tests"
@@ -146,7 +149,6 @@ fi
 
 if [ "$ACTION" = "all" ] || [ "$ACTION" = "e2e" ]; then
   start_svelte
-  start_backend
 
   >&2 echo "-> Starting e2e tests"
   HASURA_BASEURL=http://localhost:5001 \


### PR DESCRIPTION
## :wrench: Problème

Actuellement les Axes de travail (focus) et les Objectifs (target) sont créés directement par le frontend via une mutation Hasura ce qui rend impossible la synchronisation avec Pôle emploi.

- [x] création des objectifs
- [x] création d'axe de travail
- [x] modification d'un objectif
- [x] suppression d'un axe de travail
- [x] modification d'un axe de travail

fix #1887 

## :cake: Solution

On utilise une action Hasura et un endpoint Python qui vont nous permettre plus tard de brancher la synchro PE.


## :rotating_light:  Points d'attention / Remarques

Même si la PR est un peu longue, le principe pour chaque `focus`, `target` et chaque `action` Hasura est le même. On rajoute une action Hasura et les types associés. On remplace la requête GraphQL côté client par l'appel à cette action, cette action forward vers un nouveau endpoint python. Dans ce endpoint Python on crée les objets Pydantic nécessaires pour mapper les input, et on fait appel à la requête qui était originalement appelée dans le front.

L'action hasura de `delete` d'un notebook focus s'appelle `remove` car Hasura n'acceptait pas que je l'appelle `delete_notebook_focus` à cause d'un conflit de nommage interne.

On passe aussi les permissions en update / insert / delete en Backend only pour qu'ils ne puissent plus être appelés du Front.

## :desert_island: Comment tester

S'assurer que la création d'axes de travail et d'objectifs fonctionne toujours normalement.

:warning: __Bien tester tous les types de manipulations__ que l'on pouvait faire sur les objectifs et les axes de travail pour s'assurer que le passage en backend only n'a rien cassé.
