### PR TITLE
feat(app): améliore le format des erreurs graphql

### DIFF
--- a/app/elm.json
+++ b/app/elm.json
@@ -10,6 +10,7 @@
         "direct": {
             "Confidenceman02/elm-select": "8.2.1",
             "Gizra/elm-debouncer": "2.0.0",
+            "ThinkAlexandria/elm-pretty-print-json": "1.0.1",
             "betagouv/elm-dsfr": "5.1.0",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
@@ -33,11 +34,13 @@
             "elm/file": "1.0.5",
             "elm/parser": "1.1.0",
             "elm/virtual-dom": "1.0.3",
+            "elm-community/basics-extra": "4.1.0",
             "elm-community/html-extra": "3.4.0",
             "elm-community/maybe-extra": "5.3.0",
             "robinheghan/murmur3": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
-            "tesk9/accessible-html": "6.1.0"
+            "tesk9/accessible-html": "6.1.0",
+            "the-sett/elm-pretty-printer": "2.2.3"
         }
     },
     "test-dependencies": {

--- a/app/elm/Diagnostic/AllSituations.elm
+++ b/app/elm/Diagnostic/AllSituations.elm
@@ -10,6 +10,7 @@ import Diagnostic.SyncWithPE
 import Domain.Account
 import Extra.GraphQL
 import GraphQL.Enum.Ref_theme_enum exposing (Ref_theme_enum(..))
+import Http
 import Maybe
 import Time
 
@@ -22,9 +23,9 @@ type alias DataSyncInfo =
 -- Synchronize
 
 
-syncWithPE : String -> (Result String DataSyncInfo -> msg) -> Cmd msg
+syncWithPE : String -> (Result Http.Error DataSyncInfo -> msg) -> Cmd msg
 syncWithPE notebookId responseMsg =
-    Extra.GraphQL.postOperation
+    Extra.GraphQL.send
         (Diagnostic.SyncWithPE.mutation { notebookId = notebookId })
         (Result.map
             (.update_notebook_from_pole_emploi
@@ -39,7 +40,6 @@ syncWithPE notebookId responseMsg =
                     , has_pe_diagnostic = False
                     }
             )
-            >> Result.mapError (always "graphql error!")
             >> responseMsg
         )
 
@@ -78,9 +78,9 @@ toDomainAccount { orientation_manager, professional } =
     }
 
 
-fetchByNotebookId : String -> (Result String (List PersonalSituation) -> msg) -> Cmd msg
+fetchByNotebookId : String -> (Result Http.Error (List PersonalSituation) -> msg) -> Cmd msg
 fetchByNotebookId notebookId responseMsg =
-    Extra.GraphQL.postOperation
+    Extra.GraphQL.send
         (Diagnostic.GetSituationsByNotebookId.query { notebookId = notebookId })
         (Result.map
             (.situations
@@ -102,6 +102,5 @@ fetchByNotebookId notebookId responseMsg =
                         }
                     )
             )
-            >> Result.mapError (always "graphql error!")
             >> responseMsg
         )

--- a/app/elm/Diagnostic/PersonalSituation.elm
+++ b/app/elm/Diagnostic/PersonalSituation.elm
@@ -7,6 +7,7 @@ import Extra.Date
 import GraphQL.Enum.Ref_theme_enum exposing (Ref_theme_enum)
 import Html exposing (Html)
 import Html.Attributes as Attr
+import Http
 import List.Extra
 import Sentry
 import UI.Spinner
@@ -56,8 +57,8 @@ init { notebookId } =
 
 
 type Msg
-    = FetchedSituations (Result String (List PersonalSituation))
-    | SyncedWithPE (Result String DataSyncInfo)
+    = FetchedSituations (Result Http.Error (List PersonalSituation))
+    | SyncedWithPE (Result Http.Error DataSyncInfo)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -66,7 +67,7 @@ update msg model =
         FetchedSituations result ->
             case result of
                 Err message ->
-                    ( model, Sentry.sendError message )
+                    ( model, Sentry.reportHttpError message )
 
                 Ok situations ->
                     ( { model | themes = groupByTheme situations }
@@ -77,7 +78,7 @@ update msg model =
             case result of
                 Err message ->
                     ( { model | refreshState = Failed }
-                    , Sentry.sendError message
+                    , Sentry.reportHttpError message
                     )
 
                 Ok { has_pe_diagnostic, data_has_been_updated } ->

--- a/app/elm/DiagnosticEdit/RomeSelect.elm
+++ b/app/elm/DiagnosticEdit/RomeSelect.elm
@@ -35,7 +35,7 @@ init props =
 
 getRome : SearchSelect.SearchApi
 getRome { search, callbackMsg } =
-    Extra.GraphQL.postOperation
+    Extra.GraphQL.send
         (DiagnosticEdit.SearchRomes.query { searchString = search })
         (Result.map .rome_codes >> callbackMsg)
 

--- a/app/elm/Effect.elm
+++ b/app/elm/Effect.elm
@@ -110,6 +110,6 @@ performAtomic effect =
             Task.perform msg Time.now
 
         GetDossierIndividu { notebookId, callbackMsg } ->
-            Extra.GraphQL.postOperation
+            Extra.GraphQL.send
                 (Pages.Carnet.Diagnostic.PoleEmploi.GetDiagnosticPE.getDiagnosticPE { notebookId = notebookId })
                 callbackMsg

--- a/app/elm/Extra/Http.elm
+++ b/app/elm/Extra/Http.elm
@@ -1,10 +1,10 @@
-module Extra.Http exposing (toString)
+module Extra.Http exposing (printError)
 
 import Http
 
 
-toString : Http.Error -> String
-toString error =
+printError : Http.Error -> String
+printError error =
     case error of
         Http.BadUrl url ->
             "URL invalide : " ++ url

--- a/app/elm/Extra/Result.elm
+++ b/app/elm/Extra/Result.elm
@@ -1,0 +1,11 @@
+module Extra.Result exposing (fold)
+
+
+fold : { onError : err -> a, onOk : ok -> a } -> Result err ok -> a
+fold { onError, onOk } result =
+    case result of
+        Ok ok ->
+            onOk ok
+
+        Err err ->
+            onError err

--- a/app/elm/NPSRating/Main.elm
+++ b/app/elm/NPSRating/Main.elm
@@ -64,7 +64,7 @@ main =
 
 getLastRatingDates : Cmd Msg
 getLastRatingDates =
-    Extra.GraphQL.postOperation
+    Extra.GraphQL.send
         NPSRating.GraphQL.latestNPSAnswers
         (Result.map
             (\data ->
@@ -86,7 +86,7 @@ submitRating : Model -> Cmd Msg
 submitRating model =
     case model.nps of
         Just score ->
-            Extra.GraphQL.postOperation
+            Extra.GraphQL.send
                 (NPSRating.GraphQL.createNpsRating { score = score })
                 (Result.map (always ()) >> RatingSent)
 
@@ -96,7 +96,7 @@ submitRating model =
 
 dismiss : Cmd Msg
 dismiss =
-    Extra.GraphQL.postOperation
+    Extra.GraphQL.send
         NPSRating.GraphQL.dismissNPS
         (Result.map (always ()) >> RatingSent)
 

--- a/app/elm/OrientationHome/Main.elm
+++ b/app/elm/OrientationHome/Main.elm
@@ -39,7 +39,7 @@ extractCount =
 
 getOrientationHomeInfos : String -> (Result Http.Error OrientationHomeInfos -> msg) -> Cmd msg
 getOrientationHomeInfos accountId toMsg =
-    Extra.GraphQL.postOperation
+    Extra.GraphQL.send
         (OrientationHome.GetBeneficiaryDashboard.query { id = accountId })
         (Result.map
             (\data ->

--- a/app/elm/Pages/Carnet/Diagnostic/PoleEmploi/Page.elm
+++ b/app/elm/Pages/Carnet/Diagnostic/PoleEmploi/Page.elm
@@ -5,7 +5,6 @@ import BetaGouv.DSFR.Alert
 import Domain.PoleEmploi.ContraintePersonnelle as ContraintePersonnelle
 import Effect exposing (Effect)
 import Extra.Date
-import Extra.Http
 import GraphQL.Enum.PoleEmploiBesoinValeurEnum as PoleEmploiBesoinValeurEnum exposing (PoleEmploiBesoinValeurEnum)
 import GraphQL.Enum.PoleEmploiContrainteValeurEnum as PoleEmploiContrainteValeurEnum
 import GraphQL.Enum.PoleEmploiObjectifValeurEnum as PoleEmploiObjectifValeurEnum
@@ -93,7 +92,7 @@ update msg model =
             of
                 Err error ->
                     ( Error "Erreur lors de la récupération du diagnostic France Travail."
-                    , Effect.fromCmd <| Sentry.sendError (Extra.Http.toString error)
+                    , Effect.fromCmd <| Sentry.reportHttpError error
                     )
 
                 Ok response ->

--- a/app/elm/Pages/Pro/Carnet/Action/List/ActionSelect.elm
+++ b/app/elm/Pages/Pro/Carnet/Action/List/ActionSelect.elm
@@ -63,7 +63,7 @@ apiSearch theme { search, callbackMsg } =
         refTheme =
             RefTheme.fromString theme |> Maybe.withDefault RefTheme.Logement
     in
-    Extra.GraphQL.postOperation
+    Extra.GraphQL.send
         (Pages.Pro.Carnet.Action.List.SearchRefAction.query { searchString = search })
         (Result.map
             (toOptions refTheme)

--- a/app/elm/Pages/Pro/Carnet/Action/List/AllActions.elm
+++ b/app/elm/Pages/Pro/Carnet/Action/List/AllActions.elm
@@ -2,6 +2,7 @@ module Pages.Pro.Carnet.Action.List.AllActions exposing (Action, Creator, fetchA
 
 import Extra.GraphQL
 import GraphQL.Enum.Action_status_enum
+import Http
 import Pages.Pro.Carnet.Action.List.GetActionsByTargetId
 import Time
 
@@ -19,44 +20,46 @@ type alias Creator =
     { firstName : String, lastName : String }
 
 
-fetchAllByTargetId : { id : String, responseMsg : Result String (List Action) -> msg } -> Cmd msg
+fetchAllByTargetId : { id : String, responseMsg : Result Http.Error (List Action) -> msg } -> Cmd msg
 fetchAllByTargetId { id, responseMsg } =
-    Extra.GraphQL.postOperation
+    Extra.GraphQL.send
         (Pages.Pro.Carnet.Action.List.GetActionsByTargetId.query { targetId = id })
-        (Result.map
-            (.target
-                >> Maybe.map .actions
-                >> Maybe.withDefault []
-                >> List.map
-                    (\action ->
-                        { id = action.id
-                        , description = action.action
-                        , status = action.status
-                        , startingAt =
-                            action.startingAt
-                        , creator =
-                            case ( action.creator.orientation_manager, action.creator.professional ) of
-                                ( Just om, _ ) ->
-                                    { firstName = Maybe.withDefault "" om.firstname
-                                    , lastName = Maybe.withDefault "" om.lastname
-                                    }
-
-                                ( _, Just pro ) ->
-                                    { firstName = pro.firstname
-                                    , lastName = pro.lastname
-                                    }
-
-                                _ ->
-                                    { firstName = ""
-                                    , lastName = ""
-                                    }
-                        }
-                    )
-                >> sortByStatus
-            )
-            >> Result.mapError (always "graphql error!")
+        (Result.map toActions
             >> responseMsg
         )
+
+
+toActions : { target : Maybe Pages.Pro.Carnet.Action.List.GetActionsByTargetId.Notebook_target } -> List Action
+toActions =
+    .target
+        >> Maybe.map .actions
+        >> Maybe.withDefault []
+        >> List.map
+            (\action ->
+                { id = action.id
+                , description = action.action
+                , status = action.status
+                , startingAt =
+                    action.startingAt
+                , creator =
+                    case ( action.creator.orientation_manager, action.creator.professional ) of
+                        ( Just om, _ ) ->
+                            { firstName = Maybe.withDefault "" om.firstname
+                            , lastName = Maybe.withDefault "" om.lastname
+                            }
+
+                        ( _, Just pro ) ->
+                            { firstName = pro.firstname
+                            , lastName = pro.lastname
+                            }
+
+                        _ ->
+                            { firstName = ""
+                            , lastName = ""
+                            }
+                }
+            )
+        >> sortByStatus
 
 
 sortByStatus : List Action -> List Action

--- a/app/elm/Pages/Pro/Carnet/Action/List/Main.elm
+++ b/app/elm/Pages/Pro/Carnet/Action/List/Main.elm
@@ -3,6 +3,7 @@ port module Pages.Pro.Carnet.Action.List.Main exposing (Flags, Model, Msg(..), R
 import BetaGouv.DSFR.Alert as Alert
 import Browser
 import Html
+import Http
 import Pages.Pro.Carnet.Action.List.ActionSelect as ActionSelect
 import Pages.Pro.Carnet.Action.List.AllActions as AllActions exposing (Action)
 import Pages.Pro.Carnet.Action.List.Page as Page
@@ -58,13 +59,13 @@ init flags =
 
 type Msg
     = ReadyMsg ReadyMsg
-    | LoadedActions (Result String (List Action))
+    | LoadedActions (Result Http.Error (List Action))
 
 
 type ReadyMsg
     = PageMsg Page.Msg
     | RefreshActions
-    | RefreshedActions (Result String (List Action))
+    | RefreshedActions (Result Http.Error (List Action))
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -91,7 +92,7 @@ update msg model =
                                 |> updateReady model
 
                         Err error ->
-                            ( { model | state = Failed }, Sentry.sendError error )
+                            ( { model | state = Failed }, Sentry.reportHttpError error )
 
         ( Loading, LoadedActions result ) ->
             case result of
@@ -106,7 +107,7 @@ update msg model =
 
                 Err error ->
                     ( { model | state = Failed }
-                    , Sentry.sendError error
+                    , Sentry.reportHttpError error
                     )
 
         _ ->

--- a/app/elm/Sentry.elm
+++ b/app/elm/Sentry.elm
@@ -1,4 +1,12 @@
-port module Sentry exposing (sendError)
+port module Sentry exposing (reportHttpError)
+
+import Extra.Http
+import Http
 
 
 port sendError : String -> Cmd msg
+
+
+reportHttpError : Http.Error -> Cmd msg
+reportHttpError =
+    Extra.Http.printError >> sendError

--- a/app/elm/UI/SearchSelect/SearchSelect.elm
+++ b/app/elm/UI/SearchSelect/SearchSelect.elm
@@ -4,7 +4,6 @@ module UI.SearchSelect.SearchSelect exposing (Mode(..), Model, Msg(..), Option, 
 -}
 
 import Debouncer.Messages as Debouncer exposing (debounce, fromSeconds, provideInput, toDebouncer)
-import Extra.Http
 import Html
 import Html.Attributes as Attr
 import Html.Events as Evts
@@ -185,7 +184,7 @@ update msg model =
 
                 Err httpError ->
                     ( { model | status = Failed }
-                    , Sentry.sendError <| Extra.Http.toString httpError
+                    , Sentry.reportHttpError httpError
                     )
 
         DebouncerMsg subMsg ->


### PR DESCRIPTION
## :wrench: Problème

Les erreurs graphql sont affichées dans Sentry comme suit : "graphql error !". Il est possible d'aller chercher le détail dans les logs. Cependant, le diagnostic pourrait être facilité avec plus de détails.

## :cake: Solution

Afficher la réponse en erreur dans Sentry. Exemple de sortie :
```
Error: Body invalide : [
  {
    "message": "field 'asdfasdfgorientation_manager' not found in type: 'account'",
    "locations": null,
    "path": null
  }
]
```

## :rotating_light:  Points d'attention / Remarques

Malheureusement, pour avoir cette réponse en erreur loggable, il a fallu la réencoder à partir du elm. Si on ne veut pas cette étape, il faudrait forker la librarie de génération.

## :desert_island: Comment tester

Il faut trouver une situation où une requête gql plante. Ça peut être compliqué. Pour forcer le cas, j'ai modifié à la main une requête générée dans le Elm.