### PR TITLE
feat: demande le consentement du bénéficiaire lors de l'ajout d'un objectif à un contrat

### DIFF
--- a/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusDetails.svelte
+++ b/app/src/lib/ui/ProNotebookFocus/ProNotebookFocusDetails.svelte
@@ -20,7 +20,7 @@
 	import { type OperationStore, mutation, operationStore, query } from '@urql/svelte';
 	import { ProNotebookActionList } from '../ProNotebookAction';
 	import ProNotebookCreatorView from '../ProNotebookCreator/ProNotebookCreatorView.svelte';
-	import ProNotebookTargetCreate from '../ProNotebookTarget/ProNotebookTargetCreate.svelte';
+	import ProNotebookTargetCreate from '../ProNotebookTarget';
 	import { targetStatusValues } from '$lib/constants';
 	import { LoaderIndicator } from '$lib/ui/utils';
 	import Alert from '$lib/ui/base/Alert.svelte';

--- a/app/src/lib/ui/ProNotebookTarget/AddNotebookTarget.gql
+++ b/app/src/lib/ui/ProNotebookTarget/AddNotebookTarget.gql
@@ -1,5 +1,15 @@
-mutation AddNotebookTarget($focusId: uuid!, $target: String!, $linkedTo: String!) {
-  create_notebook_target(focusId: $focusId, target: $target, linkedTo: $linkedTo) {
+mutation AddNotebookTarget(
+  $focusId: uuid!
+  $target: String!
+  $linkedTo: String!
+  $userConsent: Boolean!
+) {
+  create_notebook_target(
+    focusId: $focusId
+    target: $target
+    linkedTo: $linkedTo
+    userConsent: $userConsent
+  ) {
     id
   }
 }

--- a/app/src/lib/ui/ProNotebookTarget/ProNotebookTargetCreate.svelte
+++ b/app/src/lib/ui/ProNotebookTarget/ProNotebookTargetCreate.svelte
@@ -1,101 +1,52 @@
 <script lang="ts">
-	import {
-		AddNotebookTargetDocument,
-		GetRefTargetByFocusDocument,
-		RefThemeEnum,
-	} from '$lib/graphql/_gen/typed-document-nodes';
-	import { openComponent } from '$lib/stores';
-	import { trackEvent } from '$lib/tracking/matomo';
 	import { Button, Radio, Select } from '$lib/ui/base';
-	import { mutation, operationStore, query } from '@urql/svelte';
-	import { LoaderIndicator } from '$lib/ui/utils';
 	import { contractTypeFullKeys } from '$lib/constants/keys';
+	import { createEventDispatcher } from 'svelte';
+	import type { AddTargetPayload, Target } from '.';
 
-	export let focusId: string;
-	export let focusTheme: RefThemeEnum;
+	export let targets: Target[] = [];
 
-	function close() {
-		openComponent.close();
-	}
-	function transformTheme(focusTheme: RefThemeEnum): RefThemeEnum[] {
-		switch (focusTheme) {
-			case 'emploi':
-				return [
-					RefThemeEnum.ChoisirUnMetier,
-					RefThemeEnum.PreparerSaCandidature,
-					RefThemeEnum.TrouverUnEmploi,
-					RefThemeEnum.CreerUneEntreprise,
-					RefThemeEnum.SOuvrirALInternational,
-				];
-			case 'formation':
-				return [RefThemeEnum.SeFormer];
-			default:
-				return [focusTheme];
-		}
-	}
-	const refTargetStore = operationStore(GetRefTargetByFocusDocument, {
-		theme: transformTheme(focusTheme),
-	});
-	query(refTargetStore);
+	const formData: AddTargetPayload = {
+		target: null,
+		linkedTo: null,
+	};
 
-	const addNotebookTarget = mutation(
-		operationStore(AddNotebookTargetDocument, null, {
-			additionalTypenames: ['notebook_event', 'notebook_target'],
-		})
-	);
-
-	function initFormData() {
-		return {
-			target: null,
-			linkedTo: null,
-		};
-	}
-
-	const formData = initFormData();
-
-	async function createTarget() {
-		trackEvent('pro', 'notebook', `add target ${formData.target}`);
-		await addNotebookTarget({
-			focusId,
-			target: formData.target,
-			linkedTo: formData.linkedTo,
-		});
-
-		openComponent.close();
-	}
+	const dispatch = createEventDispatcher<{ 'create-target': AddTargetPayload; cancel: unknown }>();
 
 	$: targetOptions =
-		$refTargetStore.data?.refTargets.map(({ description, refTheme }) => ({
+		targets.map(({ description, refTheme }) => ({
 			label: description,
 			name: description,
 			group: refTheme.label,
 		})) || [];
 
 	$: disabled = !formData.target || !formData.linkedTo;
+
+	function onAddTarget() {
+		dispatch('create-target', formData);
+	}
+	function onCancel() {
+		dispatch('cancel');
+	}
 </script>
 
-<section class="flex flex-col gap-4">
-	<div>
-		<h1>Ajouter un objectif</h1>
-		<p class="my-6">Veuillez sélectionner un objectif</p>
-	</div>
-	<LoaderIndicator result={refTargetStore}>
-		<div class="min-w-0">
-			<Select
-				selectLabel={'Objectif'}
-				options={targetOptions}
-				bind:selected={formData.target}
-				groupOption
-			/>
-		</div>
-		<Radio
-			caption={'Veuillez sélectionner le type de contrat lié à cet objectif.'}
-			bind:selected={formData.linkedTo}
-			options={contractTypeFullKeys.options}
-		/>
-		<div class="flex flex-row gap-6 pt-4 pb-12">
-			<Button {disabled} on:click={createTarget}>Ajouter</Button>
-			<Button outline={true} on:click={close}>Annuler</Button>
-		</div>
-	</LoaderIndicator>
-</section>
+<div class="min-w-0">
+	<Select
+		name="objectif"
+		selectLabel={'Objectif'}
+		options={targetOptions}
+		bind:selected={formData.target}
+		groupOption
+	/>
+</div>
+<Radio
+	caption={'Veuillez sélectionner le type de contrat lié à cet objectif.'}
+	bind:selected={formData.linkedTo}
+	options={contractTypeFullKeys.options}
+	name="contrat"
+/>
+
+<div class="flex flex-row gap-6 pt-4 pb-12">
+	<Button title="Ajouter" {disabled} on:click={onAddTarget}>Ajouter</Button>
+	<Button title="Annuler" outline={true} on:click={onCancel}>Annuler</Button>
+</div>

--- a/app/src/lib/ui/ProNotebookTarget/ProNotebookTargetCreate.test.ts
+++ b/app/src/lib/ui/ProNotebookTarget/ProNotebookTargetCreate.test.ts
@@ -1,0 +1,76 @@
+import { describe, test } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ProNotebookTargetCreate from './ProNotebookTargetCreate.svelte';
+import type { Target } from '.';
+import userEvent from '@testing-library/user-event';
+
+const user = userEvent.setup();
+
+const targets: Target[] = [
+	{
+		id: 'a',
+		description: 'Objectif A1',
+		refTheme: { label: 'Theme 1' },
+	},
+	{
+		id: 'b',
+		description: 'Objectif B1',
+		refTheme: { label: 'Theme 1' },
+	},
+	{
+		id: 'c',
+		description: 'Objectif C',
+		refTheme: { label: 'Theme 2' },
+	},
+	{
+		id: 'd',
+		description: 'Objectif D',
+		refTheme: { label: 'Theme 2' },
+	},
+];
+describe('ProNoteBookTargetCreate', () => {
+	test('display a form', () => {
+		setupComponent();
+		expect(screen.getByText('Objectif')).toBeInTheDocument();
+		expect(
+			screen.getByText(/Veuillez sélectionner le type de contrat lié à cet objectif/)
+		).toBeInTheDocument();
+	});
+
+	test('dispatch a cancel event on cancel', async () => {
+		const { onCancel } = setupComponent();
+		const cancelButton = screen.getByText('Annuler');
+		await user.click(cancelButton);
+
+		expect(onCancel).toHaveBeenCalled();
+	});
+
+	test('dispatch a data on create target', async () => {
+		const { onAdd } = setupComponent();
+		const addButton = screen.getByTitle(/Ajouter/);
+		const select = screen.getByLabelText(/objectif/i);
+		await user.selectOptions(select, ['Objectif B1']);
+		expect(addButton).toBeDisabled();
+		await user.click(screen.getByText(/CER/i));
+
+		expect(addButton).toBeEnabled();
+
+		await user.click(addButton);
+		expect(onAdd).toBeCalledWith({ target: 'Objectif B1', linkedTo: 'cer' });
+	});
+});
+
+function setupComponent() {
+	const { component } = render(ProNotebookTargetCreate, {
+		props: {
+			targets: targets,
+		},
+	});
+	const onCancel = vi.fn();
+	const onAdd = vi.fn();
+	component.$on('cancel', onCancel);
+	component.$on('create-target', (e) => {
+		onAdd(e.detail);
+	});
+	return { onCancel, onAdd };
+}

--- a/app/src/lib/ui/ProNotebookTarget/ProNotebookTargetCreate.test.ts
+++ b/app/src/lib/ui/ProNotebookTarget/ProNotebookTargetCreate.test.ts
@@ -29,14 +29,6 @@ const targets: Target[] = [
 	},
 ];
 describe('ProNoteBookTargetCreate', () => {
-	test('display a form', () => {
-		setupComponent();
-		expect(screen.getByText('Objectif')).toBeInTheDocument();
-		expect(
-			screen.getByText(/Veuillez sélectionner le type de contrat lié à cet objectif/)
-		).toBeInTheDocument();
-	});
-
 	test('dispatch a cancel event on cancel', async () => {
 		const { onCancel } = setupComponent();
 		const cancelButton = screen.getByText('Annuler');
@@ -45,32 +37,57 @@ describe('ProNoteBookTargetCreate', () => {
 		expect(onCancel).toHaveBeenCalled();
 	});
 
-	test('dispatch a data on create target', async () => {
-		const { onAdd } = setupComponent();
-		const addButton = screen.getByTitle(/Ajouter/);
-		const select = screen.getByLabelText(/objectif/i);
+	test('dispatch  create-target event', async () => {
+		const { onAdd, submit } = setupComponent();
+		const select = screen.getByLabelText(/Objectif/);
 		await user.selectOptions(select, ['Objectif B1']);
-		expect(addButton).toBeDisabled();
 		await user.click(screen.getByText(/CER/i));
+		await user.click(screen.getByLabelText(/le bénéficiaire s'engage/i));
+		await submit();
+		expect(onAdd).toBeCalledWith({ target: 'Objectif B1', linkedTo: 'cer', consent: true });
+	});
 
-		expect(addButton).toBeEnabled();
+	test('show error when submited with empty field', async () => {
+		const { submit } = setupComponent();
+		await submit();
+		const statuses = screen.getAllByText(/Ce champ est requis/i);
+		expect(statuses.length).toBe(2);
+	});
 
-		await user.click(addButton);
-		expect(onAdd).toBeCalledWith({ target: 'Objectif B1', linkedTo: 'cer' });
+	test('hide error when fixed', async () => {
+		const { onAdd, submit } = setupComponent();
+		await submit();
+		let errorMsg = screen.getAllByText(/Ce champ est requis/i);
+		expect(errorMsg.length).toBe(2);
+		const select = screen.getByLabelText(/Objectif/);
+		await user.selectOptions(select, ['Objectif B1']);
+		errorMsg = screen.getAllByText(/Ce champ est requis/i);
+		await user.click(screen.getByText(/CER/i));
+		expect(screen.queryByText('Ce champ est requis')).toBe(null);
+		screen.getByText(/le consentement/i);
+		await user.click(screen.getByLabelText(/le bénéficiaire s'engage/i));
+		await submit();
+		expect(onAdd).toBeCalledWith({ target: 'Objectif B1', linkedTo: 'cer', consent: true });
 	});
 });
 
 function setupComponent() {
-	const { component } = render(ProNotebookTargetCreate, {
+	const { component, debug } = render(ProNotebookTargetCreate, {
 		props: {
 			targets: targets,
 		},
 	});
 	const onCancel = vi.fn();
 	const onAdd = vi.fn();
+	const submit = async () => {
+		const addButton = screen.getByText(/Ajouter/);
+		await user.click(addButton);
+	};
+
 	component.$on('cancel', onCancel);
 	component.$on('create-target', (e) => {
 		onAdd(e.detail);
 	});
-	return { onCancel, onAdd };
+
+	return { onCancel, onAdd, submit, debug };
 }

--- a/app/src/lib/ui/ProNotebookTarget/ProNotebookTargetCreateContainter.svelte
+++ b/app/src/lib/ui/ProNotebookTarget/ProNotebookTargetCreateContainter.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import {
+		AddNotebookTargetDocument,
+		GetRefTargetByFocusDocument,
+		RefThemeEnum,
+	} from '$lib/graphql/_gen/typed-document-nodes';
+	import { openComponent } from '$lib/stores';
+	import { trackEvent } from '$lib/tracking/matomo';
+	import { mutation, operationStore, query } from '@urql/svelte';
+	import { LoaderIndicator } from '$lib/ui/utils';
+	import ProNotebookTargetCreate from './ProNotebookTargetCreate.svelte';
+	import type { AddTargetPayload } from '.';
+
+	export let focusId: string;
+	export let focusTheme: RefThemeEnum;
+
+	function close() {
+		openComponent.close();
+	}
+
+	function transformTheme(focusTheme: RefThemeEnum): RefThemeEnum[] {
+		switch (focusTheme) {
+			case 'emploi':
+				return [
+					RefThemeEnum.ChoisirUnMetier,
+					RefThemeEnum.PreparerSaCandidature,
+					RefThemeEnum.TrouverUnEmploi,
+					RefThemeEnum.CreerUneEntreprise,
+					RefThemeEnum.SOuvrirALInternational,
+				];
+			case 'formation':
+				return [RefThemeEnum.SeFormer];
+			default:
+				return [focusTheme];
+		}
+	}
+	const refTargetStore = operationStore(GetRefTargetByFocusDocument, {
+		theme: transformTheme(focusTheme),
+	});
+
+	query(refTargetStore);
+
+	const addNotebookTarget = mutation(
+		operationStore(AddNotebookTargetDocument, null, {
+			additionalTypenames: ['notebook_event', 'notebook_target'],
+		})
+	);
+
+	async function createTarget(event: CustomEvent<AddTargetPayload>) {
+		trackEvent('pro', 'notebook', `add target ${event.detail.target}`);
+		await addNotebookTarget({
+			focusId,
+			target: event.detail.target,
+			linkedTo: event.detail.linkedTo,
+		});
+
+		openComponent.close();
+	}
+</script>
+
+<section class="flex flex-col gap-4">
+	<div>
+		<h1>Ajouter un objectif</h1>
+		<p class="my-6">Veuillez sélectionner un objectif</p>
+	</div>
+	<LoaderIndicator result={refTargetStore}>
+		<ProNotebookTargetCreate
+			targets={$refTargetStore.data?.refTargets}
+			on:create-target={createTarget}
+			on:cancel={close}
+		/>
+	</LoaderIndicator>
+</section>

--- a/app/src/lib/ui/ProNotebookTarget/index.ts
+++ b/app/src/lib/ui/ProNotebookTarget/index.ts
@@ -1,3 +1,11 @@
-import ProNotebookTargetCreate from './ProNotebookTargetCreate.svelte';
+import type { GetRefTargetByFocusQuery } from '$lib/graphql/_gen/typed-document-nodes';
+import ProNotebookTargetCreateContainter from './ProNotebookTargetCreateContainter.svelte';
 
-export { ProNotebookTargetCreate };
+export type Target = GetRefTargetByFocusQuery['refTargets'][number];
+
+export type AddTargetPayload = {
+	target: string;
+	linkedTo: string | null;
+};
+
+export default ProNotebookTargetCreateContainter;

--- a/app/src/lib/ui/ProNotebookTarget/index.ts
+++ b/app/src/lib/ui/ProNotebookTarget/index.ts
@@ -6,6 +6,7 @@ export type Target = GetRefTargetByFocusQuery['refTargets'][number];
 export type AddTargetPayload = {
 	target: string;
 	linkedTo: string | null;
+	consent: boolean;
 };
 
 export default ProNotebookTargetCreateContainter;

--- a/app/src/lib/ui/base/Radio.svelte
+++ b/app/src/lib/ui/base/Radio.svelte
@@ -11,6 +11,7 @@
 	export let caption: string | null = null;
 	export let ariaControls: string | null = null;
 	export let legendClass = '';
+	export let error: string | null = '';
 
 	const dispatch = createEventDispatcher();
 
@@ -23,11 +24,21 @@
 	export let name = `radio-group`;
 
 	$: groupId = `${name}-${counter}`;
+
+	$: roleProp = error ? { role: 'group' } : {};
 </script>
 
 <div class="fr-form-group">
-	<fieldset class="fr-fieldset">
-		<legend class="fr-fieldset__legend fr-text--regular" id="radio-legend">
+	<fieldset
+		class="fr-fieldset"
+		class:fr-fieldset--error={error}
+		{...roleProp}
+		aria-labelledby={`${groupId}-radio-legend`}
+	>
+		<legend
+			class="fr-fieldset__legend fr-text--regular"
+			id={`${groupId}-radio-legend ${error ? `${groupId}-error-messages` : ''}`}
+		>
 			{#if caption}
 				<span class={legendClass}>
 					{caption}
@@ -50,5 +61,10 @@
 				</div>
 			{/each}
 		</div>
+		{#if error}
+			<div class="fr-messages-group" id={`${groupId}-error-messages`} aria-live="assertive">
+				<p class="fr-message fr-message--error" id={`${groupId}-error-message-error`}>{error}</p>
+			</div>
+		{/if}
 	</fieldset>
 </div>

--- a/app/src/lib/ui/base/Select.svelte
+++ b/app/src/lib/ui/base/Select.svelte
@@ -59,7 +59,6 @@
 </script>
 
 <div
-	{id}
 	class={`fr-select-group ${error ? 'fr-select-group--error' : ''} ${
 		valid ? 'fr-select-group--valid' : ''
 	} ${twWidthClass} ${classNames}`}

--- a/app/src/lib/ui/base/Select.svelte
+++ b/app/src/lib/ui/base/Select.svelte
@@ -105,12 +105,12 @@
 	</select>
 
 	{#if error}
-		<p id={`select-error-desc-error-${id}`} class="fr-error-text" role="status">
+		<p id={`select-error-desc-error-${id}`} class="fr-error-text" aria-live="assertive">
 			{error}
 		</p>
 	{/if}
 	{#if valid}
-		<p id={`select-valid-desc-valid-${id}`} class="fr-valid-text" role="status">
+		<p id={`select-valid-desc-valid-${id}`} class="fr-valid-text" aria-live="assertive">
 			{valid}
 		</p>
 	{/if}

--- a/backend/cdb/api/db/crud/notebook_target.py
+++ b/backend/cdb/api/db/crud/notebook_target.py
@@ -29,6 +29,7 @@ async def insert_notebook_target(
                 "focusId": notebook_target.focus_id,
                 "target": notebook_target.target,
                 "linkedTo": notebook_target.linked_to,
+                "userConsent": notebook_target.user_consent,
             }
         },
     )

--- a/backend/cdb/api/v1/payloads/notebook_target.py
+++ b/backend/cdb/api/v1/payloads/notebook_target.py
@@ -9,6 +9,7 @@ class CreateNotebookTargetInput(BaseModel):
     focus_id: UUID = Field(alias="focusId")
     target: str
     linked_to: str | None = Field(alias="linkedTo")
+    user_consent: bool = Field(alias="userConsent")
 
 
 class CreateNotebookTargetActionPayload(HasuraActionPayload):

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -17,6 +17,7 @@ type Mutation {
     focusId: uuid!
     target: String!
     linkedTo: String!
+    userConsent: Boolean!
   ): CreateNotebookTargetOutput
 }
 
@@ -37,7 +38,6 @@ type Mutation {
     id: uuid!
   ): RemoveNotebookFocusOutput
 }
-
 
 type Mutation {
   update_notebook_from_pole_emploi(

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -2,7 +2,7 @@ actions:
   - name: create_notebook
     definition:
       kind: synchronous
-      handler: "{{BACKEND_API_ACTION_URL}}/v1/notebooks"
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebooks'
       headers:
         - name: secret-token
           value_from_env: ACTION_SECRET
@@ -12,7 +12,7 @@ actions:
   - name: create_notebook_focus
     definition:
       kind: synchronous
-      handler: "{{BACKEND_API_ACTION_URL}}/v1/notebook_focus"
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebook_focus'
       headers:
         - name: secret-token
           value_from_env: ACTION_SECRET
@@ -24,7 +24,7 @@ actions:
   - name: create_notebook_target
     definition:
       kind: synchronous
-      handler: "{{BACKEND_API_ACTION_URL}}/v1/notebook_target"
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebook_target'
       headers:
         - name: secret-token
           value_from_env: ACTION_SECRET
@@ -36,7 +36,7 @@ actions:
   - name: create_nps_rating
     definition:
       kind: synchronous
-      handler: "{{BACKEND_API_ACTION_URL}}/v1/nps-rating"
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/nps-rating'
       headers:
         - name: secret-token
           value_from_env: ACTION_SECRET
@@ -50,7 +50,7 @@ actions:
   - name: diagnostic_pole_emploi
     definition:
       kind: ""
-      handler: "{{BACKEND_API_ACTION_URL}}/v1/notebooks/dossier-individu-pole-emploi"
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebooks/dossier-individu-pole-emploi'
       headers:
         - name: secret-token
           value_from_env: ACTION_SECRET
@@ -63,7 +63,7 @@ actions:
   - name: remove_notebook_focus
     definition:
       kind: synchronous
-      handler: "{{BACKEND_API_ACTION_URL}}/v1/notebook_focus/delete"
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebook_focus/delete'
       headers:
         - name: secret-token
           value_from_env: ACTION_SECRET
@@ -75,7 +75,7 @@ actions:
   - name: update_notebook_from_pole_emploi
     definition:
       kind: synchronous
-      handler: "{{BACKEND_API_ACTION_URL}}/v1/notebooks/update-notebook-from-pole-emploi"
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebooks/update-notebook-from-pole-emploi'
       headers:
         - name: secret-token
           value_from_env: ACTION_SECRET
@@ -87,7 +87,7 @@ actions:
   - name: update_notebook_target_action
     definition:
       kind: synchronous
-      handler: "{{BACKEND_API_ACTION_URL}}/v1/notebook_target/update"
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/notebook_target/update'
       headers:
         - name: secret-token
           value_from_env: ACTION_SECRET
@@ -99,7 +99,7 @@ actions:
   - name: update_socio_pro
     definition:
       kind: synchronous
-      handler: "{{BACKEND_API_ACTION_URL}}/v1/socio_pro/update"
+      handler: '{{BACKEND_API_ACTION_URL}}/v1/socio_pro/update'
       headers:
         - name: secret-token
           value_from_env: ACTION_SECRET

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_target.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_notebook_target.yaml
@@ -9,16 +9,19 @@ configuration:
       custom_name: creatorId
     focus_id:
       custom_name: focusId
-    updated_at:
-      custom_name: updatedAt
     linked_to:
       custom_name: linkedTo
+    updated_at:
+      custom_name: updatedAt
+    user_consent:
+      custom_name: userConsent
   custom_column_names:
     created_at: createdAt
     creator_id: creatorId
     focus_id: focusId
-    updated_at: updatedAt
     linked_to: linkedTo
+    updated_at: updatedAt
+    user_consent: userConsent
   custom_root_fields: {}
 object_relationships:
   - name: creator
@@ -40,10 +43,13 @@ insert_permissions:
     permission:
       check: {}
       columns:
-        - id
-        - focus_id
-        - target
         - created_at
+        - focus_id
+        - id
+        - linked_to
+        - status
+        - target
+        - user_consent
       backend_only: true
   - role: orientation_manager
     permission:
@@ -61,9 +67,10 @@ insert_permissions:
       columns:
         - creator_id
         - focus_id
+        - linked_to
         - status
         - target
-        - linked_to
+        - user_consent
       backend_only: true
   - role: professional
     permission:
@@ -81,9 +88,10 @@ insert_permissions:
       columns:
         - creator_id
         - focus_id
+        - linked_to
         - status
         - target
-        - linked_to
+        - user_consent
       backend_only: true
 select_permissions:
   - role: admin_cdb

--- a/hasura/migrations/carnet_de_bord/1694023456180_alter_table_public_notebook_target_add_column_user_consent/down.sql
+++ b/hasura/migrations/carnet_de_bord/1694023456180_alter_table_public_notebook_target_add_column_user_consent/down.sql
@@ -2,3 +2,4 @@
 -- Please write an appropriate down migration for the SQL below:
 -- alter table "public"."notebook_target" add column "user_consent" boolean
 --  not null default 'false';
+ALTER TABLE "public"."notebook_target" DROP COLUMN "user_consent";

--- a/hasura/migrations/carnet_de_bord/1694023456180_alter_table_public_notebook_target_add_column_user_consent/down.sql
+++ b/hasura/migrations/carnet_de_bord/1694023456180_alter_table_public_notebook_target_add_column_user_consent/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."notebook_target" add column "user_consent" boolean
+--  not null default 'false';

--- a/hasura/migrations/carnet_de_bord/1694023456180_alter_table_public_notebook_target_add_column_user_consent/up.sql
+++ b/hasura/migrations/carnet_de_bord/1694023456180_alter_table_public_notebook_target_add_column_user_consent/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."notebook_target" add column "user_consent" boolean
+ not null default 'false';

--- a/hasura/schema.graphql
+++ b/hasura/schema.graphql
@@ -5517,7 +5517,7 @@ type mutation_root {
   create_notebook_focus(notebookId: uuid!, theme: String!): CreateNotebookFocusOutput
 
   """create a notebook target"""
-  create_notebook_target(focusId: uuid!, linkedTo: String!, target: String!): CreateNotebookTargetOutput
+  create_notebook_target(focusId: uuid!, linkedTo: String!, target: String!, userConsent: Boolean!): CreateNotebookTargetOutput
 
   """Create NPS Rating"""
   create_nps_rating(score: Int!): NPSRatingOutput
@@ -12327,6 +12327,7 @@ type notebook_target {
   status: String!
   target: String!
   updatedAt: timestamptz!
+  userConsent: Boolean!
 }
 
 """
@@ -12338,7 +12339,23 @@ type notebook_target_aggregate {
 }
 
 input notebook_target_aggregate_bool_exp {
+  bool_and: notebook_target_aggregate_bool_exp_bool_and
+  bool_or: notebook_target_aggregate_bool_exp_bool_or
   count: notebook_target_aggregate_bool_exp_count
+}
+
+input notebook_target_aggregate_bool_exp_bool_and {
+  arguments: notebook_target_select_column_notebook_target_aggregate_bool_exp_bool_and_arguments_columns!
+  distinct: Boolean
+  filter: notebook_target_bool_exp
+  predicate: Boolean_comparison_exp!
+}
+
+input notebook_target_aggregate_bool_exp_bool_or {
+  arguments: notebook_target_select_column_notebook_target_aggregate_bool_exp_bool_or_arguments_columns!
+  distinct: Boolean
+  filter: notebook_target_bool_exp
+  predicate: Boolean_comparison_exp!
 }
 
 input notebook_target_aggregate_bool_exp_count {
@@ -12395,6 +12412,7 @@ input notebook_target_bool_exp {
   status: String_comparison_exp
   target: String_comparison_exp
   updatedAt: timestamptz_comparison_exp
+  userConsent: Boolean_comparison_exp
 }
 
 """
@@ -12427,6 +12445,7 @@ input notebook_target_insert_input {
   status: String
   target: String
   updatedAt: timestamptz
+  userConsent: Boolean
 }
 
 """aggregate max on columns"""
@@ -12524,6 +12543,7 @@ input notebook_target_order_by {
   status: order_by
   target: order_by
   updatedAt: order_by
+  userConsent: order_by
 }
 
 """primary key columns input for table: notebook_target"""
@@ -12558,6 +12578,25 @@ enum notebook_target_select_column {
 
   """column name"""
   updatedAt
+
+  """column name"""
+  userConsent
+}
+
+"""
+select "notebook_target_aggregate_bool_exp_bool_and_arguments_columns" columns of table "notebook_target"
+"""
+enum notebook_target_select_column_notebook_target_aggregate_bool_exp_bool_and_arguments_columns {
+  """column name"""
+  userConsent
+}
+
+"""
+select "notebook_target_aggregate_bool_exp_bool_or_arguments_columns" columns of table "notebook_target"
+"""
+enum notebook_target_select_column_notebook_target_aggregate_bool_exp_bool_or_arguments_columns {
+  """column name"""
+  userConsent
 }
 
 """
@@ -12572,6 +12611,7 @@ input notebook_target_set_input {
   status: String
   target: String
   updatedAt: timestamptz
+  userConsent: Boolean
 }
 
 """
@@ -12595,6 +12635,7 @@ input notebook_target_stream_cursor_value_input {
   status: String
   target: String
   updatedAt: timestamptz
+  userConsent: Boolean
 }
 
 """
@@ -12624,6 +12665,9 @@ enum notebook_target_update_column {
 
   """column name"""
   updatedAt
+
+  """column name"""
+  userConsent
 }
 
 input notebook_target_updates {


### PR DESCRIPTION
## :wrench: Problème

ETQ pro, j'ai besoin de demander le consentement du bénéficiaire à l'ajout d'un objectif attaché à un contrat

## :cake: Solution

On ajoute une case à cocher pour le consentement du bénéficiaire lorsqu'un contrat est sélectionné.

## :rotating_light:  Points d'attention / Remarques

L'utilisation de yup avec svelte-form-lib pour exprimer le choix (case à cocher obligatoire si un contrat est choisi) s'est révélé compliqué. J'ai décidé de coder la validation coté front de manière indépendante.  

## :desert_island: Comment tester

- Se connecter en tant que `pierre.chevalier`
- Aller sur le carnet de `Sophie Tifour`
- Ouvrir l'axe de travail `Logement` 
- Ajouter un objectif.
- Cliquer sur Ajouter 
- Voir les erreurs s'afficher
- Sélectionner un objectif et un contrat
- Voir l'erreur s'afficher
- Cliquer la case 
- Cliquer sur Ajouter 

fix #1985
