### PR TITLE
feat: ajout de la déclaration d'accessibilité

### DIFF
--- a/app/src/lib/ui/base/Footer.svelte
+++ b/app/src/lib/ui/base/Footer.svelte
@@ -58,7 +58,10 @@
 				</li>
 				<li class="fr-footer__bottom-item">
 					<!-- svelte-ignore a11y-missing-attribute -->
-					<a class="fr-footer__bottom-link">Accessibilité : non conforme</a>
+					<a class="fr-footer__bottom-link"
+						><a class="fr-footer__bottom-link" href="/declaration-accessibilite">Accessibilité</a> :
+						non conforme</a
+					>
 				</li>
 				<li class="fr-footer__bottom-item">
 					<a class="fr-footer__bottom-link" href="/mentions-legales">Mentions légales</a>

--- a/app/src/routes/(public)/declaration-accessibilite/+page.svelte
+++ b/app/src/routes/(public)/declaration-accessibilite/+page.svelte
@@ -1,0 +1,71 @@
+<svelte:head>
+	<title>Déclaration d'accessibilité - Carnet de bord</title>
+</svelte:head>
+<div class="fr-container fr-py-6w fr-px-2w">
+	<h1>Déclaration d’accessibilité</h1>
+	<p>Établie le <span>9 novembre 2023</span>.</p>
+	<p>
+		<span>Plateforme de l'Inclusion</span> s’engage à rendre son service accessible, conformément à l’article
+		47 de la loi n° 2005-102 du 11 février 2005.
+	</p>
+	<p>
+		Cette déclaration d’accessibilité s’applique à <strong>Carnet de bord</strong>
+		<span> (<span>https://carnetdebord.inclusion.beta.gouv.fr/</span>)</span>.
+	</p>
+	<h2>État de conformité</h2>
+	<p>
+		<strong>Carnet de bord</strong> est
+		<strong><span data-printfilter="lowercase">non conforme</span></strong> avec le
+		<abbr title="Référentiel général d’amélioration de l’accessibilité">RGAA</abbr>.
+		<span>Le site n’a encore pas été audité.</span>
+	</p>
+	<h2>Résultats des tests</h2>
+	<p>
+		L’audit de conformité réalisé <span>en auto-évaluation</span> révèle que <span>25</span>% des
+		critères sont respectés.
+	</p>
+	<h2>Contenus non accessibles</h2>
+	<h2>Établissement de cette déclaration d’accessibilité</h2>
+	<p>Cette déclaration a été établie le <span>9 novembre 2023</span>.</p>
+	<h3>Technologies utilisées</h3>
+	<p>
+		L’accessibilité de <span>Carnet de bord</span> s’appuie sur les technologies suivantes&nbsp;:
+	</p>
+	<ul class="technical-information technologies-used">
+		<li>HTML</li>
+		<li>WAI-ARIA</li>
+		<li>CSS</li>
+		<li>JavaScript</li>
+	</ul>
+	<h2>Voie de recours</h2>
+	<p>
+		Cette procédure est à utiliser dans le cas suivant&nbsp;: vous avez signalé au responsable du
+		site internet un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des
+		services du portail et vous n’avez pas obtenu de réponse satisfaisante.
+	</p>
+	<p>Vous pouvez&nbsp;:</p>
+	<ul>
+		<li>
+			Écrire un message au <a href="https://formulaire.defenseurdesdroits.fr/"
+				>Défenseur des droits</a
+			>
+		</li>
+		<li>
+			Contacter <a href="https://www.defenseurdesdroits.fr/saisir/delegues"
+				>le délégué du Défenseur des droits dans votre région</a
+			>
+		</li>
+		<li>
+			Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre)&nbsp;:<br />
+			Défenseur des droits<br />
+			Libre réponse 71120 75342 Paris CEDEX 07
+		</li>
+	</ul>
+	<hr />
+	<p>
+		Cette déclaration d’accessibilité a été créé le <span>9 novembre 2023</span> grâce au
+		<a href="https://betagouv.github.io/a11y-generateur-declaration/#create"
+			>Générateur de Déclaration d’Accessibilité de BetaGouv</a
+		>.
+	</p>
+</div>


### PR DESCRIPTION
## :wrench: Problème

Obligation légale avant le 31/12 : Ajouter la déclaration d'accessibilité

## :cake: Solution

On ajoute la page avec le texte généré, cf https://github.com/gip-inclusion/carnet-de-bord/issues/2042

## :desert_island: Comment tester

Cliquer sur le lien accessibilité dans le Footer et vérifier que tout est ok.

fix #2042 
