### PR TITLE
feat(KPI): suivre les modification d'un carnet

### DIFF
--- a/e2e/integration/manager/orientationImport.js
+++ b/e2e/integration/manager/orientationImport.js
@@ -48,10 +48,12 @@ Scenario('Changement de référent', async () => {
 	const result = await getResultsForBeneficiary('Herring');
 	assert.deepEqual(
 		[
-			{ status: 'outdated', structure: { name: 'Service Social Départemental' } },
 			{ status: 'current', structure: { name: 'Groupe NS' } },
+			{ status: 'outdated', structure: { name: 'Service Social Départemental' } },
 		],
-		result.data.data.notebook[0]?.beneficiary.structures,
+		result.data.data.notebook[0]?.beneficiary.structures.sort((a, b) =>
+			a.structure.name.localeCompare(b.structure.name)
+		),
 		'beneficiary_structure not match'
 	);
 	assert.deepEqual(

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_updates_track.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_updates_track.yaml
@@ -1,0 +1,3 @@
+table:
+  name: notebook_updates_track
+  schema: public

--- a/hasura/metadata/databases/carnet_de_bord/tables/tables.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/tables.yaml
@@ -24,6 +24,7 @@
 - "!include public_notebook_public_view.yaml"
 - "!include public_notebook_situation.yaml"
 - "!include public_notebook_target.yaml"
+- "!include public_notebook_updates_track.yaml"
 - "!include public_notebook_visit.yaml"
 - "!include public_nps_rating.yaml"
 - "!include public_nps_rating_dismissal.yaml"

--- a/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/down.sql
+++ b/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/down.sql
@@ -1,0 +1,100 @@
+DROP TABLE "public"."notebook_updates_track";
+
+-- Delete new triggers
+
+DROP TRIGGER track_notebook_beneficiary_updates ON public.beneficiary;
+DROP TRIGGER track_notebook_appointment_updates ON public.notebook_appointment;
+DROP TRIGGER track_notebook_situation_updates ON public.notebook_situation;
+
+DROP FUNCTION public.notebook_beneficiary_modification_date();
+DROP FUNCTION public.notebook_appointment_modification_date();
+DROP FUNCTION public.notebook_situation_modification_date();
+
+-- Restore old triggers
+
+CREATE OR REPLACE FUNCTION public.notebook_modification_date()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS
+$$
+DECLARE
+  session_variables json;
+  account uuid;
+BEGIN
+  session_variables := current_setting('hasura.user', 't');
+  IF session_variables IS NOT NULL then
+    account := session_variables ->> 'x-hasura-user-id';
+    IF account IS NOT NULL then
+      UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id=NEW.id AND account_id = account;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.notebook_focus_modification_date()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS
+$$
+DECLARE
+  session_variables json;
+  account uuid;
+BEGIN
+  session_variables := current_setting('hasura.user', 't');
+  IF session_variables IS NOT NULL then
+    account := session_variables ->> 'x-hasura-user-id';
+    IF account IS NOT NULL then
+      UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id=NEW.notebook_id AND account_id = account;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.notebook_target_modification_date()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS
+$$
+DECLARE
+  session_variables json;
+  account uuid;
+  notebook uuid;
+BEGIN
+  session_variables := current_setting('hasura.user', 't');
+  IF session_variables IS NOT NULL then
+    account := session_variables ->> 'x-hasura-user-id';
+    IF account IS NOT NULL then
+      SELECT focus.notebook_id into notebook FROM public.notebook_focus as focus where focus.id = NEW.focus_id;
+      UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id=notebook AND account_id = account;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.notebook_action_modification_date()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS
+$$
+DECLARE
+  session_variables json;
+  account uuid;
+  notebook uuid;
+  focus uuid;
+BEGIN
+  session_variables := current_setting('hasura.user', 't');
+  IF session_variables IS NOT NULL then
+    account := session_variables ->> 'x-hasura-user-id';
+    IF account IS NOT NULL then
+      SELECT focus_id into focus FROM public.notebook_target where id = NEW.target_id;
+      SELECT notebook_id into notebook FROM public.notebook_focus where id = focus;
+      UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id=notebook AND account_id = account;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;

--- a/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
+++ b/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
@@ -41,7 +41,7 @@ END ;
 $$;
 
 CREATE TRIGGER track_notebook_beneficiary_updates
-	AFTER INSERT OR UPDATE
+	AFTER UPDATE OF updated_at
 	ON public.beneficiary
 	FOR EACH ROW
 EXECUTE PROCEDURE public.notebook_beneficiary_modification_date();
@@ -70,7 +70,7 @@ END ;
 $$;
 
 CREATE TRIGGER track_notebook_appointment_updates
-	AFTER INSERT OR UPDATE
+	AFTER UPDATE OF updated_at
 	ON public.notebook_appointment
 	FOR EACH ROW
 EXECUTE PROCEDURE public.notebook_appointment_modification_date();
@@ -99,7 +99,7 @@ END ;
 $$;
 
 CREATE TRIGGER track_notebook_situation_updates
-	AFTER INSERT OR UPDATE
+	AFTER UPDATE
 	ON public.notebook_situation
 	FOR EACH ROW
 EXECUTE PROCEDURE public.notebook_situation_modification_date();

--- a/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
+++ b/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
@@ -32,6 +32,7 @@ BEGIN
 		account := session_variables ->> 'x-hasura-user-id';
 		IF account IS NOT NULL then
 			SELECT notebook.id into notebook_id FROM notebook where notebook.beneficiary_id = NEW.id;
+			UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id = notebook_id AND account_id = account;
 			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
 			VALUES (notebook_id, account, now(), 'beneficiary');
 		END IF;
@@ -63,6 +64,7 @@ BEGIN
 		IF account IS NOT NULL then
 			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
 			VALUES (NEW.notebook_id, account, now(), 'appointment');
+			UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id = NEW.notebook_id AND account_id = account;
 		END IF;
 	END IF;
 	RETURN NEW;
@@ -92,6 +94,7 @@ BEGIN
 		IF account IS NOT NULL then
 			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
 			VALUES (NEW.notebook_id, account, now(), 'situation');
+			UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id = NEW.notebook_id AND account_id = account;
 		END IF;
 	END IF;
 	RETURN NEW;

--- a/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
+++ b/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
@@ -91,7 +91,7 @@ BEGIN
 		account := session_variables ->> 'x-hasura-user-id';
 		IF account IS NOT NULL then
 			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
-			VALUES (NEW.notebook_id, account, now(), 'beneficiary');
+			VALUES (NEW.notebook_id, account, now(), 'situation');
 		END IF;
 	END IF;
 	RETURN NEW;

--- a/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
+++ b/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
@@ -5,11 +5,8 @@ CREATE TABLE "public"."notebook_updates_track"
 	"updated_at"  time NOT NULL,
 	"type"        text NOT NULL,
 	"id"          uuid NOT NULL DEFAULT gen_random_uuid(),
-	PRIMARY KEY ("id"),
-	FOREIGN KEY ("notebook_id") REFERENCES "public"."notebook" ("id") ON UPDATE cascade ON DELETE cascade,
-	FOREIGN KEY ("account_id") REFERENCES "public"."account" ("id") ON UPDATE cascade ON DELETE cascade
+	PRIMARY KEY ("id")
 );
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 -----------------------------------------
 -- Add new triggers

--- a/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
+++ b/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
@@ -6,8 +6,8 @@ CREATE TABLE "public"."notebook_updates_track"
 	"type"        text NOT NULL,
 	"id"          uuid NOT NULL DEFAULT gen_random_uuid(),
 	PRIMARY KEY ("id"),
-	FOREIGN KEY ("notebook_id") REFERENCES "public"."notebook" ("id") ON UPDATE restrict ON DELETE restrict,
-	FOREIGN KEY ("account_id") REFERENCES "public"."account" ("id") ON UPDATE restrict ON DELETE restrict
+	FOREIGN KEY ("notebook_id") REFERENCES "public"."notebook" ("id") ON UPDATE cascade ON DELETE set null,
+	FOREIGN KEY ("account_id") REFERENCES "public"."account" ("id") ON UPDATE cascade ON DELETE set null
 );
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
@@ -29,7 +29,7 @@ BEGIN
 	IF session_variables IS NOT NULL then
 		account := session_variables ->> 'x-hasura-user-id';
 		IF account IS NOT NULL then
-		  SELECT notebook.id into notebook_id FROM notebook where notebook.beneficiary_id = NEW.id;
+			SELECT notebook.id into notebook_id FROM notebook where notebook.beneficiary_id = NEW.id;
 			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
 			VALUES (notebook_id, account, now(), 'beneficiary');
 		END IF;
@@ -39,10 +39,10 @@ END ;
 $$;
 
 CREATE TRIGGER track_notebook_beneficiary_updates
-  AFTER INSERT OR UPDATE
-  ON public.beneficiary
-  FOR EACH ROW
-  EXECUTE PROCEDURE public.notebook_beneficiary_modification_date();
+	AFTER INSERT OR UPDATE
+	ON public.beneficiary
+	FOR EACH ROW
+EXECUTE PROCEDURE public.notebook_beneficiary_modification_date();
 
 -----------------------------------------
 
@@ -68,10 +68,10 @@ END ;
 $$;
 
 CREATE TRIGGER track_notebook_appointment_updates
-  AFTER INSERT OR UPDATE
-  ON public.notebook_appointment
-  FOR EACH ROW
-  EXECUTE PROCEDURE public.notebook_appointment_modification_date();
+	AFTER INSERT OR UPDATE
+	ON public.notebook_appointment
+	FOR EACH ROW
+EXECUTE PROCEDURE public.notebook_appointment_modification_date();
 
 -----------------------------------------
 
@@ -97,10 +97,10 @@ END ;
 $$;
 
 CREATE TRIGGER track_notebook_situation_updates
-  AFTER INSERT OR UPDATE
-  ON public.notebook_situation
-  FOR EACH ROW
-  EXECUTE PROCEDURE public.notebook_situation_modification_date();
+	AFTER INSERT OR UPDATE
+	ON public.notebook_situation
+	FOR EACH ROW
+EXECUTE PROCEDURE public.notebook_situation_modification_date();
 
 -----------------------------------------
 -- Change existing triggers

--- a/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
+++ b/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
@@ -1,0 +1,202 @@
+CREATE TABLE "public"."notebook_updates_track"
+(
+	"notebook_id" uuid NOT NULL,
+	"account_id"  uuid NOT NULL,
+	"updated_at"  time NOT NULL,
+	"type"        text NOT NULL,
+	"id"          uuid NOT NULL DEFAULT gen_random_uuid(),
+	PRIMARY KEY ("id"),
+	FOREIGN KEY ("notebook_id") REFERENCES "public"."notebook" ("id") ON UPDATE restrict ON DELETE restrict,
+	FOREIGN KEY ("account_id") REFERENCES "public"."account" ("id") ON UPDATE restrict ON DELETE restrict
+);
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-----------------------------------------
+-- Add new triggers
+-----------------------------------------
+
+CREATE OR REPLACE FUNCTION public.notebook_beneficiary_modification_date()
+	RETURNS TRIGGER
+	LANGUAGE PLPGSQL
+AS
+$$
+DECLARE
+	session_variables json;
+	account           uuid;
+	notebook_id       uuid;
+BEGIN
+	session_variables := current_setting('hasura.user', 't');
+	IF session_variables IS NOT NULL then
+		account := session_variables ->> 'x-hasura-user-id';
+		IF account IS NOT NULL then
+		  SELECT notebook.id into notebook_id FROM notebook where notebook.beneficiary_id = NEW.id;
+			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
+			VALUES (notebook_id, account, now(), 'beneficiary');
+		END IF;
+	END IF;
+	RETURN NEW;
+END ;
+$$;
+
+CREATE TRIGGER track_notebook_beneficiary_updates
+  AFTER INSERT OR UPDATE
+  ON public.beneficiary
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.notebook_beneficiary_modification_date();
+
+-----------------------------------------
+
+CREATE OR REPLACE FUNCTION public.notebook_appointment_modification_date()
+	RETURNS TRIGGER
+	LANGUAGE PLPGSQL
+AS
+$$
+DECLARE
+	session_variables json;
+	account           uuid;
+BEGIN
+	session_variables := current_setting('hasura.user', 't');
+	IF session_variables IS NOT NULL then
+		account := session_variables ->> 'x-hasura-user-id';
+		IF account IS NOT NULL then
+			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
+			VALUES (NEW.notebook_id, account, now(), 'beneficiary');
+		END IF;
+	END IF;
+	RETURN NEW;
+END ;
+$$;
+
+CREATE TRIGGER track_notebook_appointment_updates
+  AFTER INSERT OR UPDATE
+  ON public.notebook_appointment
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.notebook_appointment_modification_date();
+
+-----------------------------------------
+
+CREATE OR REPLACE FUNCTION public.notebook_situation_modification_date()
+	RETURNS TRIGGER
+	LANGUAGE PLPGSQL
+AS
+$$
+DECLARE
+	session_variables json;
+	account           uuid;
+BEGIN
+	session_variables := current_setting('hasura.user', 't');
+	IF session_variables IS NOT NULL then
+		account := session_variables ->> 'x-hasura-user-id';
+		IF account IS NOT NULL then
+			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
+			VALUES (NEW.notebook_id, account, now(), 'beneficiary');
+		END IF;
+	END IF;
+	RETURN NEW;
+END ;
+$$;
+
+CREATE TRIGGER track_notebook_situation_updates
+  AFTER INSERT OR UPDATE
+  ON public.notebook_situation
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.notebook_situation_modification_date();
+
+-----------------------------------------
+-- Change existing triggers
+-----------------------------------------
+
+CREATE OR REPLACE FUNCTION public.notebook_modification_date()
+	RETURNS TRIGGER
+	LANGUAGE PLPGSQL
+AS
+$$
+DECLARE
+	session_variables json;
+	account           uuid;
+BEGIN
+	session_variables := current_setting('hasura.user', 't');
+	IF session_variables IS NOT NULL then
+		account := session_variables ->> 'x-hasura-user-id';
+		IF account IS NOT NULL then
+			UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id = NEW.id AND account_id = account;
+			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
+			VALUES (NEW.id, account, now(), 'notebook');
+		END IF;
+	END IF;
+	RETURN NEW;
+END ;
+$$;
+
+CREATE OR REPLACE FUNCTION public.notebook_focus_modification_date()
+	RETURNS TRIGGER
+	LANGUAGE PLPGSQL
+AS
+$$
+DECLARE
+	session_variables json;
+	account           uuid;
+BEGIN
+	session_variables := current_setting('hasura.user', 't');
+	IF session_variables IS NOT NULL then
+		account := session_variables ->> 'x-hasura-user-id';
+		IF account IS NOT NULL then
+			UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id = NEW.notebook_id AND account_id = account;
+			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
+			VALUES (NEW.notebook_id, account, now(), 'focus');
+		END IF;
+	END IF;
+	RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.notebook_target_modification_date()
+	RETURNS TRIGGER
+	LANGUAGE PLPGSQL
+AS
+$$
+DECLARE
+	session_variables json;
+	account           uuid;
+	notebook          uuid;
+BEGIN
+	session_variables := current_setting('hasura.user', 't');
+	IF session_variables IS NOT NULL then
+		account := session_variables ->> 'x-hasura-user-id';
+		IF account IS NOT NULL then
+			SELECT focus.notebook_id into notebook FROM public.notebook_focus as focus where focus.id = NEW.focus_id;
+			UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id = notebook AND account_id = account;
+			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
+			VALUES (notebook, account, now(), 'target');
+		END IF;
+	END IF;
+	RETURN NEW;
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.notebook_action_modification_date()
+	RETURNS TRIGGER
+	LANGUAGE PLPGSQL
+AS
+$$
+DECLARE
+	session_variables json;
+	account           uuid;
+	notebook          uuid;
+	focus             uuid;
+BEGIN
+	session_variables := current_setting('hasura.user', 't');
+	IF session_variables IS NOT NULL then
+		account := session_variables ->> 'x-hasura-user-id';
+		IF account IS NOT NULL then
+			SELECT focus_id into focus FROM public.notebook_target where id = NEW.target_id;
+			SELECT notebook_id into notebook FROM public.notebook_focus where id = focus;
+			UPDATE notebook_member SET last_modified_at=now() WHERE notebook_id = notebook AND account_id = account;
+			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
+			VALUES (notebook, account, now(), 'action');
+		END IF;
+	END IF;
+	RETURN NEW;
+END;
+$$;

--- a/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
+++ b/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
@@ -62,7 +62,7 @@ BEGIN
 		account := session_variables ->> 'x-hasura-user-id';
 		IF account IS NOT NULL then
 			INSERT INTO notebook_updates_track (notebook_id, account_id, updated_at, type)
-			VALUES (NEW.notebook_id, account, now(), 'beneficiary');
+			VALUES (NEW.notebook_id, account, now(), 'appointment');
 		END IF;
 	END IF;
 	RETURN NEW;

--- a/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
+++ b/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
@@ -1,12 +1,17 @@
 CREATE TABLE "public"."notebook_updates_track"
 (
-	"notebook_id" uuid NOT NULL,
-	"account_id"  uuid NOT NULL,
-	"updated_at"  time NOT NULL,
-	"type"        text NOT NULL,
-	"id"          uuid NOT NULL DEFAULT gen_random_uuid(),
-	PRIMARY KEY ("id")
+	"notebook_id" uuid                     NOT NULL,
+	"account_id"  uuid                     NOT NULL,
+	"updated_at"  timestamp with time zone NOT NULL,
+	"type"        text                     NOT NULL,
+	"id"          uuid                     NOT NULL DEFAULT gen_random_uuid(),
+	PRIMARY KEY ("id"),
+	FOREIGN KEY ("notebook_id") REFERENCES "public"."notebook" ("id") ON UPDATE restrict ON DELETE restrict,
+	FOREIGN KEY ("account_id") REFERENCES "public"."account" ("id") ON UPDATE restrict ON DELETE restrict
 );
+
+alter table public.notebook_updates_track
+    owner to cdb;
 
 -----------------------------------------
 -- Add new triggers

--- a/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
+++ b/hasura/migrations/carnet_de_bord/1691584295337_track_notebook_updates/up.sql
@@ -6,8 +6,8 @@ CREATE TABLE "public"."notebook_updates_track"
 	"type"        text NOT NULL,
 	"id"          uuid NOT NULL DEFAULT gen_random_uuid(),
 	PRIMARY KEY ("id"),
-	FOREIGN KEY ("notebook_id") REFERENCES "public"."notebook" ("id") ON UPDATE cascade ON DELETE set null,
-	FOREIGN KEY ("account_id") REFERENCES "public"."account" ("id") ON UPDATE cascade ON DELETE set null
+	FOREIGN KEY ("notebook_id") REFERENCES "public"."notebook" ("id") ON UPDATE cascade ON DELETE cascade,
+	FOREIGN KEY ("account_id") REFERENCES "public"."account" ("id") ON UPDATE cascade ON DELETE cascade
 );
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 

--- a/hasura/seeds/carnet_de_bord/seed-data.sql
+++ b/hasura/seeds/carnet_de_bord/seed-data.sql
@@ -9,6 +9,7 @@ DELETE FROM public.external_data;
 DELETE FROM public.nps_rating;
 DELETE FROM public.nps_rating_dismissal;
 
+DELETE FROM notebook_updates_track;
 DELETE FROM notebook_member;
 DELETE FROM professional_project;
 DELETE FROM notebook_appointment;


### PR DESCRIPTION
## :wrench: Problème
Fix: #1890 

Pour mieux mesure l'impact de carnet de bord on souhaite connaitre la fréquence de modification des carnets par utilisateurice.

## :cake: Solution

Ajouter une table de suivi de ces modifications qui est renseignée lorsqu'une table reliée à un carnet est modifiée.

## :rotating_light:  Points d'attention / Remarques

## :desert_island: Comment tester

Les modification suivantes ajoutent une ligne dans la table notebook_updates_track :
- de bénéficiaire
- de rendez-vous
- de situation
- d'action
- de focus
- de target
- le carnet lui-même