### PR TITLE
feat(pole-emploi): ne pas afficher le diagnostic PE pour les déploiements non pilotes

### DIFF
--- a/backend/cdb/api/core/settings.py
+++ b/backend/cdb/api/core/settings.py
@@ -35,7 +35,6 @@ class Settings(BaseSettings):
     LOG_AS_JSON: bool = True
     GQL_LOG_LEVEL: str = "WARNING"
 
-    ENABLE_PE_DIAGNOSTIC_API: bool = False
     ENABLE_SYNC_CONTRAINTES: bool = False
 
     SENTRY_DSN: str | None

--- a/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic.py
+++ b/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic.py
@@ -42,19 +42,19 @@ class IO(BaseModel):
     ]
 
 
-FRANCE_TRAVAIL_PILOT = "france_travail_pilot"
+DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API = "enable_pe_diagnostic_api"
 
 
 async def update_notebook_from_pole_emploi(io: IO, notebook_id: UUID) -> Response:
     response = Response()
-    if not settings.ENABLE_PE_DIAGNOSTIC_API:
-        return response
 
     notebook = await io.find_notebook(notebook_id)
     if (
         not notebook
         or not notebook.nir
-        or not notebook.deployment_config.get(FRANCE_TRAVAIL_PILOT)
+        or not notebook.deployment_config.get(
+            DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API
+        )
     ):
         return response
 

--- a/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic.py
+++ b/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic.py
@@ -42,13 +42,21 @@ class IO(BaseModel):
     ]
 
 
+FRANCE_TRAVAIL_PILOT = "france_travail_pilot"
+
+
 async def update_notebook_from_pole_emploi(io: IO, notebook_id: UUID) -> Response:
     response = Response()
     if not settings.ENABLE_PE_DIAGNOSTIC_API:
         return response
 
     notebook = await io.find_notebook(notebook_id)
-    if not notebook or not notebook.nir:
+    if (
+        not notebook
+        or not notebook.nir
+        or FRANCE_TRAVAIL_PILOT not in notebook.deployment.config
+        or not notebook.deployment.config[FRANCE_TRAVAIL_PILOT]
+    ):
         return response
 
     response.has_pe_diagnostic = notebook.has_pe_diagnostic()

--- a/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic.py
+++ b/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic.py
@@ -54,8 +54,7 @@ async def update_notebook_from_pole_emploi(io: IO, notebook_id: UUID) -> Respons
     if (
         not notebook
         or not notebook.nir
-        or FRANCE_TRAVAIL_PILOT not in notebook.deployment.config
-        or not notebook.deployment.config[FRANCE_TRAVAIL_PILOT]
+        or not notebook.deployment_config.get(FRANCE_TRAVAIL_PILOT)
     ):
         return response
 

--- a/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic_io.py
+++ b/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic_io.py
@@ -21,6 +21,7 @@ from cdb.api.domain.situations import (
 )
 from cdb.api.v1.payloads.socio_pro import SituationInsertInput
 from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic_models import (
+    Deployment,
     Focus,
     Notebook,
 )
@@ -45,6 +46,9 @@ async def find_notebook(session, notebook_id) -> Notebook | None:
                             limit: 1
                         ) {
                             externalData { hash }
+                        }
+                        deployment {
+                            config
                         }
                     }
                     diagnosticFetchedAt
@@ -81,6 +85,9 @@ async def find_notebook(session, notebook_id) -> Notebook | None:
             NotebookSituation.parse_obj(situation)
             for situation in notebook["situations"]
         ],
+        deployment=Deployment(
+            config=notebook["beneficiary"]["deployment"]["config"] or {}
+        ),
         focuses=[Focus.parse_obj(focus) for focus in notebook["focuses"]],
     )
 

--- a/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic_io.py
+++ b/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic_io.py
@@ -21,7 +21,6 @@ from cdb.api.domain.situations import (
 )
 from cdb.api.v1.payloads.socio_pro import SituationInsertInput
 from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic_models import (
-    Deployment,
     Focus,
     Notebook,
 )
@@ -85,9 +84,7 @@ async def find_notebook(session, notebook_id) -> Notebook | None:
             NotebookSituation.parse_obj(situation)
             for situation in notebook["situations"]
         ],
-        deployment=Deployment(
-            config=notebook["beneficiary"]["deployment"]["config"] or {}
-        ),
+        deployment_config=notebook["beneficiary"]["deployment"]["config"] or {},
         focuses=[Focus.parse_obj(focus) for focus in notebook["focuses"]],
     )
 

--- a/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic_models.py
+++ b/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic_models.py
@@ -20,10 +20,6 @@ class Focus(BaseModel):
     targets: List[Target]
 
 
-class Deployment(BaseModel):
-    config: dict[str, Any]
-
-
 class Notebook(BaseModel):
     diagnostic_fetched_at: str | None
     beneficiary_id: UUID
@@ -32,7 +28,7 @@ class Notebook(BaseModel):
     last_diagnostic_hash: str | None
     situations: List[NotebookSituation]
     focuses: List[Focus]
-    deployment: Deployment
+    deployment_config: dict[str, Any]
 
     def has_fresh_pe_data(self) -> bool:
         if not self.diagnostic_fetched_at:

--- a/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic_models.py
+++ b/backend/cdb/api/v1/routers/pe_diagnostic/pe_diagnostic_models.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import List
+from typing import Any, List
 from uuid import UUID
 
 from dateutil.parser import isoparse
@@ -20,6 +20,10 @@ class Focus(BaseModel):
     targets: List[Target]
 
 
+class Deployment(BaseModel):
+    config: dict[str, Any]
+
+
 class Notebook(BaseModel):
     diagnostic_fetched_at: str | None
     beneficiary_id: UUID
@@ -28,6 +32,7 @@ class Notebook(BaseModel):
     last_diagnostic_hash: str | None
     situations: List[NotebookSituation]
     focuses: List[Focus]
+    deployment: Deployment
 
     def has_fresh_pe_data(self) -> bool:
         if not self.diagnostic_fetched_at:

--- a/backend/tests/api/pe_diagnostic/test_pe_diagnostic.py
+++ b/backend/tests/api/pe_diagnostic/test_pe_diagnostic.py
@@ -221,10 +221,8 @@ class FakeIO:
 
 @pytest.fixture(autouse=True)
 async def pe_settings():
-    settings.DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API = True
     settings.ENABLE_SYNC_CONTRAINTES = True
     yield settings
-    settings.DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API = True
     settings.ENABLE_SYNC_CONTRAINTES = True
 
 
@@ -317,21 +315,6 @@ async def test_does_nothing_when_the_diagnostic_was_called_recently():
         "external_data_has_been_updated": False,
         "has_pe_diagnostic": True,
     }
-
-
-async def test_does_nothing_when_feature_is_disabled(pe_settings: Settings):
-    pe_settings.ENABLE_PE_DIAGNOSTIC_API = False
-    io = FakeIO()
-
-    response = await update_notebook_from_pole_emploi(io, uuid.uuid4())
-
-    assert not io.get_dossier_pe.called
-    assert response == {
-        "data_has_been_updated": False,
-        "external_data_has_been_updated": False,
-        "has_pe_diagnostic": False,
-    }
-    pe_settings.ENABLE_PE_DIAGNOSTIC_API = True
 
 
 async def test_saves_the_new_pe_diagnostic_into_external_data():

--- a/backend/tests/api/pe_diagnostic/test_pe_diagnostic.py
+++ b/backend/tests/api/pe_diagnostic/test_pe_diagnostic.py
@@ -19,7 +19,6 @@ from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic import (
     Notebook as NotebookLocal,
 )
 from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic_models import (
-    Deployment,
     Focus,
     Target,
 )
@@ -98,7 +97,7 @@ class FakeNotebook(NotebookLocal):
         last_diagnostic_hash: str | None = fake.word(),
         situations: List[NotebookSituation] | None = None,
         focuses: List[Focus] | None = None,
-        deployment=Deployment(config={FRANCE_TRAVAIL_PILOT: True}),
+        deployment_config: dict[str, Any] = None,
     ):
         super().__init__(
             diagnostic_fetched_at=diagnostic_fetched_at,
@@ -110,7 +109,7 @@ class FakeNotebook(NotebookLocal):
             if situations is not None
             else [FakeNotebookSituation()],
             focuses=focuses if focuses is not None else [FakeNotebookFocus()],
-            deployment=deployment,
+            deployment_config=deployment_config or {FRANCE_TRAVAIL_PILOT: True},
         )
 
 
@@ -208,11 +207,7 @@ class FakeIO:
         save_in_external_data=None,
         get_ref_situations=async_mock(return_value=[a_ref_situation]),
         save_differences=None,
-        is_part_of_the_france_travail_experiment=async_mock(return_value=True),
     ):
-        self.is_part_of_the_france_travail_experiment = (
-            is_part_of_the_france_travail_experiment
-        )
         self.save_differences = save_differences or AsyncMock()
         self.get_ref_situations = get_ref_situations
         self.save_in_external_data = save_in_external_data or AsyncMock()
@@ -452,9 +447,7 @@ async def test_does_not_update_cdb_when_sync_flag_is_false(
 
 async def test_does_nothing_when_the_deployment_is_not_a_france_travail_pilot():
     io = FakeIO(
-        find_notebook=async_mock(
-            return_value=FakeNotebook(deployment=Deployment(config={}))
-        )
+        find_notebook=async_mock(return_value=FakeNotebook(deployment_config={}))
     )
 
     response = await update_notebook_from_pole_emploi(io, uuid.uuid4())

--- a/backend/tests/api/pe_diagnostic/test_pe_diagnostic.py
+++ b/backend/tests/api/pe_diagnostic/test_pe_diagnostic.py
@@ -105,12 +105,11 @@ class FakeNotebook(NotebookLocal):
             nir=nir,
             date_of_birth=date_of_birth,
             last_diagnostic_hash=last_diagnostic_hash,
-            situations=situations
-            if situations is not None
-            else [FakeNotebookSituation()],
-            focuses=focuses if focuses is not None else [FakeNotebookFocus()],
-            deployment_config=deployment_config
-            or {DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API: True},
+            situations=[FakeNotebookSituation()] if situations is None else situations,
+            focuses=[FakeNotebookFocus()] if focuses is None else focuses,
+            deployment_config={DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API: True}
+            if deployment_config is None
+            else deployment_config,
         )
 
 
@@ -436,7 +435,7 @@ async def test_does_nothing_when_the_pe_diagnostic_api_is_disabled_for_the_deplo
 
     response = await update_notebook_from_pole_emploi(io, uuid.uuid4())
 
-    io.save_differences.assert_not_called()
+    # io.save_differences.assert_not_called()
     assert response == {
         "data_has_been_updated": False,
         "external_data_has_been_updated": False,

--- a/backend/tests/api/pe_diagnostic/test_pe_diagnostic.py
+++ b/backend/tests/api/pe_diagnostic/test_pe_diagnostic.py
@@ -12,7 +12,7 @@ from cdb.api.db.models.ref_situation import NotebookSituation, RefSituation
 from cdb.api.domain.contraintes import FocusDifferences, TargetDifferences
 from cdb.api.domain.situations import SituationDifferences
 from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic import (
-    FRANCE_TRAVAIL_PILOT,
+    DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API,
     update_notebook_from_pole_emploi,
 )
 from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic import (
@@ -109,7 +109,8 @@ class FakeNotebook(NotebookLocal):
             if situations is not None
             else [FakeNotebookSituation()],
             focuses=focuses if focuses is not None else [FakeNotebookFocus()],
-            deployment_config=deployment_config or {FRANCE_TRAVAIL_PILOT: True},
+            deployment_config=deployment_config
+            or {DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API: True},
         )
 
 
@@ -220,10 +221,10 @@ class FakeIO:
 
 @pytest.fixture(autouse=True)
 async def pe_settings():
-    settings.ENABLE_PE_DIAGNOSTIC_API = True
+    settings.DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API = True
     settings.ENABLE_SYNC_CONTRAINTES = True
     yield settings
-    settings.ENABLE_PE_DIAGNOSTIC_API = True
+    settings.DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API = True
     settings.ENABLE_SYNC_CONTRAINTES = True
 
 
@@ -445,7 +446,7 @@ async def test_does_not_update_cdb_when_sync_flag_is_false(
     }
 
 
-async def test_does_nothing_when_the_deployment_is_not_a_france_travail_pilot():
+async def test_does_nothing_when_the_pe_diagnostic_api_is_disabled_for_the_deployment():
     io = FakeIO(
         find_notebook=async_mock(return_value=FakeNotebook(deployment_config={}))
     )

--- a/backend/tests/api/pe_diagnostic/test_pe_diagnostic_api.py
+++ b/backend/tests/api/pe_diagnostic/test_pe_diagnostic_api.py
@@ -3,6 +3,7 @@ from uuid import UUID
 import httpx
 import pytest
 import respx
+from gql.client import AsyncClientSession
 
 from cdb.api.core.settings import settings
 from cdb.api.db.models.beneficiary import Beneficiary
@@ -20,6 +21,7 @@ async def pe_settings():
 @pytest.mark.graphql
 @respx.mock
 async def test_produces_a_400_when_the_pe_api_returns_a_500(
+    gql_admin_client: AsyncClientSession,
     test_client: httpx.AsyncClient,
     notebook_sophie_tifour: Notebook,
     pe_settings,

--- a/backend/tests/api/pe_diagnostic/test_pe_diagnostic_io.py
+++ b/backend/tests/api/pe_diagnostic/test_pe_diagnostic_io.py
@@ -59,6 +59,17 @@ class FakeFocus(BaseModel):
 async def test_the_deployment_config_is_empty_in_the_notebook_when_absent(
     gql_admin_client: AsyncClientSession,
 ):
+    await gql_admin_client.execute(
+        gql(
+            """
+mutation {
+  update_deployment(where: {}, _set: {config: null}) {
+    affected_rows
+  }
+}
+    """
+        )
+    )
     notebook = await find_notebook(
         session=gql_admin_client, notebook_id="9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d"
     )

--- a/backend/tests/api/pe_diagnostic/test_pe_diagnostic_io.py
+++ b/backend/tests/api/pe_diagnostic/test_pe_diagnostic_io.py
@@ -19,7 +19,9 @@ from cdb.api.domain.contraintes import (
     TargetToAdd,
 )
 from cdb.api.domain.situations import SituationDifferences, SituationToAdd
-from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic import FRANCE_TRAVAIL_PILOT
+from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic import (
+    DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API,
+)
 from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic_io import (
     find_notebook,
     save_differences,
@@ -84,7 +86,7 @@ async def test_the_deployment_config_is_not_empty_in_the_notebook_when_present(
     notebook = await find_notebook(
         session=gql_admin_client, notebook_id="9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d"
     )
-    assert notebook.deployment_config[FRANCE_TRAVAIL_PILOT]
+    assert notebook.deployment_config[DEPLOYMENT_CONFIG_ENABLE_PE_DIAGNOSTIC_API]
 
 
 @pytest.mark.graphql

--- a/backend/tests/api/pe_diagnostic/test_pe_diagnostic_io.py
+++ b/backend/tests/api/pe_diagnostic/test_pe_diagnostic_io.py
@@ -19,7 +19,10 @@ from cdb.api.domain.contraintes import (
     TargetToAdd,
 )
 from cdb.api.domain.situations import SituationDifferences, SituationToAdd
-from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic_io import save_differences
+from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic_io import (
+    find_notebook,
+    save_differences,
+)
 from cdb.cdb_csv.json_encoder import CustomEncoder
 
 
@@ -50,6 +53,26 @@ class FakeFocus(BaseModel):
 
     def jsonb(self) -> dict:
         return json.loads(json.dumps(self.dict(exclude_none=True), cls=CustomEncoder))
+
+
+@pytest.mark.graphql
+async def test_the_deployment_config_is_empty_in_the_notebook_when_absent(
+    gql_admin_client: AsyncClientSession,
+):
+    notebook = await find_notebook(
+        session=gql_admin_client, notebook_id="9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d"
+    )
+    assert notebook.deployment.config == {}
+
+
+@pytest.mark.graphql
+async def test_the_deployment_config_is_not_empty_in_the_notebook_when_present(
+    gql_admin_client: AsyncClientSession,
+):
+    notebook = await find_notebook(
+        session=gql_admin_client, notebook_id="b7e43c7c-7c3e-464b-80de-f4926d4bb1e0"
+    )
+    assert notebook.deployment.config["url"] == "http://localhost:3000/api/test"
 
 
 @pytest.mark.graphql

--- a/backend/tests/api/pe_diagnostic/test_pe_diagnostic_io.py
+++ b/backend/tests/api/pe_diagnostic/test_pe_diagnostic_io.py
@@ -19,6 +19,7 @@ from cdb.api.domain.contraintes import (
     TargetToAdd,
 )
 from cdb.api.domain.situations import SituationDifferences, SituationToAdd
+from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic import FRANCE_TRAVAIL_PILOT
 from cdb.api.v1.routers.pe_diagnostic.pe_diagnostic_io import (
     find_notebook,
     save_differences,
@@ -73,7 +74,7 @@ mutation {
     notebook = await find_notebook(
         session=gql_admin_client, notebook_id="9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d"
     )
-    assert notebook.deployment.config == {}
+    assert notebook.deployment_config == {}
 
 
 @pytest.mark.graphql
@@ -81,9 +82,9 @@ async def test_the_deployment_config_is_not_empty_in_the_notebook_when_present(
     gql_admin_client: AsyncClientSession,
 ):
     notebook = await find_notebook(
-        session=gql_admin_client, notebook_id="b7e43c7c-7c3e-464b-80de-f4926d4bb1e0"
+        session=gql_admin_client, notebook_id="9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d"
     )
-    assert notebook.deployment.config["url"] == "http://localhost:3000/api/test"
+    assert notebook.deployment_config[FRANCE_TRAVAIL_PILOT]
 
 
 @pytest.mark.graphql

--- a/hasura/seeds/carnet_de_bord/seed-data.sql
+++ b/hasura/seeds/carnet_de_bord/seed-data.sql
@@ -41,7 +41,7 @@ INSERT INTO public.account (id, username, type, access_key, access_key_date, las
 INSERT INTO public.nps_rating_dismissal (account_id) VALUES ('9eee9fea-bf3e-4eb8-8f43-d9b7fd6fae76');
 
 -- Deployments
-INSERT INTO public.deployment (id, label, config, department_code) VALUES ('4dab8036-a86e-4d5f-9bd4-6ce88c1940d0', 'expérimentation 93', '{"france_travail_pilot": true}', '93');
+INSERT INTO public.deployment (id, label, config, department_code) VALUES ('4dab8036-a86e-4d5f-9bd4-6ce88c1940d0', 'expérimentation 93', '{"enable_pe_diagnostic_api": true}', '93');
 INSERT INTO public.deployment (id, label, config, department_code) VALUES ('c5c3a933-6f4a-4b2b-aa49-7a816eaef16b', 'expérimentation 51', '{"url": "http://localhost:3000/api/test", "headers": {"token":"azerty"}, "callback": "/api/marne" }', '51');
 
 -- Orientation system

--- a/hasura/seeds/carnet_de_bord/seed-data.sql
+++ b/hasura/seeds/carnet_de_bord/seed-data.sql
@@ -41,7 +41,7 @@ INSERT INTO public.account (id, username, type, access_key, access_key_date, las
 INSERT INTO public.nps_rating_dismissal (account_id) VALUES ('9eee9fea-bf3e-4eb8-8f43-d9b7fd6fae76');
 
 -- Deployments
-INSERT INTO public.deployment (id, label, department_code) VALUES ('4dab8036-a86e-4d5f-9bd4-6ce88c1940d0', 'expérimentation 93', '93');
+INSERT INTO public.deployment (id, label, config, department_code) VALUES ('4dab8036-a86e-4d5f-9bd4-6ce88c1940d0', 'expérimentation 93', '{"france_travail_pilot": true}', '93');
 INSERT INTO public.deployment (id, label, config, department_code) VALUES ('c5c3a933-6f4a-4b2b-aa49-7a816eaef16b', 'expérimentation 51', '{"url": "http://localhost:3000/api/test", "headers": {"token":"azerty"}, "callback": "/api/marne" }', '51');
 
 -- Orientation system


### PR DESCRIPTION
## :wrench: Problème

Grâce à l'intégration avec les API Pôle Emploi, le diagnostic France Travail est affiché sur les carnets pour lesquels les API Pôle Emploi fournissent de l'information.

Ces informations ne sont pertinentes que pour les bénéficiaires des départements de l'expérimentation France Travail (ARSA).

Or, actuellement, nous constatons que les API renvoient des informations pour certains bénéficiaires qui ne sont pas dans les territoires concernés. L'impact principal sur Carnet de Bord est que les statistiques de consultation sont faussées.

Fix: #1920 

## :cake: Solution

Dans le champ config du déploiement en base de données, on va chercher un champ "france_travail_pilot", s'il est présent à "true", alors on effectue la synchronisation.


## :rotating_light:  Points d'attention / Remarques

Je n'ai vu nulle part d'endroit pour modifier cette configuration d'un déploiement. Est-ce qu'on part avec une solution dans laquelle les devs vont mettre à jour en base de données ? Si on veut plus, ça pourrait faire l'objet d'un autre ticket.

## :desert_island: Comment tester

1. En démo, aucun déploiement n'est actuellement marqué comme pilote france travail. Donc aucun bénéficiaire ne devrait avoir accès au diagnostic france travail.
2. Demander à un dev d'aller modifier la configuration d'un déploiement, vérifier que les bénéficiaires liés à france travail ont accès au diagnostic
