### PR TITLE
feat: historise les changements d'orientation

### DIFF
--- a/app/src/lib/constants.ts
+++ b/app/src/lib/constants.ts
@@ -51,7 +51,7 @@ export const eventTypes: { label: string; name: string }[] = [
 		name: NotebookEventTypeEnum.Target,
 	},
 	{
-		label: 'Réorientation',
+		label: 'Accompagnement',
 		name: NotebookEventTypeEnum.Orientation,
 	},
 ];

--- a/app/src/lib/constants.ts
+++ b/app/src/lib/constants.ts
@@ -50,4 +50,8 @@ export const eventTypes: { label: string; name: string }[] = [
 		label: 'Objectif',
 		name: NotebookEventTypeEnum.Target,
 	},
+	{
+		label: 'Réorientation',
+		name: NotebookEventTypeEnum.Orientation,
+	},
 ];

--- a/app/src/lib/ui/NotebookEvent/GetNotebookEvents.gql
+++ b/app/src/lib/ui/NotebookEvent/GetNotebookEvents.gql
@@ -1,0 +1,31 @@
+query GetNotebookEvents(
+  $eventsStart: timestamptz = "-infinity"
+  $eventsEnd: timestamptz = "infinity"
+  $notebookId: uuid!
+) {
+  lastOrientationEvent: notebook_event(
+    where: { notebookId: { _eq: $notebookId }, eventType: { _eq: orientation } }
+    limit: 1
+    order_by: { eventDate: desc_nulls_last }
+  ) {
+    id
+  }
+  notebook_event(
+    order_by: { eventDate: desc_nulls_last }
+    where: { eventDate: { _gte: $eventsStart, _lte: $eventsEnd }, notebookId: { _eq: $notebookId } }
+  ) {
+    id
+    eventDate
+    event
+    eventType
+    creatorId
+    creator {
+      professional {
+        structureId
+        structure {
+          name
+        }
+      }
+    }
+  }
+}

--- a/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
+++ b/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
@@ -95,10 +95,7 @@
 
 	function eventStatus(event: NotebookEvent): string {
 		if (event.eventType == NotebookEventTypeEnum.Orientation) {
-			if (event.id === $getNotebookEvents.data?.lastOrientationEvent[0]?.id) {
-				return 'En cours';
-			}
-			return 'Clos';
+			return 'En cours';
 		}
 		return constantToString(
 			event.event.status,
@@ -219,6 +216,20 @@
 							<td>{eventStructure(event)}</td>
 							<td>{eventStatus(event)}</td>
 						</tr>
+						{#if event.eventType == NotebookEventTypeEnum.Orientation && event.event.previousStructure}
+							<tr>
+								<td>{formatDateLocale(event.eventDate)} </td>
+								<td>{eventCategory(event)}</td>
+								<td>{eventLabel(event)}</td>
+								<td>
+									{event.event.previousStructure}
+									{#if event.event.previousOrientation}
+										(Dispositif: {event.event.previousOrientation})
+									{/if}
+								</td>
+								<td>Clos</td>
+							</tr>
+						{/if}
 					{:else}
 						<tr class="shadow-sm">
 							<td class="!text-center" colspan="5">

--- a/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
+++ b/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
@@ -52,7 +52,7 @@
 
 	function eventCategory(event): string {
 		if (event.eventType == NotebookEventTypeEnum.Orientation) {
-			return 'Accompagnement';
+			return constantToString(event.eventType, eventTypes);
 		}
 		if (
 			(event.eventType != NotebookEventTypeEnum.Action &&
@@ -70,8 +70,7 @@
 	}
 
 	function eventLabel(notebookEvent: NotebookEvent): string {
-		if (notebookEvent.eventType === NotebookEventTypeEnum.Orientation) return '(Ré)orientation';
-		else return notebookEvent.event.event_label;
+		return notebookEvent.event.event_label;
 	}
 
 	function eventStructure(notebookEvent: NotebookEvent): string {

--- a/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
+++ b/app/src/lib/ui/NotebookEvent/NotebookEventList.svelte
@@ -54,12 +54,6 @@
 		if (event.eventType == NotebookEventTypeEnum.Orientation) {
 			return 'Accompagnement';
 		}
-		console.log(
-			event,
-			event.eventType,
-			NotebookEventTypeEnum.Orientation,
-			event.enventType == NotebookEventTypeEnum.Orientation
-		);
 		if (
 			(event.eventType != NotebookEventTypeEnum.Action &&
 				event.eventType != NotebookEventTypeEnum.Target) ||

--- a/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
+++ b/app/src/routes/(auth)/pro/carnet/_getNotebook.gql
@@ -225,32 +225,3 @@ query GetNotebook($id: uuid!, $withOrientationRequests: Boolean = true) {
     }
   }
 }
-
-query GetNotebookEvents(
-  $eventsStart: timestamptz = "-infinity"
-  $eventsEnd: timestamptz = "infinity"
-  $notebookId: uuid!
-) {
-  notebook_event(
-    order_by: { eventDate: desc_nulls_last }
-    where: { eventDate: { _gte: $eventsStart, _lte: $eventsEnd }, notebookId: { _eq: $notebookId } }
-  ) {
-    ...eventFields
-  }
-}
-
-fragment eventFields on notebook_event {
-  id
-  eventDate
-  event
-  eventType
-  creatorId
-  creator {
-    professional {
-      structureId
-      structure {
-        name
-      }
-    }
-  }
-}

--- a/backend/cdb/api/db/crud/orientation_info.py
+++ b/backend/cdb/api/db/crud/orientation_info.py
@@ -19,6 +19,7 @@ def parse_orientation_info_from_gql(orientation_info_response, with_new_referent
         new_referent=orientation_info_response.get("newReferent")[0]
         if with_new_referent and len(orientation_info_response.get("newReferent")) > 0
         else None,
+        notebook=notebook.get("notebook"),
     )
 
 
@@ -38,6 +39,7 @@ async def get_orientation_info(
             "with_new_referent": with_new_referent,
         },
     )
+    print(orientation_info_response)
     return parse_orientation_info_from_gql(orientation_info_response, with_new_referent)
 
 
@@ -51,6 +53,9 @@ query orientationInfos(
   $new_referent_account_id: uuid
 ) {
   notebook: notebook_public_view(where: { id: { _eq: $notebook_id } }) {
+    notebook {
+      notebookInfo { orientationSystem { name }}
+    }
     beneficiary {
       id
       orientation_request: orientationRequest(
@@ -67,6 +72,7 @@ query orientationInfos(
       cafNumber
       structures(where: { status: { _eq: "current" } }) {
         structureId
+        structure { name }
       }
     }
     former_referents: members(

--- a/backend/cdb/api/db/crud/orientation_info.py
+++ b/backend/cdb/api/db/crud/orientation_info.py
@@ -39,7 +39,6 @@ async def get_orientation_info(
             "with_new_referent": with_new_referent,
         },
     )
-    print(orientation_info_response)
     return parse_orientation_info_from_gql(orientation_info_response, with_new_referent)
 
 

--- a/backend/cdb/api/db/models/notebook_event.py
+++ b/backend/cdb/api/db/models/notebook_event.py
@@ -21,6 +21,7 @@ class EventStatus(StrEnum):
 class EventType(StrEnum):
     action = "action"
     target = "target"
+    orientation = "orientation"
 
 
 class NotebookEventInsert(BaseModel):

--- a/backend/cdb/api/db/models/orientation_info.py
+++ b/backend/cdb/api/db/models/orientation_info.py
@@ -9,6 +9,7 @@ class OrientationInfo(BaseModel):
     former_referents: List[dict]
     new_structure: dict
     new_referent: dict | None
+    notebook: dict
 
     @property
     def former_referent_account_id(self) -> UUID | None:

--- a/backend/cdb/api/v1/routers/orientations.py
+++ b/backend/cdb/api/v1/routers/orientations.py
@@ -150,6 +150,7 @@ async def change_beneficiary_orientation(
                 dsl_schema, data.orientation_request_id, data.orientation_system_id
             )
         orientation_event = {
+            "event_label": "(Ré)Orientation",
             "orientation": orientation_system.name,
             "structure": orientation_info.new_structure.get("name"),
             "referent": get_referent_name(orientation_info.new_referent)

--- a/backend/cdb/api/v1/routers/orientations.py
+++ b/backend/cdb/api/v1/routers/orientations.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Header
@@ -15,6 +16,7 @@ from cdb.api.db.crud.beneficiary_structure import (
     get_deactivate_beneficiary_structure_mutation,
     get_insert_beneficiary_structure_mutation,
 )
+from cdb.api.db.crud.notebook_event import get_insert_notebook_event_gql
 from cdb.api.db.crud.notebook_info import get_insert_notebook_info_mutation
 from cdb.api.db.crud.notebook_member import (
     get_deactivate_notebook_members_mutation,
@@ -25,6 +27,7 @@ from cdb.api.db.crud.orientation_info import get_orientation_info
 from cdb.api.db.crud.orientation_request import get_accept_orientation_request_mutation
 from cdb.api.db.crud.orientation_system import get_orientation_system_by_id
 from cdb.api.db.models.member_type import MemberTypeEnum
+from cdb.api.db.models.notebook_event import EventType
 from cdb.api.db.models.orientation_info import OrientationInfo
 from cdb.api.db.models.orientation_system import OrientationSystem
 from cdb.api.db.models.role import RoleEnum
@@ -118,7 +121,6 @@ async def change_beneficiary_orientation(
         mutations: dict[str, DSLField] = {}
 
         if data.orientation_request_id:
-
             try:
                 raise_if_orientation_request_not_match_notebook(
                     data.orientation_request_id,
@@ -147,7 +149,29 @@ async def change_beneficiary_orientation(
             mutations = mutations | get_accept_orientation_request_mutation(
                 dsl_schema, data.orientation_request_id, data.orientation_system_id
             )
-
+        orientation_event = {
+            "orientation": orientation_system.name,
+            "structure": orientation_info.new_structure.get("name"),
+            "referent": get_referent_name(orientation_info.new_referent)
+            if orientation_info.new_referent
+            else None,
+            "previousOrientation": orientation_info.notebook["notebookInfo"][
+                "orientationSystem"
+            ]["name"]
+            if orientation_info.notebook["notebookInfo"]
+            and orientation_info.notebook["notebookInfo"]["orientationSystem"]
+            else None,
+            "previousReferent": get_referent_name(
+                orientation_info.former_referents[0]["account"]["professional"]
+            )
+            if orientation_info.former_referent_account_id
+            else None,
+            "previousStructure": get_structure_name(
+                orientation_info.beneficiary["structures"][0]["structure"]
+            )
+            if orientation_info.former_structure_ids
+            else None,
+        }
         mutations = mutations | get_insert_notebook_info_mutation(
             dsl_schema,
             data.notebook_id,
@@ -199,6 +223,14 @@ async def change_beneficiary_orientation(
                     MemberTypeEnum.referent,
                 )
 
+        mutations = mutations | get_insert_notebook_event_gql(
+            dsl_schema,
+            data.notebook_id,
+            EventType.orientation,
+            datetime.now(),
+            orientation_event,
+        )
+
         response = await session.execute(dsl_gql(DSLMutation(**mutations)))
 
         former_referents = [
@@ -239,9 +271,16 @@ async def change_beneficiary_orientation(
 def raise_if_orientation_request_not_match_notebook(
     orientation_request_id: UUID, beneficiary_request_id: UUID | None
 ) -> None:
-
     if orientation_request_id != beneficiary_request_id:
         raise Exception(
             f"orientation_request_id {orientation_request_id} does not match "
             f"beneficiary_request_id {beneficiary_request_id}"
         )
+
+
+def get_referent_name(referent: dict[str, str]) -> str:
+    return f'{referent.get("firstname")} {referent.get("lastname")}'
+
+
+def get_structure_name(structure: dict[str, str]) -> str:
+    return f'{structure.get("name")}'

--- a/backend/tests/api/test_orientations.test_change_orientation_with_new_referent.approved.json
+++ b/backend/tests/api/test_orientations.test_change_orientation_with_new_referent.approved.json
@@ -1,0 +1,13 @@
+{
+    "creatorId": "2addd10f-9bd3-4d37-b3c9-10a6e2c4be4f",
+    "event": {
+        "orientation": "Social",
+        "previousOrientation": "Professionnel",
+        "previousReferent": "Pierre Chevalier",
+        "previousStructure": "Centre Communal d'action social Livry-Gargan",
+        "referent": "Paul Camara",
+        "structure": "Service Social D\u00e9partemental"
+    },
+    "eventDate": "<date0>",
+    "eventType": "orientation"
+}

--- a/backend/tests/api/test_orientations.test_change_orientation_with_new_referent.approved.json
+++ b/backend/tests/api/test_orientations.test_change_orientation_with_new_referent.approved.json
@@ -1,6 +1,7 @@
 {
     "creatorId": "2addd10f-9bd3-4d37-b3c9-10a6e2c4be4f",
     "event": {
+        "event_label": "(R\u00e9)Orientation",
         "orientation": "Social",
         "previousOrientation": "Professionnel",
         "previousReferent": "Pierre Chevalier",

--- a/backend/tests/utils/approvaltests.py
+++ b/backend/tests/utils/approvaltests.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import approvaltests
 from approvaltests import Options
+from approvaltests.scrubbers.date_scrubber import create_regex_scrubber
 
 
 def verify(data: Any, extension: str = ".txt"):
@@ -13,8 +14,16 @@ def verify_python(data: Any):
     approvaltests.verify(pformat(data))
 
 
+isoformat_date_scrubber = create_regex_scrubber(
+    r"\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}:\d{2}.\d{4,6}\+\d{2}:\d{2}",
+    lambda t: f"<date{t}>",
+)
+
+
 def verify_as_json(data: Any):
     approvaltests.verify_as_json(
         data,
-        options=Options().for_file.with_extension(".json"),
+        options=Options()
+        .for_file.with_extension(".json")
+        .with_scrubber(isoformat_date_scrubber),
     )

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_event.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_event.yaml
@@ -42,6 +42,42 @@ insert_permissions:
         - id
         - notebook_id
         - creator_id
+  - role: manager
+    permission:
+      check:
+        notebook:
+          beneficiary:
+            deployment_id:
+              _eq: X-Hasura-Deployment-Id
+      set:
+        creator_id: x-hasura-User-Id
+      columns:
+        - creation_date
+        - creator_id
+        - event
+        - event_date
+        - event_type
+        - id
+        - notebook_id
+    comment: ""
+  - role: orientation_manager
+    permission:
+      check:
+        notebook:
+          beneficiary:
+            deployment_id:
+              _eq: X-Hasura-Deployment-Id
+      set:
+        creator_id: x-hasura-User-Id
+      columns:
+        - creation_date
+        - creator_id
+        - event
+        - event_date
+        - event_type
+        - id
+        - notebook_id
+    comment: ""
   - role: professional
     permission:
       check:
@@ -72,6 +108,23 @@ select_permissions:
         - creator_id
       filter: {}
       allow_aggregations: true
+  - role: manager
+    permission:
+      columns:
+        - creation_date
+        - creator_id
+        - event
+        - event_date
+        - event_type
+        - id
+        - notebook_id
+      filter:
+        notebook:
+          beneficiary:
+            deployment_id:
+              _eq: X-Hasura-Deployment-Id
+      allow_aggregations: true
+    comment: ""
   - role: orientation_manager
     permission:
       columns:

--- a/hasura/migrations/carnet_de_bord/1693388929776_add_orientation_event_type/down.sql
+++ b/hasura/migrations/carnet_de_bord/1693388929776_add_orientation_event_type/down.sql
@@ -1,0 +1,1 @@
+delete from notebook_event_type where value = 'orientation';

--- a/hasura/migrations/carnet_de_bord/1693388929776_add_orientation_event_type/up.sql
+++ b/hasura/migrations/carnet_de_bord/1693388929776_add_orientation_event_type/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO notebook_event_type VALUES('orientation', 'Orientation ou réorientation');

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -10404,6 +10404,9 @@ enum notebook_event_type_enum {
   """Action d'un objectif"""
   action
 
+  """Orientation ou réorientation"""
+  orientation
+
   """Objectif d'un parcours"""
   target
 }


### PR DESCRIPTION
## :wrench: Problème

Il est impossible actuellement de pouvoir visualiser l'évolution des types d'accompagnement d'un bénéficiaire. Cela rend compliqué de faire le lien avec le travail d'accompagnement précédemment réalisé et d'éviter de renvoyer les bénéficiaires sur un dispositif déjà mobilisé.

## :cake: Solution
On ajoute dans l'historique une ligne à chaque orientation / réorientation.
En terme de statut, sera en cours jusqu'à une nouvelle (ré)orientation et dans ce cas, le statut doit passer à clos.

## :rotating_light:  Points d'attention / Remarques

On aggrège dans le champs event les infos courantes (dispositif, structure, référent si défini) et leur valeurs précédentes

## :desert_island: Comment tester

Se connecter en tant que giulia diaby
aller sur le carnet de sophie tifour
Réorienter dans différent dispositif et voir les évènements correspondant.


fix #1984