### PR TITLE
fix: bloquer la connection des comptes supprimés

### DIFF
--- a/app/src/routes/(auth)/manager/_getAccountById.gql
+++ b/app/src/routes/(auth)/manager/_getAccountById.gql
@@ -4,6 +4,7 @@ query GetAccountById($id: uuid!) {
     username
     confirmed
     type
+    deletedAt
     orientation_manager {
       firstname
       lastname

--- a/app/src/routes/(auth)/manager/professionnels/+page.svelte
+++ b/app/src/routes/(auth)/manager/professionnels/+page.svelte
@@ -85,10 +85,14 @@
 		} else if (emails[id] === 'ToConfirm') {
 			if (confirm) {
 				emails[id] = 'Sending';
-				const response = await post(`/manager/sendConnectionEmail`, { id });
-				if (response.ok) {
-					emails[id] = 'Sent';
-				} else {
+				try {
+					const response = await post(`/manager/sendConnectionEmail`, { id });
+					if (response.ok) {
+						emails[id] = 'Sent';
+					} else {
+						emails[id] = 'Failed';
+					}
+				} catch {
 					emails[id] = 'Failed';
 				}
 			} else {
@@ -172,7 +176,7 @@
 							{/if}
 						</td>
 						<td class="text-center">
-							{#if account.confirmed}
+							{#if account.confirmed && !account.deletedAt}
 								{#if typeof emails[account.id] === 'undefined'}
 									<IconButton
 										icon="fr-icon-mail-line"

--- a/app/src/routes/(auth)/manager/sendConnectionEmail/+server.ts
+++ b/app/src/routes/(auth)/manager/sendConnectionEmail/+server.ts
@@ -81,6 +81,16 @@ export const POST: RequestHandler = async ({ request }) => {
 		throw error(500, 'sendConnectionEmail: unconfirmed account');
 	}
 
+	if (data.account.deletedAt) {
+		logger.error({
+			message: 'Did not send email to deleted account',
+			email,
+			lastname,
+			firstname,
+		});
+		throw error(500, 'sendConnectionEmail: deleted account');
+	}
+
 	const result = await updateAccessKey(client, id);
 	if (result.error) {
 		logger.error(result.error, 'Could not update access key');

--- a/app/src/routes/auth/jwt/_getAccountInfo.gql
+++ b/app/src/routes/auth/jwt/_getAccountInfo.gql
@@ -1,5 +1,5 @@
 query GetAccountInfo($accessKey: String!) {
-  account(where: { accessKey: { _eq: $accessKey } }) {
+  account(where: { accessKey: { _eq: $accessKey }, deletedAt: { _is_null: true } }) {
     id
     type
     username


### PR DESCRIPTION
## :wrench: Problème

ETQ admin, je peux envoyer un lien de connexion a un pro désactivé (CO dans la situation vécue), le lien reçu permet de se connecter, voir qu'il existe des demande de réo, mais ne permet pas d'accéder aux carnets.
 
## :cake: Solution

désactiver la possibilité d'envoyer un lien pour les compte désactivé (ou même globalement si c'est plus simple).


## :rotating_light:  Points d'attention / Remarques

On en profite pour ne pas remonter les comptes supprimés quand on valide un lien magique

## :desert_island: Comment tester

Se connecter en tant que manager.cd93
Afficher les professionnels
Valider l'absence de bouton pour envoyer un courriel de connexion



fix  #1957