### PR TITLE
chore(nix): 🧑‍💻 gère les versions des outils avec asdf 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,17 @@ if command -v nix-shell &> /dev/null ; then
 		source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
 	fi
 	use flake
+
+	# Add asdf tools to path
+	ASDF_CONF=$(dirname $(dirname $(which asdf)))/share/asdf-vm
+	if command -v fish_config &> /dev/null ; then
+		source $ASDF_CONF/asdf.fish
+	else
+		source $ASDF_CONF/asdf.sh
+	fi
 fi
+
+
 
 # Source the poetry env to enable import resolution in vim and vscode
 poetry_env=$(cd backend && poetry env list --full-path | cut -d " " -f 1)

--- a/flake.nix
+++ b/flake.nix
@@ -19,10 +19,8 @@
             pkg-config
           ];
           packages = with pkgs; [
-            nodejs_20
-            python311
+            asdf-vm
             pre-commit
-            poetry
             gnumake
             tmux
             postgresql_15


### PR DESCRIPTION
## :wrench: Problème

Nix ne permet pas de fixer les versions des outils (de manière simple et lisible). Les versions des outils nix sont décidées par la [release Nix en cours](https://search.nixos.org/packages).

## :cake: Solution

Utiliser [ASDF](https://asdf-vm.com/) en complément de nix pour la gestion précise des versions. L'outil a déjà une configuration présente dans le projet. 

## :rotating_light:  Points d'attention / Remarques

Pour lier nix et asdf on passe par le chargement d'un fichier asdf dans le .envrc (en fonction du shell).

## :desert_island: Comment tester

```bash
cd carnet-de-bord
which node # $HOME/.asdf/shims/node
which poetry # $HOME/.asdf/shims/poetry
```