### PR TITLE
chore(e2e): ignore un test e2e non fiable

### DIFF
--- a/e2e/features/home.feature
+++ b/e2e/features/home.feature
@@ -10,16 +10,17 @@ Scénario: Home CdB
 	Alors je vois "Bienvenue sur Carnet de bord !"
 	Alors le lien "Accéder à mon compte" pointe sur "/auth/login"
 
-Scénario: Demande de consentement
-	Soit un utilisateur sur la page d'accueil
-	Alors je vois "Ce site utilise des cookies pour offrir une expérience optimale de support et vous donne le contrôle si vous souhaitez l'activer"
- 	Quand je clique sur "Personnaliser"
-	# Pour une raison inconnue, on doit faire une deuxiement click
-	# dans codecept pour que la fenetre s'ouvre.
- 	Quand je clique sur "Personnaliser"
-	Alors je vois "Préférences pour tous les services"
-	Alors je clique sur "Tout accepter"
-	Alors je ne vois pas "Ce site utilise des cookies pour offrir une expérience optimale de support et vous donne le contrôle si vous souhaitez l'activer"
-	Soit un "pro" authentifié pour la première fois avec l'email "pierre.chevalier@livry-gargan.fr"
-	Quand je clique sur "Ouvrir le chat"
-	Alors je vois "Comment puis-je vous aider"
+# TODO: HMP 2023-07-24 - trouver pourquoi ce test n'est pas déterministe
+# Scénario: Demande de consentement
+# 	Soit un utilisateur sur la page d'accueil
+# 	Alors je vois "Ce site utilise des cookies pour offrir une expérience optimale de support et vous donne le contrôle si vous souhaitez l'activer"
+#  	Quand je clique sur "Personnaliser"
+# 	# Pour une raison inconnue, on doit faire une deuxiement click
+# 	# dans codecept pour que la fenetre s'ouvre.
+#  	Quand je clique sur "Personnaliser"
+# 	Alors je vois "Préférences pour tous les services"
+# 	Alors je clique sur "Tout accepter"
+# 	Alors je ne vois pas "Ce site utilise des cookies pour offrir une expérience optimale de support et vous donne le contrôle si vous souhaitez l'activer"
+# 	Soit un "pro" authentifié pour la première fois avec l'email "pierre.chevalier@livry-gargan.fr"
+# 	Quand je clique sur "Ouvrir le chat"
+# 	Alors je vois "Comment puis-je vous aider"


### PR DESCRIPTION
## :wrench: Problème

Le test end to end "Demande de consentement" est rouge presque systématiquement sur les PRs. En relançant le job il passe. Les PRs prennent plus de temps à être validées

## :cake: Solution

Ignorer le test. S'il donne trop de faux négatifs, il est néfaste. Je ne comprends pas bien pourquoi ça ne fonctionne pas, mais en attendant de trouver il serait bien d'avoir des résultats plus fiables.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester
Les checks doivent passer