### PR TITLE
feat: possibilité de marquer une structure comme sensible

### DIFF
--- a/app/src/lib/ui/StructureEdit/StructureCreationForm.svelte
+++ b/app/src/lib/ui/StructureEdit/StructureCreationForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button, Checkboxes } from '$lib/ui/base';
-	import { Form, Input } from '$lib/ui/forms';
+	import { Form, Input, Checkbox } from '$lib/ui/forms';
 	import type { GetStructureByIdQuery } from '$lib/graphql/_gen/typed-document-nodes';
 	import type { LabelName } from '$lib/types';
 
@@ -11,6 +11,7 @@
 	export let orientationSystemOptions: LabelName[];
 	export let onSubmit: (values: StructureFormInput, orientationSystems: string[]) => void;
 	export let onCancel: () => void = null;
+
 	function submitHandler(values: StructureFormInput) {
 		onSubmit(structureSchema.cast(values), orientationSystems);
 	}
@@ -34,6 +35,15 @@
 		<h2 class="text-vert-cdb fr-h4">Informations générales</h2>
 
 		<Input placeholder="Pole insertion" inputLabel="Nom" name="name" />
+
+		<div class="mb-4">
+			<Checkbox
+				additionalLabel="Une structure sensible est une structure dont l'objet ou la dénomination fait référence, ou permet de déduire, des informations personnelles sensibles concernant un usager (suivi judiciaire, médical, opinion politique, religieuse, …)"
+				name="sensitive"
+				label="Structure sensible"
+			/>
+		</div>
+
 		<Input placeholder="service d'insertion" inputLabel="Description" name="shortDesc" />
 		<Input placeholder="agence@cd08.fr" inputLabel="Courriel" name="email" />
 		<Input

--- a/app/src/lib/ui/StructureEdit/StructureEditLayer.svelte
+++ b/app/src/lib/ui/StructureEdit/StructureEditLayer.svelte
@@ -40,6 +40,7 @@
 			address2: values.address2,
 			postalCode: values.postalCode,
 			city: values.city,
+			sensitive: values.sensitive,
 			website: values.website,
 			orientationSystemsToAdd,
 			orientationSystemsToDelete,

--- a/app/src/lib/ui/StructureEdit/structure.schema.test.ts
+++ b/app/src/lib/ui/StructureEdit/structure.schema.test.ts
@@ -8,6 +8,7 @@ describe('structureSchema model', () => {
 				id: '939364c2-d825-4e42-8dac-e7126fdb2f1c',
 				siret: '',
 				name: 'test lionel',
+				sensible: true,
 				shortDesc: 'testée',
 				phone: '',
 				email: '',
@@ -30,6 +31,7 @@ describe('structureSchema model', () => {
 			  "shortDesc": "testée",
 			  "siret": null,
 			  "website": null,
+				"sensible": true,
 			}
 		`);
 	});

--- a/app/src/lib/ui/StructureEdit/structure.schema.test.ts
+++ b/app/src/lib/ui/StructureEdit/structure.schema.test.ts
@@ -28,10 +28,10 @@ describe('structureSchema model', () => {
 			  "name": "test lionel",
 			  "phone": null,
 			  "postalCode": "08000",
+			  "sensible": true,
 			  "shortDesc": "testée",
 			  "siret": null,
 			  "website": null,
-				"sensible": true,
 			}
 		`);
 	});

--- a/app/src/lib/ui/StructureEdit/structure.schema.ts
+++ b/app/src/lib/ui/StructureEdit/structure.schema.ts
@@ -20,6 +20,7 @@ export const structureSchema = yup.object().shape({
 		.transform(nullifyEmptyString)
 		.nullable(),
 	name: yup.string().trim().required(),
+	sensitive: yup.boolean(),
 	shortDesc: yup.string().trim().nullable(),
 	phone: yup
 		.string()

--- a/app/src/lib/ui/StructureEdit/updateStructure.gql
+++ b/app/src/lib/ui/StructureEdit/updateStructure.gql
@@ -10,6 +10,7 @@ mutation updateStructure(
   $phone: String
   $name: citext
   $email: String
+  $sensitive: Boolean
   $orientationSystemsToAdd: [structure_orientation_system_insert_input!]!
   $orientationSystemsToDelete: [uuid!]
 ) {
@@ -26,6 +27,7 @@ mutation updateStructure(
       shortDesc: $shortDesc
       siret: $siret
       website: $website
+      sensitive: $sensitive
     }
   ) {
     id

--- a/app/src/lib/ui/StructureList/StructureList.svelte
+++ b/app/src/lib/ui/StructureList/StructureList.svelte
@@ -32,6 +32,7 @@
 				<th class="text-right">Code postal</th>
 				<th>Ville</th>
 				<th class="">Dispositifs d'accompagnement</th>
+				<th class="">Structure sensible</th>
 				<th class="text-center w-20">Éditer</th>
 			</tr>
 		</thead>
@@ -48,6 +49,9 @@
 							{/each}
 						</ul>
 					</td>
+					<td
+						>{#if structure.sensitive}Oui{:else}Non{/if}</td
+					>
 					<td class="text-center">
 						<IconButton
 							icon="fr-icon-edit-line"

--- a/app/src/routes/(auth)/admin/deployment/_getStructuresForDeployment.gql
+++ b/app/src/routes/(auth)/admin/deployment/_getStructuresForDeployment.gql
@@ -7,6 +7,7 @@ query GetStructuresForDeployment($deployment: deployment_bool_exp = {}) {
     email
     postalCode
     city
+    sensitive
     orientationSystems {
       orientationSystem {
         id

--- a/app/src/routes/(auth)/manager/structures/[structure_id]/_getStructureById.gql
+++ b/app/src/routes/(auth)/manager/structures/[structure_id]/_getStructureById.gql
@@ -11,6 +11,7 @@ query GetStructureById($structureId: uuid!) {
     address1
     address2
     website
+    sensitive
     deployment {
       id
       label

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_structure.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_structure.yaml
@@ -117,36 +117,38 @@ select_permissions:
         - address1
         - address2
         - city
+        - created_at
+        - deployment_id
         - email
+        - id
         - name
         - phone
         - postal_code
-        - siret
-        - website
+        - sensitive
         - short_desc
-        - created_at
+        - siret
         - updated_at
-        - deployment_id
-        - id
+        - website
       filter: {}
       allow_aggregations: true
   - role: admin_structure
     permission:
       columns:
-        - id
-        - siret
-        - name
-        - short_desc
-        - phone
-        - email
-        - postal_code
-        - city
         - address1
         - address2
+        - city
         - created_at
+        - deployment_id
+        - email
+        - id
+        - name
+        - phone
+        - postal_code
+        - sensitive
+        - short_desc
+        - siret
         - updated_at
         - website
-        - deployment_id
       filter:
         deployment_id:
           _eq: X-hasura-deployment-Id
@@ -206,6 +208,7 @@ select_permissions:
         - name
         - phone
         - postal_code
+        - sensitive
         - short_desc
         - siret
         - updated_at

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_structure.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_structure.yaml
@@ -268,6 +268,7 @@ update_permissions:
         - name
         - phone
         - postal_code
+        - sensitive
         - short_desc
         - siret
         - website
@@ -283,6 +284,7 @@ update_permissions:
         - name
         - phone
         - postal_code
+        - sensitive
         - short_desc
         - siret
         - website

--- a/hasura/migrations/carnet_de_bord/1693401046986_alter_table_public_structure_add_column_sensitive/down.sql
+++ b/hasura/migrations/carnet_de_bord/1693401046986_alter_table_public_structure_add_column_sensitive/down.sql
@@ -1,4 +1,1 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- alter table "public"."structure" add column "sensitive" boolean
---  not null default 'false';
+alter table "public"."structure" drop column "sensitive";

--- a/hasura/migrations/carnet_de_bord/1693401046986_alter_table_public_structure_add_column_sensitive/down.sql
+++ b/hasura/migrations/carnet_de_bord/1693401046986_alter_table_public_structure_add_column_sensitive/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."structure" add column "sensitive" boolean
+--  not null default 'false';

--- a/hasura/migrations/carnet_de_bord/1693401046986_alter_table_public_structure_add_column_sensitive/up.sql
+++ b/hasura/migrations/carnet_de_bord/1693401046986_alter_table_public_structure_add_column_sensitive/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."structure" add column "sensitive" boolean
+ not null default 'false';

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -20197,6 +20197,7 @@ type structure {
     """filter the rows returned"""
     where: professional_bool_exp
   ): professional_aggregate!
+  sensitive: Boolean!
   shortDesc: String
   siret: String
   updatedAt: timestamptz
@@ -20212,7 +20213,23 @@ type structure_aggregate {
 }
 
 input structure_aggregate_bool_exp {
+  bool_and: structure_aggregate_bool_exp_bool_and
+  bool_or: structure_aggregate_bool_exp_bool_or
   count: structure_aggregate_bool_exp_count
+}
+
+input structure_aggregate_bool_exp_bool_and {
+  arguments: structure_select_column_structure_aggregate_bool_exp_bool_and_arguments_columns!
+  distinct: Boolean
+  filter: structure_bool_exp
+  predicate: Boolean_comparison_exp!
+}
+
+input structure_aggregate_bool_exp_bool_or {
+  arguments: structure_select_column_structure_aggregate_bool_exp_bool_or_arguments_columns!
+  distinct: Boolean
+  filter: structure_bool_exp
+  predicate: Boolean_comparison_exp!
 }
 
 input structure_aggregate_bool_exp_count {
@@ -20276,6 +20293,7 @@ input structure_bool_exp {
   postalCode: String_comparison_exp
   professionals: professional_bool_exp
   professionals_aggregate: professional_aggregate_bool_exp
+  sensitive: Boolean_comparison_exp
   shortDesc: String_comparison_exp
   siret: String_comparison_exp
   updatedAt: timestamptz_comparison_exp
@@ -20316,6 +20334,7 @@ input structure_insert_input {
   phone: String
   postalCode: String
   professionals: professional_arr_rel_insert_input
+  sensitive: Boolean
   shortDesc: String
   siret: String
   updatedAt: timestamptz
@@ -20445,6 +20464,7 @@ input structure_order_by {
   phone: order_by
   postalCode: order_by
   professionals_aggregate: professional_aggregate_order_by
+  sensitive: order_by
   shortDesc: order_by
   siret: order_by
   updatedAt: order_by
@@ -20740,6 +20760,9 @@ enum structure_select_column {
   postalCode
 
   """column name"""
+  sensitive
+
+  """column name"""
   shortDesc
 
   """column name"""
@@ -20750,6 +20773,22 @@ enum structure_select_column {
 
   """column name"""
   website
+}
+
+"""
+select "structure_aggregate_bool_exp_bool_and_arguments_columns" columns of table "structure"
+"""
+enum structure_select_column_structure_aggregate_bool_exp_bool_and_arguments_columns {
+  """column name"""
+  sensitive
+}
+
+"""
+select "structure_aggregate_bool_exp_bool_or_arguments_columns" columns of table "structure"
+"""
+enum structure_select_column_structure_aggregate_bool_exp_bool_or_arguments_columns {
+  """column name"""
+  sensitive
 }
 
 """
@@ -20766,6 +20805,7 @@ input structure_set_input {
   name: citext
   phone: String
   postalCode: String
+  sensitive: Boolean
   shortDesc: String
   siret: String
   updatedAt: timestamptz
@@ -20795,6 +20835,7 @@ input structure_stream_cursor_value_input {
   name: citext
   phone: String
   postalCode: String
+  sensitive: Boolean
   shortDesc: String
   siret: String
   updatedAt: timestamptz
@@ -20834,6 +20875,9 @@ enum structure_update_column {
 
   """column name"""
   postalCode
+
+  """column name"""
+  sensitive
 
   """column name"""
   shortDesc


### PR DESCRIPTION
## :wrench: Problème

Pour pouvoir obfusquer certains titres de structure, on a besoin de savoir si ce sont des structures considérées comme « sensibles ».

## :cake: Solution

Ajout d'un booléen sur la structure permettant de la marquer comme sensible.

## :desert_island: Comment tester

En tant que manager, dans la liste des structures, vérifier que le booléen structure sensible est bien affiché.
Lors de l'édition d'une structure, vérifier que la case à cocher « structure sensible » fonctionne correctement.

fix #1962 