### PR TITLE
fix: affiche le type de compte correct pour les co

### DIFF
--- a/app/src/lib/ui/OrientationManager/View.svelte
+++ b/app/src/lib/ui/OrientationManager/View.svelte
@@ -5,7 +5,7 @@
 	import { Text } from '$lib/ui/utils';
 
 	export let orientationManager: AccountData['orientation_manager'];
-	export let mainTitle = "Chargé d'orientaion";
+	export let mainTitle = "Chargé d'orientation";
 </script>
 
 <div class="w-1/2 flex flex-col gap-4">

--- a/app/src/lib/ui/OrientationManager/View.svelte
+++ b/app/src/lib/ui/OrientationManager/View.svelte
@@ -5,7 +5,7 @@
 	import { Text } from '$lib/ui/utils';
 
 	export let orientationManager: AccountData['orientation_manager'];
-	export let mainTitle = 'Gestionnaire de structure';
+	export let mainTitle = "Chargé d'orientaion";
 </script>
 
 <div class="w-1/2 flex flex-col gap-4">


### PR DESCRIPTION
## :wrench: Problème

lorsqu'un Chargé d'orientation se connecte et qu'il va sur "mon compte" il est affiché "Gestionnaire de structure" au lien de Chargé d'orientation

## :cake: Solution

changer le wording

## :rotating_light:  Points d'attention / Remarques

ras

## :desert_island: Comment tester
 

- se connecter en tant que `giulia.diaby`
- aller sur mon compte
- voir Chargé d'orientation

fix #1960
