### PR TITLE
fix: correction des CGU du footer

### DIFF
--- a/app/src/routes/(auth)/cguvalidate/+page.svelte
+++ b/app/src/routes/(auth)/cguvalidate/+page.svelte
@@ -45,662 +45,653 @@
 	<h1 class="fr-h4 mt-8">Validation des CGU</h1>
 
 	<div class="cgu">
-		<td class="d-block comment-body markdown-body js-comment-body">
-			<h4 dir="auto">Préambule</h4>
-			<ol dir="auto">
-				<li>
-					Le service « <strong>CARNET DE BORD</strong> » (ci-après « le service ») est un système d’information
-					qui permet de partager et d’échanger des informations et données relatives aux personnes rencontrant
-					des difficultés sociales et professionnelles particulières dans le cadre de leurs parcours
-					d’insertion
-				</li>
-				<li>
-					Le « service » est créé par le ministère chargé de l’insertion et administré par le
-					Groupement d’intérêt public « Plateforme de l’inclusion ».
-				</li>
-				<li>
-					« L’Utilisateur » reconnaît que l’utilisation du « service » nécessite le respect de
-					l’ensemble des dispositions des présentes et adhère sans réserve aux présentes conditions
-					générales d’utilisation.
-				</li>
-				<li>
-					« L’Utilisateur » peut bénéficier des fonctionnalités proposées par « <strong
-						>CARNET DE BORD</strong
-					> » uniquement sous réserve de l’acceptation des présentes conditions générales. Chaque nouvelles
-					versions des CGU remplace les précédentes et doivent faire l’objet d’une acceptation par l’Utilisateur
-					du service.
-				</li>
-				<li>
-					« L’Utilisateur » dispose de la faculté de sauvegarder et d’imprimer les présentes
-					conditions générales d’utilisation en utilisant les fonctionnalités standard de son
-					navigateur ou de son ordinateur.
-				</li>
-				<li>
-					« L’Utilisateur » reconnaît disposer des compétences et des moyens nécessaires pour
-					accéder au « service ».
-				</li>
-				<li>
-					Le Ministère agit en tant que responsable de traitement sur la mise à disposition du «
-					service » qui permet à « l’Utilisateur » de remplir ses missions et d’accomplir ses
-					propres traitements. Le Groupement d’intérêt public « Plateforme de l’inclusion » agit en
-					tant que sous-traitant du ministère chargé de l’insertion
-				</li>
-			</ol>
-			<h4 dir="auto">Définitions</h4>
-			<ol start="8" dir="auto">
-				<li>Les termes ci-dessous définis ont entre les parties la signification suivante :</li>
-			</ol>
-			<ul dir="auto">
-				<li>
-					« <strong>DGEFP</strong> » : Délégation générale à l’emploi et à la formation professionnelle.
-				</li>
-				<li>« <strong>CARNET DE BORD</strong> » : Application du dit Service</li>
-				<li>
-					« <strong>Salariés</strong> » et/ou « <strong>Agents</strong> » : Utilisateurs rattachés au
-					ministère du travail, du plein emploi et de l’insertion, des conseils départementaux, des centres
-					communaux d’actions sociale et des salariés de structures habilités.
-				</li>
-				<li>
-					« <strong>Ministère</strong> » : Ministère du Travail, du plein Emploi et de l’Insertion.
-				</li>
-				<li>
-					« <strong>GIP Plateforme de l’inclusion</strong> » ou « <strong>GIP</strong> » : Groupement
-					d’intérêt public Plateforme de l’inclusion
-				</li>
-				<li>
-					« <strong>Utilisateur</strong> » : désigne toute personne physique, professionnel de l’insertion,
-					qui utilise le service « CARNET DE BORD » ou l'une des fonctionnalités proposées par le service
-					et ayant accepté les présentes CGU.
-				</li>
-				<li>
-					« <strong>Personne en insertion</strong> » : les personnes rencontrant des difficultés sociales
-					et professionnelles particulières engagées dans un parcours d’insertion. Il est également appelé
-					« usager » ou « bénéficiaire ».
-				</li>
-				<li>
-					« <strong>Administrateur de territoire</strong> » : Salarié ou agent d’un organisme mentionné
-					aux articles L. 5312-1, L. 5314-1 du code du travail, L. 262-16 et L. 115-2 alinéa 5 du code
-					de l’action sociale et des familles chargé de piloter la politique d’insertion sur un territoire
-					pouvant habiliter les structures et organismes en faisant la demande et mentionné par l’article
-					L.263-4-1 du code de l’action sociale et des familles. L’administrateur de territoire est habilité
-					par le Groupement d’Intérêt Public « Plateforme de l’inclusion ».
-				</li>
-				<li>
-					« <strong>Gestionnaire de structure</strong> » : salarié ou agent d’une structure habilitée
-					ayant un rôle de gestion au sein de cette structure (habilitation des professionnels, rattachement
-					des bénéficiaires orienté vers la structure, …).
-				</li>
-				<li>
-					« <strong>Chargé d’orientation</strong> » : salarié ou agent habilité par un administrateur
-					de territoire pour l’orientation / la réorientation et le suivi de parcours des bénéficiaires.
-				</li>
-				<li>
-					« <strong>Professionnels</strong> » : salarié ou agent d’une structure, habilité par l’un de
-					ses gestionnaires de structure.
-				</li>
-				<li>
-					« <strong>Référent</strong> » : rôle attribué à un professionnel lorsque celui-ci est habilité
-					à exercer la mission de référence de parcours sur un dispositif d’accompagnement au sein d’une
-					structure et qu’il est désigné référent unique d’un usager au titre de l’article L262-30 du
-					code de l’action sociale et des familles.
-				</li>
-				<li>
-					« <strong>Structure</strong> » : organisme intervenant pour fournir un accompagnement personnalisé
-					aux personnes rencontrant des difficultés sociales et professionnelles particulières dans le
-					but de faciliter leur insertion sociale et professionnelle. Ces organismes mentionnés à l’article
-					L.263-4-1 du Code de l’Action Sociale et des Familles sont habilités par un administrateur
-					de territoire.
-				</li>
-				<li>
-					« <strong>Groupe de suivi</strong> » : Ensemble des professionnels, complété éventuellement
-					du chargé d’orientation, intervenant dans le parcours du bénéficiaire et rattaché au carnet
-					de celui-ci.
-				</li>
-				<li>
-					« <strong>Habilitation des structures ou organismes</strong> » : Processus d’autorisation ou
-					de validation choisi par l’administrateur de structure, ou le cas échéant par le Groupement
-					d’intérêt public « Plateforme de l’inclusion », permettant d’utiliser Carnet de Bord des personnes
-					prévues par l’article L.263-4-1 du code de l’action sociale et des familles. L’habilitation
-					n’est pas la même que celle prévue pour « l’administrateur de territoire ».
-				</li>
-			</ul>
-			<h4 dir="auto">Objet</h4>
-			<ol start="9" dir="auto">
-				<li>
-					Les présentes conditions générales ont pour objet de définir les modalités d’utilisation
-					du « service ». Elles sont un accord juridique et contraignant entre le Ministère et les
-					Utilisateurs.
-				</li>
-			</ol>
-			<h4 dir="auto">Opposabilité</h4>
-			<ol start="10" dir="auto">
-				<li>
-					Les présentes conditions générales sont opposables à « l’Utilisateur » dès leur
-					acceptation par ce dernier.
-				</li>
-				<li>
-					Elles seront présentées auprès du futur « Utilisateur » à l’issue de sa première
-					authentification sur « CARNET DE BORD », et de nouveau pour toute mise à jour des
-					présentes CGU.
-				</li>
-				<li>
-					Dans tous les cas, les présentes conditions générales sont réputées lues et applicables à
-					la date de l’acceptation des présentes par « l’Utilisateur » via une action positive.
-				</li>
-				<li>
-					Le Ministère se réserve le droit d’apporter aux présentes conditions générales toutes les
-					modifications ou suppressions qu’il jugera nécessaire et utile.
-				</li>
-				<li>
-					Les présentes conditions générales d’utilisation sont opposables pendant toute la durée
-					d’utilisation du « service » et jusqu’à ce que de nouvelles conditions générales
-					d’utilisation remplacent les présentes.
-				</li>
-				<li>Les conditions générales figurant en ligne prévalent sur toute autre version.</li>
-				<li>
-					« L’Utilisateur » peut à tout moment renoncer à utiliser le « service » mais reste
-					responsable de toute action effectuée sur « CARNET DE BORD » préalablement.
-				</li>
-			</ol>
-			<h4 dir="auto">Durée - entrée en vigueur</h4>
-			<ol start="17" dir="auto">
-				<li>
-					Les présentes conditions générales d’utilisation entrent en vigueur à compter de leur date
-					de mise en ligne sur « CARNET DE BORD ».
-				</li>
-			</ol>
-			<h4 dir="auto">Création ou suppression du compte / code d’accès</h4>
-			<ol start="18" dir="auto">
-				<li>
-					Procédure de création<br />
-					Administrateur de territoire : La personne, salarié ou agent d’un organisme mentionné aux articles
-					L.5312-1, L.5314-1 du code du travail, L.262-16 et L.115-2 alinéa 5 du code de l’action sociale
-					et des familles sollicite la création d’un accès Administrateur de territoire auprès du Groupement
-					d’Intérêt Public « Plateforme de l’Inclusion ». La demande est motivée.<br />
-					Chargé d’orientation : Le compte du chargé d’orientation est créé par un administrateur de
-					territoire depuis Carnet de Bord.<br />
-					Gestionnaire de structure : Le compte du gestionnaire de structure est créé par l’administrateur
-					de territoire lors de la création de la structure. D’autres cogestionnaires peuvent être ajouté
-					à une structure par l’un de ses gestionnaires.<br />
-					Professionnels : Le compte du professionnel est créé par le gestionnaire de structure ou par
-					le biais d’un traitement automatique.<br />
-					Bénéficiaires : La création d’un compte bénéficiaire est réalisée par un administrateur de
-					territoire ou par le biais d’un traitement automatisé
-				</li>
-				<li>
-					Procédure de suppression<br />
-					Administrateur de territoire : suppression du compte par le Groupement d’Intérêt public Plateforme
-					de l’inclusion après demande de l’utilisateur ou d’un autre administrateur de territoire.<br
-					/>
-					Gestionnaire de structure : Désactivation du compte de gestionnaire de structure par un autre
-					gestionnaire de la structure puis suppression après la période d’utilité administrative ou
-					suppression par le Groupement d’Intérêt Public Plateforme de l’Inclusion.<br />
-					Professionnel : désactivation du professionnel par le gestionnaire de structure ou un administrateur
-					de territoire et suppression après la durée d’utilité administrative. Suppression par le Groupement
-					d’Intérêt Public Plateforme de l’Inclusion.<br />
-					Bénéficiaire : suppression du compte du bénéficiaire après le délai d’utilité administrative
-					incluant une période de préarchivage allant jusqu’à 5 ans.
-				</li>
-				<li>« L’Utilisateur » doit indiquer une adresse électronique valide.</li>
-				<li>
-					Il incombe à « l’Utilisateur » de s’assurer qu’il a seul accès à son courrier
-					électronique.
-				</li>
-				<li>
-					Tout accès à, et toute utilisation du « service » est présumée comme émanant exclusivement
-					de « l’Utilisateur ».
-				</li>
-				<li>
-					« L’Utilisateur » est responsable de la sincérité des informations qu’il fournit et
-					s’engage à mettre à jour les informations le concernant ou à aviser le Ministère sans
-					délai de toute modification affectant sa situation.
-				</li>
-				<li>
-					En cas d’utilisation frauduleuse de son compte, « l’Utilisateur » s’engage à prévenir
-					immédiatement les équipes habilitées via la rubrique « besoin d’aide » présente sur le
-					site Carnet de Bord.
-				</li>
-			</ol>
-			<h4 dir="auto">Présentation du service</h4>
-			<ol start="25" dir="auto">
-				<li>
-					Fonctionnalités de « CARNET DE BORD »<br />
-					CARNET DE BORD permet aux administrateurs de territoire, notamment :<br />
-					• D’inscrire une structure ;<br />
-					• D’inscrire un gestionnaire de structure ;<br />
-					• D’inscrire un usager ;<br />
-					• D’avoir accès à la liste des usagers de son territoire ;<br />
-					• De permettre le rattachement d’un usager de son territoire à un professionnel ou à une structure.
-				</li>
-			</ol>
-			<p dir="auto">
-				CARNET DE BORD permet aux gestionnaires de structure, notamment :<br />
-				• D’accéder à la liste des usagers rattaché à sa structure ;<br />
-				• D’inscrire un gestionnaire de structure<br />
-				• D’inscrire un professionnel de sa structure ;<br />
-				• De rattacher un usager orienté vers la structure à un référent de sa structure.
-			</p>
-			<p dir="auto">
-				CARNET DE BORD permet aux chargés d’orientation, notamment :<br />
-				• D’accéder à la liste des usagers à orienter et à réorienter ;<br />
-				• De rechercher un usager parmi ceux du département ;<br />
-				• De modifier une information sur le profil de l’usager ;<br />
-				• De consulter le parcours de l’usager ;<br />
-				• De prendre rendez-vous avec l’usager ;<br />
-				• De permettre le rattachement d’un usager à une structure et éventuellement à un référent.
-			</p>
-			<p dir="auto">
-				CARNET DE BORD permet aux professionnels, notamment :<br />
-				• De modifier les informations d’un usager lorsque celui-ci est membre du groupe de suivi ;<br
+		<h4 dir="auto">Préambule</h4>
+		<ol dir="auto">
+			<li>
+				Le service « <strong>CARNET DE BORD</strong> » (ci-après « le service ») est un système d’information
+				qui permet de partager et d’échanger des informations et données relatives aux personnes rencontrant
+				des difficultés sociales et professionnelles particulières dans le cadre de leurs parcours d’insertion
+			</li>
+			<li>
+				Le « service » est créé par le ministère chargé de l’insertion et administré par le
+				Groupement d’intérêt public « Plateforme de l’inclusion ».
+			</li>
+			<li>
+				« L’Utilisateur » reconnaît que l’utilisation du « service » nécessite le respect de
+				l’ensemble des dispositions des présentes et adhère sans réserve aux présentes conditions
+				générales d’utilisation.
+			</li>
+			<li>
+				« L’Utilisateur » peut bénéficier des fonctionnalités proposées par « <strong
+					>CARNET DE BORD</strong
+				> » uniquement sous réserve de l’acceptation des présentes conditions générales. Chaque nouvelles
+				versions des CGU remplace les précédentes et doivent faire l’objet d’une acceptation par l’Utilisateur
+				du service.
+			</li>
+			<li>
+				« L’Utilisateur » dispose de la faculté de sauvegarder et d’imprimer les présentes
+				conditions générales d’utilisation en utilisant les fonctionnalités standard de son
+				navigateur ou de son ordinateur.
+			</li>
+			<li>
+				« L’Utilisateur » reconnaît disposer des compétences et des moyens nécessaires pour accéder
+				au « service ».
+			</li>
+			<li>
+				Le Ministère agit en tant que responsable de traitement sur la mise à disposition du «
+				service » qui permet à « l’Utilisateur » de remplir ses missions et d’accomplir ses propres
+				traitements. Le Groupement d’intérêt public « Plateforme de l’inclusion » agit en tant que
+				sous-traitant du ministère chargé de l’insertion
+			</li>
+		</ol>
+		<h4 dir="auto">Définitions</h4>
+		<ol start="8" dir="auto">
+			<li>Les termes ci-dessous définis ont entre les parties la signification suivante :</li>
+		</ol>
+		<ul dir="auto">
+			<li>
+				« <strong>DGEFP</strong> » : Délégation générale à l’emploi et à la formation professionnelle.
+			</li>
+			<li>« <strong>CARNET DE BORD</strong> » : Application du dit Service</li>
+			<li>
+				« <strong>Salariés</strong> » et/ou « <strong>Agents</strong> » : Utilisateurs rattachés au ministère
+				du travail, du plein emploi et de l’insertion, des conseils départementaux, des centres communaux
+				d’actions sociale et des salariés de structures habilités.
+			</li>
+			<li>
+				« <strong>Ministère</strong> » : Ministère du Travail, du plein Emploi et de l’Insertion.
+			</li>
+			<li>
+				« <strong>GIP Plateforme de l’inclusion</strong> » ou « <strong>GIP</strong> » : Groupement d’intérêt
+				public Plateforme de l’inclusion
+			</li>
+			<li>
+				« <strong>Utilisateur</strong> » : désigne toute personne physique, professionnel de l’insertion,
+				qui utilise le service « CARNET DE BORD » ou l'une des fonctionnalités proposées par le service
+				et ayant accepté les présentes CGU.
+			</li>
+			<li>
+				« <strong>Personne en insertion</strong> » : les personnes rencontrant des difficultés sociales
+				et professionnelles particulières engagées dans un parcours d’insertion. Il est également appelé
+				« usager » ou « bénéficiaire ».
+			</li>
+			<li>
+				« <strong>Administrateur de territoire</strong> » : Salarié ou agent d’un organisme mentionné
+				aux articles L. 5312-1, L. 5314-1 du code du travail, L. 262-16 et L. 115-2 alinéa 5 du code
+				de l’action sociale et des familles chargé de piloter la politique d’insertion sur un territoire
+				pouvant habiliter les structures et organismes en faisant la demande et mentionné par l’article
+				L.263-4-1 du code de l’action sociale et des familles. L’administrateur de territoire est habilité
+				par le Groupement d’Intérêt Public « Plateforme de l’inclusion ».
+			</li>
+			<li>
+				« <strong>Gestionnaire de structure</strong> » : salarié ou agent d’une structure habilitée ayant
+				un rôle de gestion au sein de cette structure (habilitation des professionnels, rattachement
+				des bénéficiaires orienté vers la structure, …).
+			</li>
+			<li>
+				« <strong>Chargé d’orientation</strong> » : salarié ou agent habilité par un administrateur de
+				territoire pour l’orientation / la réorientation et le suivi de parcours des bénéficiaires.
+			</li>
+			<li>
+				« <strong>Professionnels</strong> » : salarié ou agent d’une structure, habilité par l’un de
+				ses gestionnaires de structure.
+			</li>
+			<li>
+				« <strong>Référent</strong> » : rôle attribué à un professionnel lorsque celui-ci est habilité
+				à exercer la mission de référence de parcours sur un dispositif d’accompagnement au sein d’une
+				structure et qu’il est désigné référent unique d’un usager au titre de l’article L262-30 du code
+				de l’action sociale et des familles.
+			</li>
+			<li>
+				« <strong>Structure</strong> » : organisme intervenant pour fournir un accompagnement personnalisé
+				aux personnes rencontrant des difficultés sociales et professionnelles particulières dans le
+				but de faciliter leur insertion sociale et professionnelle. Ces organismes mentionnés à l’article
+				L.263-4-1 du Code de l’Action Sociale et des Familles sont habilités par un administrateur de
+				territoire.
+			</li>
+			<li>
+				« <strong>Groupe de suivi</strong> » : Ensemble des professionnels, complété éventuellement du
+				chargé d’orientation, intervenant dans le parcours du bénéficiaire et rattaché au carnet de celui-ci.
+			</li>
+			<li>
+				« <strong>Habilitation des structures ou organismes</strong> » : Processus d’autorisation ou
+				de validation choisi par l’administrateur de structure, ou le cas échéant par le Groupement d’intérêt
+				public « Plateforme de l’inclusion », permettant d’utiliser Carnet de Bord des personnes prévues
+				par l’article L.263-4-1 du code de l’action sociale et des familles. L’habilitation n’est pas
+				la même que celle prévue pour « l’administrateur de territoire ».
+			</li>
+		</ul>
+		<h4 dir="auto">Objet</h4>
+		<ol start="9" dir="auto">
+			<li>
+				Les présentes conditions générales ont pour objet de définir les modalités d’utilisation du
+				« service ». Elles sont un accord juridique et contraignant entre le Ministère et les
+				Utilisateurs.
+			</li>
+		</ol>
+		<h4 dir="auto">Opposabilité</h4>
+		<ol start="10" dir="auto">
+			<li>
+				Les présentes conditions générales sont opposables à « l’Utilisateur » dès leur acceptation
+				par ce dernier.
+			</li>
+			<li>
+				Elles seront présentées auprès du futur « Utilisateur » à l’issue de sa première
+				authentification sur « CARNET DE BORD », et de nouveau pour toute mise à jour des présentes
+				CGU.
+			</li>
+			<li>
+				Dans tous les cas, les présentes conditions générales sont réputées lues et applicables à la
+				date de l’acceptation des présentes par « l’Utilisateur » via une action positive.
+			</li>
+			<li>
+				Le Ministère se réserve le droit d’apporter aux présentes conditions générales toutes les
+				modifications ou suppressions qu’il jugera nécessaire et utile.
+			</li>
+			<li>
+				Les présentes conditions générales d’utilisation sont opposables pendant toute la durée
+				d’utilisation du « service » et jusqu’à ce que de nouvelles conditions générales
+				d’utilisation remplacent les présentes.
+			</li>
+			<li>Les conditions générales figurant en ligne prévalent sur toute autre version.</li>
+			<li>
+				« L’Utilisateur » peut à tout moment renoncer à utiliser le « service » mais reste
+				responsable de toute action effectuée sur « CARNET DE BORD » préalablement.
+			</li>
+		</ol>
+		<h4 dir="auto">Durée - entrée en vigueur</h4>
+		<ol start="17" dir="auto">
+			<li>
+				Les présentes conditions générales d’utilisation entrent en vigueur à compter de leur date
+				de mise en ligne sur « CARNET DE BORD ».
+			</li>
+		</ol>
+		<h4 dir="auto">Création ou suppression du compte / code d’accès</h4>
+		<ol start="18" dir="auto">
+			<li>
+				Procédure de création<br />
+				Administrateur de territoire : La personne, salarié ou agent d’un organisme mentionné aux articles
+				L.5312-1, L.5314-1 du code du travail, L.262-16 et L.115-2 alinéa 5 du code de l’action sociale
+				et des familles sollicite la création d’un accès Administrateur de territoire auprès du Groupement
+				d’Intérêt Public « Plateforme de l’Inclusion ». La demande est motivée.<br />
+				Chargé d’orientation : Le compte du chargé d’orientation est créé par un administrateur de territoire
+				depuis Carnet de Bord.<br />
+				Gestionnaire de structure : Le compte du gestionnaire de structure est créé par l’administrateur
+				de territoire lors de la création de la structure. D’autres cogestionnaires peuvent être ajouté
+				à une structure par l’un de ses gestionnaires.<br />
+				Professionnels : Le compte du professionnel est créé par le gestionnaire de structure ou par
+				le biais d’un traitement automatique.<br />
+				Bénéficiaires : La création d’un compte bénéficiaire est réalisée par un administrateur de territoire
+				ou par le biais d’un traitement automatisé
+			</li>
+			<li>
+				Procédure de suppression<br />
+				Administrateur de territoire : suppression du compte par le Groupement d’Intérêt public Plateforme
+				de l’inclusion après demande de l’utilisateur ou d’un autre administrateur de territoire.<br
 				/>
-				• D’accéder à l’annuaire de ses bénéficiaires ;<br />
-				• De rechercher un usager ;<br />
-				• D’inviter un autre professionnel au groupe de suivi de l’usager ;<br />
-				• Modifier une information sur le profil de l’usager ;<br />
-				• Prendre rendez-vous avec un usager ;<br />
-				• Demander le rattachement à un usager ;<br />
-				• Lorsqu’ils sont référents, de demander la réorientation d’un bénéficiaire vers un autre accompagnement
-				ou lorsque le bénéficiaire ne relève plus d’un accompagnement, vers une fin de parcours.
-			</p>
-			<p dir="auto">
-				CARNET DE BORD permet également aux usagers disposant d’un email valide :<br />
-				• De modifier ses coordonnées ;<br />
-				• D’accéder aux informations de son carnet de bord
-			</p>
-			<ol start="26" dir="auto">
-				<li>
-					Les finalités de « CARNET DE BORD » sont notamment :<br />
-					1° La mise à disposition, au moyen de services numériques, des informations et des données
-					nécessaires à l’identification des personnes en insertion, à l'évaluation de leur situation,
-					au suivi de leur parcours d'insertion, ainsi que, le cas échéant, à la réalisation des actions
-					d’accompagnement social, socio-professionnel ou professionnel ;<br />
-					2° Le partage et l’enrichissement, entre les acteurs de l’insertion, des données strictement
-					nécessaires à la mise en œuvre de leurs missions ;<br />
-					3° L’accès des personnes en insertion aux informations relatives à leur parcours, par le biais
-					d’un compte personnel dédié dans le ou les services numériques correspondants, afin de favoriser
-					leur mobilisation et leur participation à la définition du parcours ;<br />
-					4° L’amélioration de la qualité du service rendu aux utilisateurs, notamment en leur évitant
-					de communiquer ou de saisir plusieurs fois les mêmes informations ;<br />
-					5° La communication d’informations aux personnes en insertion ou leur sollicitation à des fins
-					d’enquête ou d’évaluation ;<br />
-					6° La production de statistiques, nationales et locales, à des fins d’évaluation des politiques
-					publiques.
-				</li>
-			</ol>
-			<h4 dir="auto">Accès au « service »</h4>
-			<ol start="27" dir="auto">
-				<li>
-					L’accès à « CARNET DE BORD » est ouvert aux Utilisateurs et aux usagers de Carnet de Bord
-					dans les conditions définies par les présentes CGU.
-				</li>
-				<li>
-					La plateforme peut être accessible 7 jours sur 7, sur une plage horaire quotidienne 24 sur
-					24 mais peut faire l’objet d’arrêt pour des besoins de maintenance technique ou
-					applicative.
-				</li>
-				<li>
-					Le Ministère se réserve le droit, sans préavis, ni indemnité, de fermer temporairement
-					l’accès à une ou plusieurs fonctionnalités de « CARNET DE BORD » pour effectuer une mise à
-					jour, des modifications ou changement sur les méthodes opérationnelles, les serveurs et
-					les heures d’accessibilité. Cette liste n’est pas limitative. Dans ce cas, le Ministère
-					peut indiquer une date de réouverture du compte ou d’accessibilité à une ou plusieurs
-					fonctionnalités.
-				</li>
-				<li>
-					En cas d’impossibilité d’accéder et/ou d’utiliser le « service », « l’Utilisateur » peut
-					toujours s’adresser aux équipes habilitées pour obtenir des informations via la rubrique «
-					besoin d’aide » présente sur le site Carnet de Bord.
-				</li>
-				<li>
-					Le Ministère se réserve la possibilité de mettre en place des hyperliens sur le site «
-					CARNET DE BORD » donnant accès à des pages internet autres que celles du site.
-				</li>
-				<li>
-					Le Ministère vérifie la qualité des sites qu’il recommande, néanmoins il ne saurait être
-					responsable, contrôler ou garantir l'actualité et l'exactitude des informations diffusées
-					sur les sites des sociétés, organismes ou personne privée vers lesquels il a établi des
-					liens.
-				</li>
-				<li>
-					Les Utilisateurs sont formellement informés que les sites auxquels ils peuvent accéder par
-					l’intermédiaire des liens hypertextes n’appartiennent pas tous au Ministère.
-				</li>
-				<li>
-					Le Ministère ne saurait être responsable de l’accès par les Utilisateurs via les liens
-					hypertextes mis en place dans le cadre de « CARNET DE BORD » à d’autres ressources
-					présentes sur le réseau.
-				</li>
-				<li>
-					La mise en place d’un hyperlien en direction de « CARNET DE BORD est interdite à défaut de
-					l’autorisation expresse et préalable du Ministère. Il est, en tout état de cause, interdit
-					d’imbriquer les pages de « CARNET DE BORD » à l’intérieur des pages d’un autre site.
-				</li>
-			</ol>
-			<h4 dir="auto">Assistance technique</h4>
-			<ol start="36" dir="auto">
-				<li>
-					Le Groupement d’intérêt public « Plateforme de l’inclusion » met à disposition de «
-					l’Utilisateur » un service utilisateur à même de répondre à tous les renseignements
-					nécessaires à l’accès ou à l’utilisation du « service » accessible via la rubrique «
-					besoin d’aide ».
-				</li>
-			</ol>
-			<h4 dir="auto">Confidentialité/sécurité</h4>
-			<ol start="37" dir="auto">
-				<li>
-					Le Ministère fait ses meilleurs efforts, conformément aux règles de l’art, pour sécuriser
-					les accès, données et traitements. Il ne saurait assurer une sécurité absolue.
-				</li>
-				<li>
-					L’Utilisateur est responsable de la confidentialité des informations permettant lui
-					permettant l’accès au service. Toute faille de sécurité ou violation de données résultant
-					de sa négligence, d’une imprudence favorisant un usage frauduleux ou d’un comportement
-					fautif concernant la confidentialité mentionnée présentement est de sa responsabilité, ou
-					le cas échéant de la responsabilité de l’organisme auquel elle est rattachée.
-				</li>
-				<li>
-					Il en est de même du maintien de l’altération et de l’entrave à un système de traitement
-					automatisé de données, ainsi que de l’introduction, de la suppression ou de la
-					modification frauduleuses de données.
-				</li>
-				<li>
-					« L’Utilisateur » reconnaît avoir connaissance de la nature du réseau internet, et en
-					particulier, de ses performances techniques et des temps de réponse pour consulter,
-					interroger ou transférer les données d’informations et des risques éventuels de
-					cybersécurité.
-				</li>
-				<li>
-					« L’Utilisateur » informe le GIP de l’inclusion de toute défaillance du « service » via la
-					rubrique « besoin d’aide ».
-				</li>
-				<li>
-					« L’Utilisateur » accepte de prendre toutes les mesures appropriées de façon à assurer la
-					sécurité des données contenues dans Carnet de Bord.
-				</li>
-				<li>
-					« L’Utilisateur » est informé que l’utilisation des ordinateurs accessibles au public
-					constitue une négligence, compte tenu des risques inhérents à ce type d’accès et,
-					notamment, la possibilité de compromission de la sécurité des codes d’accès (« key-loggers
-					»)
-				</li>
-			</ol>
-			<h4 dir="auto">Responsabilité du ministère</h4>
-			<ol start="44" dir="auto">
-				<li>
-					Le Ministère ne saurait être tenu pour responsable des conséquences provoquées par le
-					caractère erroné ou frauduleux des informations fournies par « l’Utilisateur ».
-				</li>
-				<li>
-					Sauf faute ou négligence prouvée du Ministère, les atteintes à la confidentialité des
-					données personnelles de « l’Utilisateur » résultant de l’utilisation des informations lui
-					permettant l’accès au service, et utilisées par un tiers ne sauraient engager la
-					responsabilité du Ministère. Tout accès non autorisé au compte d’un « utilisateur » est
-					interdit et passible de sanctions pénales.
-				</li>
-				<li>Le Ministère ne saurait être responsable de :</li>
-			</ol>
-			<ul dir="auto">
-				<li>l’impossibilité d’utiliser le « service » ;</li>
-				<li>
-					des atteintes à la sécurité informatique pouvant causer des dommages aux matériels
-					informatiques des Utilisateurs ;
-				</li>
-				<li>
-					dommages directs ou indirects résultant de l’utilisation du « service », de l'attitude, de
-					la conduite ou du comportement d'un autre Utilisateur ;
-				</li>
-				<li>
-					faits dus à un cas de force majeure, un cas fortuit ou au fait d'un tiers ou de la victime
-					du dommage.
-				</li>
-			</ul>
-			<h4 dir="auto">Responsabilité des utilisateurs</h4>
-			<ol start="47" dir="auto">
-				<li>
-					« CARNET DE BORD » est un système de traitement automatisé de données. Tout accès
-					frauduleux à ce dernier est interdit et sanctionné pénalement. Il en est de même pour
-					toute entrave ou altération du fonctionnement de ce système, ou en cas d’introduction, de
-					suppression ou de modification des données qui y sont contenues.
-				</li>
-				<li>
-					« L’Utilisateur » reste, en toutes circonstances, responsable de l’utilisation qu’il fait
-					du « service ».
-				</li>
-				<li>« L’Utilisateur » s’engage à :</li>
-			</ol>
-			<ul dir="auto">
-				<li>
-					N’utiliser le « service » et les informations auxquelles il a accès que dans les seules
-					conditions définies aux présentes conditions générales d’utilisation et conformément aux
-					dispositions législatives et réglementaires en vigueur
-				</li>
-				<li>
-					Utiliser le « service » ainsi que l’ensemble des informations auxquelles il pourra avoir
-					accès dans un but conforme à l’ordre public, aux bonnes mœurs et aux droits des tiers ; Il
-					participe au fonctionnement normal du « service ».
-				</li>
-				<li>
-					Ne pas perturber le bon fonctionnement de ce système. Il veille notamment à ne pas
-					introduire de virus ou toute autre technologie nuisible aux fonctionnalités qui y sont
-					proposés ;
-				</li>
-				<li>
-					Ne commettre aucun acte pouvant mettre en cause la sécurité informatique du Ministère ou
-					des autres Utilisateurs.
-				</li>
-			</ul>
-			<ol start="50" dir="auto">
-				<li>
-					Toute autre utilisation donne droit au Ministère de fermer l’accès au « service » de «
-					l’Utilisateur », de supprimer les données et fichiers y figurant, de supprimer l'accès à
-					ses données ou fichiers, ou d'interdire à « l’Utilisateur » l'accès de tout ou partie du «
-					service ». Par ailleurs, toute utilisation en violation des présentes conditions générales
-					d’utilisation peut donner lieu à la fermeture de l’accès au service.
-				</li>
-				<li>Les utilisations suivantes du « service » sont formellement prohibées, notamment :</li>
-			</ol>
-			<ul dir="auto">
-				<li>
-					Le fait d’endommager, de désactiver, de surcharger l’infrastructure de « CARNET DE BORD »
-					ou encore d’entraver la jouissance du « service » par les autres Utilisateurs ;
-				</li>
-				<li>
-					Les tentatives d’accès non autorisé au « service », à d’autres comptes, aux systèmes
-					informatiques ou à d’autres réseaux connectés au « service » via le piratage ou toute
-					autre méthode ;
-				</li>
-				<li>
-					Une réutilisation ultérieure des données contraire aux dispositions légales et
-					réglementaires relatives à la protection des données personnelles, ou une réutilisation
-					incompatible avec les finalités initiales de « CARNET DE BORD ».
-				</li>
-			</ul>
-			<ol start="52" dir="auto">
-				<li>
-					Par ailleurs, « l’Utilisateur » s’engage à ne pas mettre en ligne des contenus
-					inappropriés, notamment :
-				</li>
-			</ol>
-			<ul dir="auto">
-				<li>sans rapport avec l’objet des fonctionnalités de « CARNET DE BORD » ;</li>
-				<li>comportant des opinions, politiques, religieuses ou philosophiques ;</li>
-				<li>contraires aux bonnes mœurs.</li>
-			</ul>
-			<ol start="53" dir="auto">
-				<li>
-					« L’Utilisateur » ne doit pas, sous peine de sanctions pénales, mettre en ligne des
-					contenus illégaux. Il veille à avoir des propos demeurent modérés et professionnels. Il
-					s’engage notamment à ne pas :
-				</li>
-			</ol>
-			<ul dir="auto">
-				<li>faire l’apologie de crimes contre l’humanité ;</li>
-				<li>inciter à la commission d’acte de terrorisme ou faire leur apologie ;</li>
-				<li>inciter à haine raciale ;</li>
-				<li>
-					inciter à la haine à l’égard de personnes à raison de leur sexe, de leur orientation ou
-					identité sexuelle ;
-				</li>
-				<li>inciter à la haine à l’égard de personnes à raison de leur handicap ;</li>
-				<li>diffuser de la pornographie, notamment enfantine ;</li>
-				<li>inciter à la violence, notamment, aux violences faites aux femmes ;</li>
-				<li>porter atteinte à la dignité humaine ;</li>
-				<li>proférer des injures ;</li>
-				<li>
-					alléguer ou imputer un fait qui porte atteinte à l'honneur ou à la considération d'une
-					personne (diffamation)
-				</li>
-			</ul>
-			<ol start="54" dir="auto">
-				<li>
-					L’Utilisateur s’engage à respecter la charte graphique de l’Etat, et à ne pas reprendre
-					les éléments de représentation.
-				</li>
-			</ol>
-			<h4 dir="auto">Propriété intellectuelle</h4>
-			<ol start="55" dir="auto">
-				<li>
-					« L’Utilisateur » reconnaît et accepte que le contenu de « CARNET DE BORD », et notamment
-					mais non exclusivement les textes, marques, photographies, vidéos, sons, musiques, mise en
-					page, charte graphique, logos, logiciels, les bases de données, design ou toute autre
-					information ou support présenté par le Ministère, sont protégés par leurs droits
-					d'auteurs, marque, brevet et tout autre droit de propriété intellectuelle ou industrielle
-					qui leur sont reconnus selon les lois en vigueur.
-				</li>
-			</ol>
-			<h4 dir="auto">Protection des données personnelles</h4>
-			<ol start="56" dir="auto">
-				<li>
-					La création de compte d’un « utilisateur » et son authentification nécessite la
-					communication par ce dernier de données à caractère personnel à des fins d’accès et
-					d’utilisation de l’application sécurisée ; à défaut aucun accès ou utilisation du «
-					service » n’est possible.
-				</li>
-				<li>
-					Les données à caractère personnel sont traitées dans l’application « CARNET DE BORD »
-					conformément aux dispositions du Règlement Général sur les Données Personnelles (RGPD), de
-					la Loi n° 78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés,
-					et des dispositions spécifiques du code de l’action sociale et des familles relatives à
-					l’échange de données entre acteurs de l’insertion.
-				</li>
-				<li>
-					Conformément à l’article L322-2 du code entre le public et l’administration, la
-					réutilisation éventuelle d'informations publiques comportant des données à caractère
-					personnel est subordonnée au respect des dispositions de la <a
-						href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000886460&amp;categorieLien=cid"
-						rel="nofollow"
-						class="rgh-seen--16452622714">loi n° 78-17 du 6 janvier 1978</a
-					> relative à l'informatique, aux fichiers et aux libertés.
-				</li>
-				<li>
-					« L’Utilisateur » s’engage à ne faire figurer aucune donnée sensible ou perçue comme
-					sensible au sens de l’article 9 et 10 du RGPD qui ne seraient pas nécessaires au
-					traitement.
-				</li>
-				<li>
-					Pour plus d’information, veuillez-vous rendre sur notre politique de confidentialité
-					accessible sur le pied de page de la page d’accueil de « CARNET DE BORD », bouton «
-					protection des données personnelles »
-				</li>
-			</ol>
-			<h4 dir="auto">Résiliation - résolution</h4>
-			<ol start="61" dir="auto">
-				<li>
-					En cas de manquement aux obligations des présentes, « l’Utilisateur » ou le Ministère
-					pourront prononcer de plein droit la résiliation ou la résolution des présentes sans
-					préjudice de tous dommages et intérêts auxquels ils pourraient prétendre en vertu des
-					présentes.
-				</li>
-			</ol>
-			<h4 dir="auto">Durée de l’accord</h4>
-			<ol start="62" dir="auto">
-				<li>
-					L’Accord est conclu pour une durée indéterminée à compter de l’acceptation des présentes
-					conditions générales par « l’Utilisateur » des CGU.
-				</li>
-			</ol>
-			<h4 dir="auto">Résiliation de l’accord</h4>
-			<ol start="63" dir="auto">
-				<li>
-					En cas de non-respect des CGU, si, à l’issue d’un délai de huit (8) jours calendaires à
-					compter de la notification par le Ministère du manquement constaté, « l’Utilisateur » n’a
-					pas mis fin à ce manquement ou que ce dernier n’a pas été réparé, le Ministère pourra
-					résilier l’Accord immédiatement et de plein droit, indépendamment de tous dommages et
-					intérêts auxquels il pourrait prétendre.
-				</li>
-			</ol>
-			<h4 dir="auto">Convention de preuve</h4>
-			<ol start="64" dir="auto">
-				<li>
-					L’acceptation des conditions générales par voie électronique a, entre le Ministère et «
-					l’Utilisateur », la même valeur probante que l’accord sur support papier.
-				</li>
-				<li>
-					Les registres informatisés et conservés dans les systèmes informatiques seront conservés
-					dans des conditions raisonnables de sécurité et considérés comme des preuves de
-					communications intervenues entre les parties.
-				</li>
-			</ol>
-			<h4 dir="auto">Traçabilité</h4>
-			<ol start="66" dir="auto">
-				<li>
-					Le Ministère conserve l’historique des évènements des Utilisateurs de « CARNET DE BORD »
-					et des conditions générales d’utilisation successives, le cas échéant.
-				</li>
-				<li>
-					En outre, le Ministère pourra suivre la navigation de « l’Utilisateur » au sein du «
-					service » grâce à des mesures de traçabilité.
-				</li>
-				<li>
-					Ces données de traçabilité sont conservées, à des fins de sécurité, pour une durée d’un
-					an.
-				</li>
-			</ol>
-			<h4 dir="auto">Nullité</h4>
-			<ol start="69" dir="auto">
-				<li>
-					Si une ou plusieurs stipulations des présentes sont tenues pour non valides ou déclarées
-					comme telles en application d’une loi, d’un règlement ou à la suite d’une décision passée
-					en force de chose jugée d’une juridiction compétente, les autres stipulations garderont
-					toute leur force et leur portée.
-				</li>
-			</ol>
-			<h4 dir="auto">Loi applicable</h4>
-			<ol start="70" dir="auto">
-				<li>Les présentes conditions générales sont régies par la loi française.</li>
-				<li>
-					Il en est ainsi pour les règles de fond et les règles de forme et ce, nonobstant les lieux
-					d’exécution des obligations substantielles ou accessoires
-				</li>
-			</ol>
-			<h4 dir="auto">CONFIGURATIONS REQUISES DES POSTES INFORMATIQUES</h4>
-			<p dir="auto">
-				Conditions d’accès au service « CARNET DE BORD » :<br />
-				Les utilisateurs de « CARNET DE BORD disposent d’un poste informatique équipé de :
-			</p>
-			<ul dir="auto">
-				<li>Un système d'exploitation maintenu par l'éditeur,</li>
-				<li>Un antivirus connecté à une console de gestion centralisée,</li>
-				<li>
-					Un navigateur mis à jour,<br />
-					Les utilisateurs « CARNET DE BORD » ne sont pas autorisés aux pratiques suivantes :
-				</li>
-				<li>
-					Utilisation d’outils de transfert de fichiers (WeTransfer/GoogleDrive) pour échanger des
-					données issues de « CARNET DE BORD »
-				</li>
-				<li>
-					Utilisation de logiciels d’emailing pour communiquer des données issues de « CARNET DE
-					BORD »<br />
-					Bonnes pratiques à l’attention des utilisateurs :
-				</li>
-				<li>Verrouiller le poste informatique en cas d’absence ou d’éloignement du poste</li>
-				<li>
-					Être attentif et vigilant lors de la réception de mail avant de cliquer sur un lien ou
-					d’ouvrir des pièces jointes.
-				</li>
-			</ul>
-		</td>
+				Gestionnaire de structure : Désactivation du compte de gestionnaire de structure par un autre
+				gestionnaire de la structure puis suppression après la période d’utilité administrative ou suppression
+				par le Groupement d’Intérêt Public Plateforme de l’Inclusion.<br />
+				Professionnel : désactivation du professionnel par le gestionnaire de structure ou un administrateur
+				de territoire et suppression après la durée d’utilité administrative. Suppression par le Groupement
+				d’Intérêt Public Plateforme de l’Inclusion.<br />
+				Bénéficiaire : suppression du compte du bénéficiaire après le délai d’utilité administrative
+				incluant une période de préarchivage allant jusqu’à 5 ans.
+			</li>
+			<li>« L’Utilisateur » doit indiquer une adresse électronique valide.</li>
+			<li>
+				Il incombe à « l’Utilisateur » de s’assurer qu’il a seul accès à son courrier électronique.
+			</li>
+			<li>
+				Tout accès à, et toute utilisation du « service » est présumée comme émanant exclusivement
+				de « l’Utilisateur ».
+			</li>
+			<li>
+				« L’Utilisateur » est responsable de la sincérité des informations qu’il fournit et s’engage
+				à mettre à jour les informations le concernant ou à aviser le Ministère sans délai de toute
+				modification affectant sa situation.
+			</li>
+			<li>
+				En cas d’utilisation frauduleuse de son compte, « l’Utilisateur » s’engage à prévenir
+				immédiatement les équipes habilitées via la rubrique « besoin d’aide » présente sur le site
+				Carnet de Bord.
+			</li>
+		</ol>
+		<h4 dir="auto">Présentation du service</h4>
+		<ol start="25" dir="auto">
+			<li>
+				Fonctionnalités de « CARNET DE BORD »<br />
+				CARNET DE BORD permet aux administrateurs de territoire, notamment :<br />
+				• D’inscrire une structure ;<br />
+				• D’inscrire un gestionnaire de structure ;<br />
+				• D’inscrire un usager ;<br />
+				• D’avoir accès à la liste des usagers de son territoire ;<br />
+				• De permettre le rattachement d’un usager de son territoire à un professionnel ou à une structure.
+			</li>
+		</ol>
+		<p dir="auto">
+			CARNET DE BORD permet aux gestionnaires de structure, notamment :<br />
+			• D’accéder à la liste des usagers rattaché à sa structure ;<br />
+			• D’inscrire un gestionnaire de structure<br />
+			• D’inscrire un professionnel de sa structure ;<br />
+			• De rattacher un usager orienté vers la structure à un référent de sa structure.
+		</p>
+		<p dir="auto">
+			CARNET DE BORD permet aux chargés d’orientation, notamment :<br />
+			• D’accéder à la liste des usagers à orienter et à réorienter ;<br />
+			• De rechercher un usager parmi ceux du département ;<br />
+			• De modifier une information sur le profil de l’usager ;<br />
+			• De consulter le parcours de l’usager ;<br />
+			• De prendre rendez-vous avec l’usager ;<br />
+			• De permettre le rattachement d’un usager à une structure et éventuellement à un référent.
+		</p>
+		<p dir="auto">
+			CARNET DE BORD permet aux professionnels, notamment :<br />
+			• De modifier les informations d’un usager lorsque celui-ci est membre du groupe de suivi ;<br
+			/>
+			• D’accéder à l’annuaire de ses bénéficiaires ;<br />
+			• De rechercher un usager ;<br />
+			• D’inviter un autre professionnel au groupe de suivi de l’usager ;<br />
+			• Modifier une information sur le profil de l’usager ;<br />
+			• Prendre rendez-vous avec un usager ;<br />
+			• Demander le rattachement à un usager ;<br />
+			• Lorsqu’ils sont référents, de demander la réorientation d’un bénéficiaire vers un autre accompagnement
+			ou lorsque le bénéficiaire ne relève plus d’un accompagnement, vers une fin de parcours.
+		</p>
+		<p dir="auto">
+			CARNET DE BORD permet également aux usagers disposant d’un email valide :<br />
+			• De modifier ses coordonnées ;<br />
+			• D’accéder aux informations de son carnet de bord
+		</p>
+		<ol start="26" dir="auto">
+			<li>
+				Les finalités de « CARNET DE BORD » sont notamment :<br />
+				1° La mise à disposition, au moyen de services numériques, des informations et des données nécessaires
+				à l’identification des personnes en insertion, à l'évaluation de leur situation, au suivi de
+				leur parcours d'insertion, ainsi que, le cas échéant, à la réalisation des actions d’accompagnement
+				social, socio-professionnel ou professionnel ;<br />
+				2° Le partage et l’enrichissement, entre les acteurs de l’insertion, des données strictement
+				nécessaires à la mise en œuvre de leurs missions ;<br />
+				3° L’accès des personnes en insertion aux informations relatives à leur parcours, par le biais
+				d’un compte personnel dédié dans le ou les services numériques correspondants, afin de favoriser
+				leur mobilisation et leur participation à la définition du parcours ;<br />
+				4° L’amélioration de la qualité du service rendu aux utilisateurs, notamment en leur évitant
+				de communiquer ou de saisir plusieurs fois les mêmes informations ;<br />
+				5° La communication d’informations aux personnes en insertion ou leur sollicitation à des fins
+				d’enquête ou d’évaluation ;<br />
+				6° La production de statistiques, nationales et locales, à des fins d’évaluation des politiques
+				publiques.
+			</li>
+		</ol>
+		<h4 dir="auto">Accès au « service »</h4>
+		<ol start="27" dir="auto">
+			<li>
+				L’accès à « CARNET DE BORD » est ouvert aux Utilisateurs et aux usagers de Carnet de Bord
+				dans les conditions définies par les présentes CGU.
+			</li>
+			<li>
+				La plateforme peut être accessible 7 jours sur 7, sur une plage horaire quotidienne 24 sur
+				24 mais peut faire l’objet d’arrêt pour des besoins de maintenance technique ou applicative.
+			</li>
+			<li>
+				Le Ministère se réserve le droit, sans préavis, ni indemnité, de fermer temporairement
+				l’accès à une ou plusieurs fonctionnalités de « CARNET DE BORD » pour effectuer une mise à
+				jour, des modifications ou changement sur les méthodes opérationnelles, les serveurs et les
+				heures d’accessibilité. Cette liste n’est pas limitative. Dans ce cas, le Ministère peut
+				indiquer une date de réouverture du compte ou d’accessibilité à une ou plusieurs
+				fonctionnalités.
+			</li>
+			<li>
+				En cas d’impossibilité d’accéder et/ou d’utiliser le « service », « l’Utilisateur » peut
+				toujours s’adresser aux équipes habilitées pour obtenir des informations via la rubrique «
+				besoin d’aide » présente sur le site Carnet de Bord.
+			</li>
+			<li>
+				Le Ministère se réserve la possibilité de mettre en place des hyperliens sur le site «
+				CARNET DE BORD » donnant accès à des pages internet autres que celles du site.
+			</li>
+			<li>
+				Le Ministère vérifie la qualité des sites qu’il recommande, néanmoins il ne saurait être
+				responsable, contrôler ou garantir l'actualité et l'exactitude des informations diffusées
+				sur les sites des sociétés, organismes ou personne privée vers lesquels il a établi des
+				liens.
+			</li>
+			<li>
+				Les Utilisateurs sont formellement informés que les sites auxquels ils peuvent accéder par
+				l’intermédiaire des liens hypertextes n’appartiennent pas tous au Ministère.
+			</li>
+			<li>
+				Le Ministère ne saurait être responsable de l’accès par les Utilisateurs via les liens
+				hypertextes mis en place dans le cadre de « CARNET DE BORD » à d’autres ressources présentes
+				sur le réseau.
+			</li>
+			<li>
+				La mise en place d’un hyperlien en direction de « CARNET DE BORD est interdite à défaut de
+				l’autorisation expresse et préalable du Ministère. Il est, en tout état de cause, interdit
+				d’imbriquer les pages de « CARNET DE BORD » à l’intérieur des pages d’un autre site.
+			</li>
+		</ol>
+		<h4 dir="auto">Assistance technique</h4>
+		<ol start="36" dir="auto">
+			<li>
+				Le Groupement d’intérêt public « Plateforme de l’inclusion » met à disposition de «
+				l’Utilisateur » un service utilisateur à même de répondre à tous les renseignements
+				nécessaires à l’accès ou à l’utilisation du « service » accessible via la rubrique « besoin
+				d’aide ».
+			</li>
+		</ol>
+		<h4 dir="auto">Confidentialité/sécurité</h4>
+		<ol start="37" dir="auto">
+			<li>
+				Le Ministère fait ses meilleurs efforts, conformément aux règles de l’art, pour sécuriser
+				les accès, données et traitements. Il ne saurait assurer une sécurité absolue.
+			</li>
+			<li>
+				L’Utilisateur est responsable de la confidentialité des informations permettant lui
+				permettant l’accès au service. Toute faille de sécurité ou violation de données résultant de
+				sa négligence, d’une imprudence favorisant un usage frauduleux ou d’un comportement fautif
+				concernant la confidentialité mentionnée présentement est de sa responsabilité, ou le cas
+				échéant de la responsabilité de l’organisme auquel elle est rattachée.
+			</li>
+			<li>
+				Il en est de même du maintien de l’altération et de l’entrave à un système de traitement
+				automatisé de données, ainsi que de l’introduction, de la suppression ou de la modification
+				frauduleuses de données.
+			</li>
+			<li>
+				« L’Utilisateur » reconnaît avoir connaissance de la nature du réseau internet, et en
+				particulier, de ses performances techniques et des temps de réponse pour consulter,
+				interroger ou transférer les données d’informations et des risques éventuels de
+				cybersécurité.
+			</li>
+			<li>
+				« L’Utilisateur » informe le GIP de l’inclusion de toute défaillance du « service » via la
+				rubrique « besoin d’aide ».
+			</li>
+			<li>
+				« L’Utilisateur » accepte de prendre toutes les mesures appropriées de façon à assurer la
+				sécurité des données contenues dans Carnet de Bord.
+			</li>
+			<li>
+				« L’Utilisateur » est informé que l’utilisation des ordinateurs accessibles au public
+				constitue une négligence, compte tenu des risques inhérents à ce type d’accès et, notamment,
+				la possibilité de compromission de la sécurité des codes d’accès (« key-loggers »)
+			</li>
+		</ol>
+		<h4 dir="auto">Responsabilité du ministère</h4>
+		<ol start="44" dir="auto">
+			<li>
+				Le Ministère ne saurait être tenu pour responsable des conséquences provoquées par le
+				caractère erroné ou frauduleux des informations fournies par « l’Utilisateur ».
+			</li>
+			<li>
+				Sauf faute ou négligence prouvée du Ministère, les atteintes à la confidentialité des
+				données personnelles de « l’Utilisateur » résultant de l’utilisation des informations lui
+				permettant l’accès au service, et utilisées par un tiers ne sauraient engager la
+				responsabilité du Ministère. Tout accès non autorisé au compte d’un « utilisateur » est
+				interdit et passible de sanctions pénales.
+			</li>
+			<li>Le Ministère ne saurait être responsable de :</li>
+		</ol>
+		<ul dir="auto">
+			<li>l’impossibilité d’utiliser le « service » ;</li>
+			<li>
+				des atteintes à la sécurité informatique pouvant causer des dommages aux matériels
+				informatiques des Utilisateurs ;
+			</li>
+			<li>
+				dommages directs ou indirects résultant de l’utilisation du « service », de l'attitude, de
+				la conduite ou du comportement d'un autre Utilisateur ;
+			</li>
+			<li>
+				faits dus à un cas de force majeure, un cas fortuit ou au fait d'un tiers ou de la victime
+				du dommage.
+			</li>
+		</ul>
+		<h4 dir="auto">Responsabilité des utilisateurs</h4>
+		<ol start="47" dir="auto">
+			<li>
+				« CARNET DE BORD » est un système de traitement automatisé de données. Tout accès frauduleux
+				à ce dernier est interdit et sanctionné pénalement. Il en est de même pour toute entrave ou
+				altération du fonctionnement de ce système, ou en cas d’introduction, de suppression ou de
+				modification des données qui y sont contenues.
+			</li>
+			<li>
+				« L’Utilisateur » reste, en toutes circonstances, responsable de l’utilisation qu’il fait du
+				« service ».
+			</li>
+			<li>« L’Utilisateur » s’engage à :</li>
+		</ol>
+		<ul dir="auto">
+			<li>
+				N’utiliser le « service » et les informations auxquelles il a accès que dans les seules
+				conditions définies aux présentes conditions générales d’utilisation et conformément aux
+				dispositions législatives et réglementaires en vigueur
+			</li>
+			<li>
+				Utiliser le « service » ainsi que l’ensemble des informations auxquelles il pourra avoir
+				accès dans un but conforme à l’ordre public, aux bonnes mœurs et aux droits des tiers ; Il
+				participe au fonctionnement normal du « service ».
+			</li>
+			<li>
+				Ne pas perturber le bon fonctionnement de ce système. Il veille notamment à ne pas
+				introduire de virus ou toute autre technologie nuisible aux fonctionnalités qui y sont
+				proposés ;
+			</li>
+			<li>
+				Ne commettre aucun acte pouvant mettre en cause la sécurité informatique du Ministère ou des
+				autres Utilisateurs.
+			</li>
+		</ul>
+		<ol start="50" dir="auto">
+			<li>
+				Toute autre utilisation donne droit au Ministère de fermer l’accès au « service » de «
+				l’Utilisateur », de supprimer les données et fichiers y figurant, de supprimer l'accès à ses
+				données ou fichiers, ou d'interdire à « l’Utilisateur » l'accès de tout ou partie du «
+				service ». Par ailleurs, toute utilisation en violation des présentes conditions générales
+				d’utilisation peut donner lieu à la fermeture de l’accès au service.
+			</li>
+			<li>Les utilisations suivantes du « service » sont formellement prohibées, notamment :</li>
+		</ol>
+		<ul dir="auto">
+			<li>
+				Le fait d’endommager, de désactiver, de surcharger l’infrastructure de « CARNET DE BORD » ou
+				encore d’entraver la jouissance du « service » par les autres Utilisateurs ;
+			</li>
+			<li>
+				Les tentatives d’accès non autorisé au « service », à d’autres comptes, aux systèmes
+				informatiques ou à d’autres réseaux connectés au « service » via le piratage ou toute autre
+				méthode ;
+			</li>
+			<li>
+				Une réutilisation ultérieure des données contraire aux dispositions légales et
+				réglementaires relatives à la protection des données personnelles, ou une réutilisation
+				incompatible avec les finalités initiales de « CARNET DE BORD ».
+			</li>
+		</ul>
+		<ol start="52" dir="auto">
+			<li>
+				Par ailleurs, « l’Utilisateur » s’engage à ne pas mettre en ligne des contenus inappropriés,
+				notamment :
+			</li>
+		</ol>
+		<ul dir="auto">
+			<li>sans rapport avec l’objet des fonctionnalités de « CARNET DE BORD » ;</li>
+			<li>comportant des opinions, politiques, religieuses ou philosophiques ;</li>
+			<li>contraires aux bonnes mœurs.</li>
+		</ul>
+		<ol start="53" dir="auto">
+			<li>
+				« L’Utilisateur » ne doit pas, sous peine de sanctions pénales, mettre en ligne des contenus
+				illégaux. Il veille à avoir des propos demeurent modérés et professionnels. Il s’engage
+				notamment à ne pas :
+			</li>
+		</ol>
+		<ul dir="auto">
+			<li>faire l’apologie de crimes contre l’humanité ;</li>
+			<li>inciter à la commission d’acte de terrorisme ou faire leur apologie ;</li>
+			<li>inciter à haine raciale ;</li>
+			<li>
+				inciter à la haine à l’égard de personnes à raison de leur sexe, de leur orientation ou
+				identité sexuelle ;
+			</li>
+			<li>inciter à la haine à l’égard de personnes à raison de leur handicap ;</li>
+			<li>diffuser de la pornographie, notamment enfantine ;</li>
+			<li>inciter à la violence, notamment, aux violences faites aux femmes ;</li>
+			<li>porter atteinte à la dignité humaine ;</li>
+			<li>proférer des injures ;</li>
+			<li>
+				alléguer ou imputer un fait qui porte atteinte à l'honneur ou à la considération d'une
+				personne (diffamation)
+			</li>
+		</ul>
+		<ol start="54" dir="auto">
+			<li>
+				L’Utilisateur s’engage à respecter la charte graphique de l’Etat, et à ne pas reprendre les
+				éléments de représentation.
+			</li>
+		</ol>
+		<h4 dir="auto">Propriété intellectuelle</h4>
+		<ol start="55" dir="auto">
+			<li>
+				« L’Utilisateur » reconnaît et accepte que le contenu de « CARNET DE BORD », et notamment
+				mais non exclusivement les textes, marques, photographies, vidéos, sons, musiques, mise en
+				page, charte graphique, logos, logiciels, les bases de données, design ou toute autre
+				information ou support présenté par le Ministère, sont protégés par leurs droits d'auteurs,
+				marque, brevet et tout autre droit de propriété intellectuelle ou industrielle qui leur sont
+				reconnus selon les lois en vigueur.
+			</li>
+		</ol>
+		<h4 dir="auto">Protection des données personnelles</h4>
+		<ol start="56" dir="auto">
+			<li>
+				La création de compte d’un « utilisateur » et son authentification nécessite la
+				communication par ce dernier de données à caractère personnel à des fins d’accès et
+				d’utilisation de l’application sécurisée ; à défaut aucun accès ou utilisation du « service
+				» n’est possible.
+			</li>
+			<li>
+				Les données à caractère personnel sont traitées dans l’application « CARNET DE BORD »
+				conformément aux dispositions du Règlement Général sur les Données Personnelles (RGPD), de
+				la Loi n° 78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés,
+				et des dispositions spécifiques du code de l’action sociale et des familles relatives à
+				l’échange de données entre acteurs de l’insertion.
+			</li>
+			<li>
+				Conformément à l’article L322-2 du code entre le public et l’administration, la
+				réutilisation éventuelle d'informations publiques comportant des données à caractère
+				personnel est subordonnée au respect des dispositions de la <a
+					href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000886460&amp;categorieLien=cid"
+					rel="nofollow"
+					class="rgh-seen--16452622714">loi n° 78-17 du 6 janvier 1978</a
+				> relative à l'informatique, aux fichiers et aux libertés.
+			</li>
+			<li>
+				« L’Utilisateur » s’engage à ne faire figurer aucune donnée sensible ou perçue comme
+				sensible au sens de l’article 9 et 10 du RGPD qui ne seraient pas nécessaires au traitement.
+			</li>
+			<li>
+				Pour plus d’information, veuillez-vous rendre sur notre politique de confidentialité
+				accessible sur le pied de page de la page d’accueil de « CARNET DE BORD », bouton «
+				protection des données personnelles »
+			</li>
+		</ol>
+		<h4 dir="auto">Résiliation - résolution</h4>
+		<ol start="61" dir="auto">
+			<li>
+				En cas de manquement aux obligations des présentes, « l’Utilisateur » ou le Ministère
+				pourront prononcer de plein droit la résiliation ou la résolution des présentes sans
+				préjudice de tous dommages et intérêts auxquels ils pourraient prétendre en vertu des
+				présentes.
+			</li>
+		</ol>
+		<h4 dir="auto">Durée de l’accord</h4>
+		<ol start="62" dir="auto">
+			<li>
+				L’Accord est conclu pour une durée indéterminée à compter de l’acceptation des présentes
+				conditions générales par « l’Utilisateur » des CGU.
+			</li>
+		</ol>
+		<h4 dir="auto">Résiliation de l’accord</h4>
+		<ol start="63" dir="auto">
+			<li>
+				En cas de non-respect des CGU, si, à l’issue d’un délai de huit (8) jours calendaires à
+				compter de la notification par le Ministère du manquement constaté, « l’Utilisateur » n’a
+				pas mis fin à ce manquement ou que ce dernier n’a pas été réparé, le Ministère pourra
+				résilier l’Accord immédiatement et de plein droit, indépendamment de tous dommages et
+				intérêts auxquels il pourrait prétendre.
+			</li>
+		</ol>
+		<h4 dir="auto">Convention de preuve</h4>
+		<ol start="64" dir="auto">
+			<li>
+				L’acceptation des conditions générales par voie électronique a, entre le Ministère et «
+				l’Utilisateur », la même valeur probante que l’accord sur support papier.
+			</li>
+			<li>
+				Les registres informatisés et conservés dans les systèmes informatiques seront conservés
+				dans des conditions raisonnables de sécurité et considérés comme des preuves de
+				communications intervenues entre les parties.
+			</li>
+		</ol>
+		<h4 dir="auto">Traçabilité</h4>
+		<ol start="66" dir="auto">
+			<li>
+				Le Ministère conserve l’historique des évènements des Utilisateurs de « CARNET DE BORD » et
+				des conditions générales d’utilisation successives, le cas échéant.
+			</li>
+			<li>
+				En outre, le Ministère pourra suivre la navigation de « l’Utilisateur » au sein du « service
+				» grâce à des mesures de traçabilité.
+			</li>
+			<li>
+				Ces données de traçabilité sont conservées, à des fins de sécurité, pour une durée d’un an.
+			</li>
+		</ol>
+		<h4 dir="auto">Nullité</h4>
+		<ol start="69" dir="auto">
+			<li>
+				Si une ou plusieurs stipulations des présentes sont tenues pour non valides ou déclarées
+				comme telles en application d’une loi, d’un règlement ou à la suite d’une décision passée en
+				force de chose jugée d’une juridiction compétente, les autres stipulations garderont toute
+				leur force et leur portée.
+			</li>
+		</ol>
+		<h4 dir="auto">Loi applicable</h4>
+		<ol start="70" dir="auto">
+			<li>Les présentes conditions générales sont régies par la loi française.</li>
+			<li>
+				Il en est ainsi pour les règles de fond et les règles de forme et ce, nonobstant les lieux
+				d’exécution des obligations substantielles ou accessoires
+			</li>
+		</ol>
+		<h4 dir="auto">CONFIGURATIONS REQUISES DES POSTES INFORMATIQUES</h4>
+		<p dir="auto">
+			Conditions d’accès au service « CARNET DE BORD » :<br />
+			Les utilisateurs de « CARNET DE BORD disposent d’un poste informatique équipé de :
+		</p>
+		<ul dir="auto">
+			<li>Un système d'exploitation maintenu par l'éditeur,</li>
+			<li>Un antivirus connecté à une console de gestion centralisée,</li>
+			<li>
+				Un navigateur mis à jour,<br />
+				Les utilisateurs « CARNET DE BORD » ne sont pas autorisés aux pratiques suivantes :
+			</li>
+			<li>
+				Utilisation d’outils de transfert de fichiers (WeTransfer/GoogleDrive) pour échanger des
+				données issues de « CARNET DE BORD »
+			</li>
+			<li>
+				Utilisation de logiciels d’emailing pour communiquer des données issues de « CARNET DE BORD
+				»<br />
+				Bonnes pratiques à l’attention des utilisateurs :
+			</li>
+			<li>Verrouiller le poste informatique en cas d’absence ou d’éloignement du poste</li>
+			<li>
+				Être attentif et vigilant lors de la réception de mail avant de cliquer sur un lien ou
+				d’ouvrir des pièces jointes.
+			</li>
+		</ul>
 	</div>
 	<div class="pt-8">
 		<Form

--- a/app/src/routes/(public)/cgu/+page.svelte
+++ b/app/src/routes/(public)/cgu/+page.svelte
@@ -2,292 +2,653 @@
 	<title>Conditions générales d'utilisation - Carnet de bord</title>
 </svelte:head>
 <div class="fr-container fr-py-6w fr-px-2w">
-	<h1 id="conditions-generales-d-utilisation">Conditions Générales d’Utilisation</h1>
-	<p>
-		Les présentes conditions générales d’utilisation (dites « CGU ») fixent le cadre juridique de la
-		Plateforme « Carnet de bord » et définissent les conditions d’accès et d’utilisation des
-		services par l’Utilisateur.
-	</p>
-	<h2 id="article-1-champ-d-application">Article 1 - Champ d’application</h2>
-	<p>L’utilisation de la plateforme est gratuite et ouverte à tous.</p>
-	<h2 id="article-2-objet">Article 2 – Objet</h2>
-	<p>
-		La plateforme numérique Carnet de bord a comme objectif de réduire les temps de parcours et le
-		risque de décrochage en partageant la connaissance des personnes accompagnées et de leur
-		parcours.
-	</p>
-	<p>Pour cela, il propose un service public numérique qui évolue en continu pour permettre :</p>
-	<ol>
-		<li>
-			<strong>aux publics de bénéficier d’un accompagnement sans rupture</strong> grâce à un profil partagé,
-			enrichi progressivement, auquel il peut accéder (utilisateur passif n’ayant pas d’accès direct
-			à la solution) ;
-		</li>
-		<li>
-			<strong>aux acteurs de l’insertion d’accéder directement</strong> et sans barrière à l’entrée (licence,
-			etc.) à des informations utiles et à jour pour co-construire les parcours avec la personne et faciliter
-			sa mobilisation (utilisateur actif ayant un accès direct à la solution).
-		</li>
-	</ol>
-	<h2 id="article-3-d-finitions">Article 3 – Définitions</h2>
-	<p>
-		« <b>Les Utilisateurs</b> » sont les personnes qui utilisent l’outil. Elles peuvent être «
-		<i>Administrateur</i>
-		», « <i>Manager</i> », « <i>Chargé d’orientation</i> », « <i>Professionnel</i> », ou «
-		<i>Bénéficiaire</i> ».
-	</p>
-	<p>
-		« <b>L’administrateur</b> » est toute personne administrant la plateforme par la gestion et
-		création de compte, des « <i>manager</i> » et des « <i>usagers</i> »
-	</p>
-	<p>
-		« <b>Le manager</b> » est un agent ayant un rôle d’encadrement et d’organisation général des
-		professionnels dont il a le management et de leur prise en charge des Usagers.
-	</p>
-	<p>
-		« <b>Le chargé d’orientation</b> » est un agent ayant un rôle d’organisation général des
-		structures et des professionnels dans leur prise en charge des Usagers.
-	</p>
-	<p>
-		« <b>Le professionnel</b> » est tout agent public ou privé utilisant l’application carnet de
-		bord mandaté par l’administrateur , accompagnant les usagers dans leur recherche
-		professionnelle, ou dans la création de leur projet. « Le bénéficiaire » est toute personne
-		utilisant la plateforme Carnet de bord et accompagné par un “professionnel” de l’insertion
-		utilisant l’application. Les « Services » sont les fonctionnalités offertes par la plateforme
-		pour répondre à son objet défini à l’article 2.
-	</p>
-	<h2 id="article-4-fonctionnalit-s">Article 4 - Fonctionnalités</h2>
-	<h3 id="4-1-cr-ation-de-compte">4.1 Création de compte</h3>
-	<p>
-		Carnet de Bord permet aux acteurs de l’inclusion la création d’un compte via une procédure
-		légère et rapide. Trois types de comptes peuvent être créés via la procédure décrite ci-dessus :
-	</p>
-	<ol>
-		<li>
-			Les profils administrateurs sont créés par l’équipe Carnet de Bord. Il ne peut s’agir que de
-			de profils des départements ou de Pôle emploi.
-		</li>
-		<li>
-			Les profils manager ou gestionnaire : sont des comptes de « structure » de professionnels
-			chargé de l’emploi, créés par les profils administrateurs.
-		</li>
-		<li>
-			Les profils chargé d’orientation : sont des comptes de « chargé d’orientation» chargé
-			d’orienté les usager vers les structures ou professionnel , créés par les profils
-			administrateurs.
-		</li>
-	</ol>
-	<p>
-		A cet effet, il lui suffira de remplir un formulaire sur le site de la plateforme en fournissant
-		les informations suivantes de manière obligatoire :
-	</p>
-	<ul>
-		<li>
-			Structure: Nom de structure, Siret, Adresse structure, Téléphone structure, Email structure
-		</li>
-		<li>Identification utilisateur; Nom, Prénom, Fonction, Téléphone, Email.</li>
-	</ul>
-	<p>
-		La connexion au compte se fait par en entrant son email communiqué lors de l’inscription dans le
-		champ « Identifiant » et reçoit un lien de connexion sur son adresse mail. Une fois le mail de
-		connexion réceptionné il lui suffit de on mot de passe dans le cliquer sur le bouton « Connexion
-		» du mail pour vous authentifier.
-	</p>
-	<ol>
-		<li>
-			<h4 id="compte-administrateur">Compte Administrateur</h4>
-			<p>
-				L’administrateur doit accepter les CGU émis par la DGEFP pour la création et la mise à
-				disposition de son Compte Administrateur. Il se verra adresser par la DGEFP la procédure de
-				déploiement de la plateforme précisant les éléments nécessaires à la création d’une ou des
-				structures habilités, ainsi que les informations à fournir sur le nom, prénom, mail du ou
-				des gestionnaires des structures.
-			</p>
-			<p>Toute création de compte « Administrateur » doit être validée la DGEFP.</p>
-			<p>
-				Une fois le compte validé et créé, l’administrateur se voit adresser un identifiant et un
-				lien qui lui permettront d’accéder à son compte. Ces informations sont strictement
-				confidentielles et doivent être conservées. Elles ne doivent en aucun cas être transmises.
-			</p>
-			<p>
-				la DGEFP se réserve le droit de refuser/faire cesser l’inscription/l’accès à la Plateforme
-				et/ou le fonctionnement d’un Compte Administrateur à tout utilisateur communiquant des
-				informations que la DGEFP jugerait incompatibles avec une bonne organisation et une bonne
-				gestion de la Plateforme.
-			</p>
-		</li>
-		<li>
-			<h4 id="autres-comptes">Autres comptes</h4>
-			<p>
-				A cet effet, il lui suffira de remplir un formulaire sur le site de la plateforme en
-				fournissant les informations suivantes de manière obligatoire :
-			</p>
-			<ul>
-				<li>
-					Structure: Nom de structure, Siret, Adresse structure, Téléphone structure, Email
-					structure
-				</li>
-				<li>Identification utilisateur; Nom, Prénom, Fonction, Téléphone, Email.</li>
-			</ul>
-			<p>
-				La connexion au compte se fait par en entrant son email communiqué lors de l’inscription
-				dans le champ « Identifiant » et reçoit un lien de connexion sur son adresse mail. Une fois
-				le mail de connexion réceptionné il lui suffit de remplir son mot de passe dans le cliquer
-				sur le bouton « Connexion » du mail pour vous authentifier.
-			</p>
-		</li>
-	</ol>
-
-	<h3 id="4-2-fonctionnalit-s-ouvertes-aux-administrateurs">
-		4.2 Fonctionnalités ouvertes aux administrateurs
-	</h3>
-	<ol>
-		<li>
-			<h4 id="professionnels-charges-du-retour-a-l-emploi">
-				Professionnels chargés du retour à l’emploi
-			</h4>
-			<p>
-				Les professionnels du retour à l’emploi, de l’aide sociale et médico-sociale ont accès à
-				certaines fonctionnalités :
-			</p>
-			<ul>
-				<li>Inscrire un bénéficiaire ;</li>
-				<li>Accéder à son annuaire des bénéficiaires ;</li>
-				<li>Rechercher un bénéficiaire ;</li>
-				<li>Inscription d’un référent unique ;</li>
-				<li>Modifier une information sur le profil du bénéficiaire ;</li>
-				<li>Prendre rendez-vous avec un bénéficiaire ;</li>
-				<li>Demander le rattachement à un bénéficiaire.</li>
-			</ul>
-		</li>
-		<li>
-			<h4 id="professionnels-charges-d-orientation">Professionnels chargés d’orientation</h4>
-			<p>Les professionnels chargés d’orientation ont accès à certaines fonctionnalités :</p>
-			<ul>
-				<li>Inscrire un bénéficiaire ;</li>
-				<li>Accéder à une liste d’usagers à orienter ;</li>
-				<li>Rechercher un usager ;</li>
-				<li>Inscrire une structure ;</li>
-				<li>Inscrire un référent unique ;</li>
-				<li>Modifier une information sur le profil du bénéficiaire ;</li>
-				<li>Prendre rendez-vous avec un bénéficiaire ;</li>
-				<li>Permettre le rattachement à usager à une structure ou un professionnel.</li>
-			</ul>
-		</li>
-		<li>
-			<h4 id="professionnels-gestionnaires-de-structure">
-				Professionnels gestionnaires de structure
-			</h4>
-			<p>
-				Les professionnels gestionnaires de structure encadrent les équipes qui sont sous leur
-				responsabilité. Ils ont accès à certaines fonctionnalités de création de compte et de
-				gestion d’équipes :
-			</p>
-			<ul>
-				<li>Accéder à la liste des usagers rattachés à sa structure ;</li>
-				<li>Inscrire un manager de structure ;</li>
-				<li>Inscrire un référent unique ;</li>
-				<li>Permettre le rattachement d’un usager à un professionnel.</li>
-			</ul>
-		</li>
-	</ol>
-	<h3 id="4-3-fonctionnalit-s-ouvertes-aux-b-n-ficiaires">
-		4.3 Fonctionnalités ouvertes aux bénéficiaires
-	</h3>
-	<p>Les bénéficiaires peuvent avoir accès à Carnet de Bord pour :</p>
-	<ul>
-		<li>Gérer des rendez-vous (demande, acceptation) ;</li>
-		<li>Modifier leur profil ;</li>
-		<li>Approuver ou refuser un rattachement ;</li>
-	</ul>
-	<p>Accepter une demande d’accès accompagnateur.</p>
-	<p>
-		Les accès aux carnets de bord des usagers proposés par l’administrateurs sont communiqués aux
-		bénéficiaires par l’intermédiaire de la Plateforme, l’administrateur est responsable de leur
-		exécution.
-	</p>
-	<p>
-		Le bénéficiaire aura accès à l’ensemble des carnets de bord des bénéficiaires proposés par
-		l’administrateur après avoir créé son compte via le Site (« Compte ») dans les conditions
-		décrites dans l’article 4.1
-	</p>
-	<h2 id="article-5-responsabilit-s">Article 5 - Responsabilités</h2>
-	<h3 id="5-1-l-diteur-de-la-plateforme">5.1 L’éditeur de la Plateforme</h3>
-	<p>
-		Les sources des informations diffusées sur la Plateforme sont réputées fiables mais le site ne
-		garantit pas qu’il soit exempt de défauts, d’erreurs ou d’omissions.
-	</p>
-	<p>
-		L’éditeur s’autorise à suspendre ou révoquer n’importe quel compte et toutes les actions
-		réalisées par ce biais, s’il estime que l’usage réalisé du service porte préjudice à son image
-		ou ne correspond pas aux exigences de sécurité.
-	</p>
-	<p>
-		Il peut également retirer tout contenu mis en ligne contraires aux dispositions légales et
-		réglementaires, ou relatives aux présentes CGU. Par ailleurs en cas de non-respect de ces
-		dispositions, l’éditeur peut suspendre ou supprimer toute compte portant atteinte à des
-		dispositions légales, réglementaires ou relatives aux présentes CGU.
-	</p>
-	<p>
-		L’éditeur s’engage à la sécurisation de la Plateforme, notamment en prenant toutes les mesures
-		nécessaires permettant de garantir la sécurité et la confidentialité des informations fournies.
-	</p>
-	<p>
-		L’éditeur fournit les moyens nécessaires et raisonnables pour assurer un accès continu, sans
-		contrepartie financière, à la Plateforme. Il se réserve la liberté de faire évoluer, de modifier
-		ou de suspendre, sans préavis, la plateforme pour des raisons de maintenance ou pour tout autre
-		motif jugé nécessaire.
-	</p>
-	<h3 id="5-2-utilisateurs-administrateur">5.2 Utilisateurs administrateur</h3>
-	<p>
-		Chaque Administrateur est seul responsable de la présentation des Services, leurs évolutions, la
-		fourniture de tous les renseignements légalement requis selon les champs obligatoires prévus à
-		cet effet, etc. les informations saisies doivent être complètes, exactes et loyales. Il édite
-		seul les éléments de son compte Administrateur. Néanmoins, il s’engage à ne pas mettre en ligne
-		de contenus ou informations contraires aux dispositions légales et réglementaires en vigueur. Il
-		demeure responsable du contenu mis en ligne y compris par ses équipes.
-	</p>
-	<h3 id="5-3-utilisateurs-manager-professionnel-et-charg-d-orientation">
-		5.3 Utilisateurs Manager, Professionnel et chargé d’orientation
-	</h3>
-	<p>
-		Les Utilisateurs “Manager” “Professionnels” et “Chargés d’orientations” s’assurent de la
-		confidentialité de leurs identifiants, et évitent toute imprudence pouvant favoriser un usage
-		frauduleux de l’application.
-	</p>
-	<p>
-		Il est rappelé que toute personne procédant à une fausse déclaration pour elle-même ou pour
-		autrui s’expose, notamment, aux sanctions prévues à l’article 441-1 du code pénal, prévoyant des
-		peines pouvant aller jusqu’à trois ans d’emprisonnement et 45 000 euros d’amende. Toute
-		information transmise par l’Utilisateur est de sa seule responsabilité.
-	</p>
-	<p>
-		Chaque Utilisateur a une obligation générale et permanente de discrétion professionnelle. En ce
-		sens ils se doivent de respecter le secret professionnel et les règles de confidentialité (loi
-		n° 83-634 du 13 juillet 1983 portant droits et obligations des fonctionnaires).
-	</p>
-	<h3 id="5-4-utilisateur-b-n-ficiaire">5.4 Utilisateur Bénéficiaire</h3>
-	<p>
-		Les Utilisateurs “bénéficiaires” s’assurent de la confidentialité de leurs identifiants, et
-		évitent toute imprudence pouvant favoriser un usage frauduleux de l’application.
-	</p>
-	<p>
-		Il est rappelé que toute personne procédant à une fausse déclaration pour elle-même ou pour
-		autrui s’expose, notamment, aux sanctions prévues à l’article 441-1 du code pénal, prévoyant des
-		peines pouvant aller jusqu’à trois ans d’emprisonnement et 45 000 euros d’amende. Toute
-		information transmise par l’Utilisateur est de sa seule responsabilité.
-	</p>
-	<p>
-		L’Utilisateur s’engage également à ne jamais usurper l’identité d’un tiers en se faisant passer
-		pour celui-ci vis à vis de la plateforme au risque d’encourir un an d’emprisonnement et 15 000
-		euros d’amende sur la base de l’article 226-4-1 du Code pénal.
-	</p>
-	<h2 id="article-6-mise-jour-des-conditions-d-utilisation">
-		Article 6 - Mise à jour des conditions d’utilisation
-	</h2>
-	<p>
-		Les termes des présentes conditions d’utilisation peuvent être amendés à tout moment, sans
-		préavis, en fonction des modifications apportées à la plateforme, de l’évolution de la
-		législation ou pour tout autre motif jugé nécessaire.
-	</p>
+	<div class="cgu">
+		<h4 dir="auto">Préambule</h4>
+		<ol dir="auto">
+			<li>
+				Le service « <strong>CARNET DE BORD</strong> » (ci-après « le service ») est un système d’information
+				qui permet de partager et d’échanger des informations et données relatives aux personnes rencontrant
+				des difficultés sociales et professionnelles particulières dans le cadre de leurs parcours d’insertion
+			</li>
+			<li>
+				Le « service » est créé par le ministère chargé de l’insertion et administré par le
+				Groupement d’intérêt public « Plateforme de l’inclusion ».
+			</li>
+			<li>
+				« L’Utilisateur » reconnaît que l’utilisation du « service » nécessite le respect de
+				l’ensemble des dispositions des présentes et adhère sans réserve aux présentes conditions
+				générales d’utilisation.
+			</li>
+			<li>
+				« L’Utilisateur » peut bénéficier des fonctionnalités proposées par « <strong
+					>CARNET DE BORD</strong
+				> » uniquement sous réserve de l’acceptation des présentes conditions générales. Chaque nouvelles
+				versions des CGU remplace les précédentes et doivent faire l’objet d’une acceptation par l’Utilisateur
+				du service.
+			</li>
+			<li>
+				« L’Utilisateur » dispose de la faculté de sauvegarder et d’imprimer les présentes
+				conditions générales d’utilisation en utilisant les fonctionnalités standard de son
+				navigateur ou de son ordinateur.
+			</li>
+			<li>
+				« L’Utilisateur » reconnaît disposer des compétences et des moyens nécessaires pour accéder
+				au « service ».
+			</li>
+			<li>
+				Le Ministère agit en tant que responsable de traitement sur la mise à disposition du «
+				service » qui permet à « l’Utilisateur » de remplir ses missions et d’accomplir ses propres
+				traitements. Le Groupement d’intérêt public « Plateforme de l’inclusion » agit en tant que
+				sous-traitant du ministère chargé de l’insertion
+			</li>
+		</ol>
+		<h4 dir="auto">Définitions</h4>
+		<ol start="8" dir="auto">
+			<li>Les termes ci-dessous définis ont entre les parties la signification suivante :</li>
+		</ol>
+		<ul dir="auto">
+			<li>
+				« <strong>DGEFP</strong> » : Délégation générale à l’emploi et à la formation professionnelle.
+			</li>
+			<li>« <strong>CARNET DE BORD</strong> » : Application du dit Service</li>
+			<li>
+				« <strong>Salariés</strong> » et/ou « <strong>Agents</strong> » : Utilisateurs rattachés au ministère
+				du travail, du plein emploi et de l’insertion, des conseils départementaux, des centres communaux
+				d’actions sociale et des salariés de structures habilités.
+			</li>
+			<li>
+				« <strong>Ministère</strong> » : Ministère du Travail, du plein Emploi et de l’Insertion.
+			</li>
+			<li>
+				« <strong>GIP Plateforme de l’inclusion</strong> » ou « <strong>GIP</strong> » : Groupement d’intérêt
+				public Plateforme de l’inclusion
+			</li>
+			<li>
+				« <strong>Utilisateur</strong> » : désigne toute personne physique, professionnel de l’insertion,
+				qui utilise le service « CARNET DE BORD » ou l'une des fonctionnalités proposées par le service
+				et ayant accepté les présentes CGU.
+			</li>
+			<li>
+				« <strong>Personne en insertion</strong> » : les personnes rencontrant des difficultés sociales
+				et professionnelles particulières engagées dans un parcours d’insertion. Il est également appelé
+				« usager » ou « bénéficiaire ».
+			</li>
+			<li>
+				« <strong>Administrateur de territoire</strong> » : Salarié ou agent d’un organisme mentionné
+				aux articles L. 5312-1, L. 5314-1 du code du travail, L. 262-16 et L. 115-2 alinéa 5 du code
+				de l’action sociale et des familles chargé de piloter la politique d’insertion sur un territoire
+				pouvant habiliter les structures et organismes en faisant la demande et mentionné par l’article
+				L.263-4-1 du code de l’action sociale et des familles. L’administrateur de territoire est habilité
+				par le Groupement d’Intérêt Public « Plateforme de l’inclusion ».
+			</li>
+			<li>
+				« <strong>Gestionnaire de structure</strong> » : salarié ou agent d’une structure habilitée ayant
+				un rôle de gestion au sein de cette structure (habilitation des professionnels, rattachement
+				des bénéficiaires orienté vers la structure, …).
+			</li>
+			<li>
+				« <strong>Chargé d’orientation</strong> » : salarié ou agent habilité par un administrateur de
+				territoire pour l’orientation / la réorientation et le suivi de parcours des bénéficiaires.
+			</li>
+			<li>
+				« <strong>Professionnels</strong> » : salarié ou agent d’une structure, habilité par l’un de
+				ses gestionnaires de structure.
+			</li>
+			<li>
+				« <strong>Référent</strong> » : rôle attribué à un professionnel lorsque celui-ci est habilité
+				à exercer la mission de référence de parcours sur un dispositif d’accompagnement au sein d’une
+				structure et qu’il est désigné référent unique d’un usager au titre de l’article L262-30 du code
+				de l’action sociale et des familles.
+			</li>
+			<li>
+				« <strong>Structure</strong> » : organisme intervenant pour fournir un accompagnement personnalisé
+				aux personnes rencontrant des difficultés sociales et professionnelles particulières dans le
+				but de faciliter leur insertion sociale et professionnelle. Ces organismes mentionnés à l’article
+				L.263-4-1 du Code de l’Action Sociale et des Familles sont habilités par un administrateur de
+				territoire.
+			</li>
+			<li>
+				« <strong>Groupe de suivi</strong> » : Ensemble des professionnels, complété éventuellement du
+				chargé d’orientation, intervenant dans le parcours du bénéficiaire et rattaché au carnet de celui-ci.
+			</li>
+			<li>
+				« <strong>Habilitation des structures ou organismes</strong> » : Processus d’autorisation ou
+				de validation choisi par l’administrateur de structure, ou le cas échéant par le Groupement d’intérêt
+				public « Plateforme de l’inclusion », permettant d’utiliser Carnet de Bord des personnes prévues
+				par l’article L.263-4-1 du code de l’action sociale et des familles. L’habilitation n’est pas
+				la même que celle prévue pour « l’administrateur de territoire ».
+			</li>
+		</ul>
+		<h4 dir="auto">Objet</h4>
+		<ol start="9" dir="auto">
+			<li>
+				Les présentes conditions générales ont pour objet de définir les modalités d’utilisation du
+				« service ». Elles sont un accord juridique et contraignant entre le Ministère et les
+				Utilisateurs.
+			</li>
+		</ol>
+		<h4 dir="auto">Opposabilité</h4>
+		<ol start="10" dir="auto">
+			<li>
+				Les présentes conditions générales sont opposables à « l’Utilisateur » dès leur acceptation
+				par ce dernier.
+			</li>
+			<li>
+				Elles seront présentées auprès du futur « Utilisateur » à l’issue de sa première
+				authentification sur « CARNET DE BORD », et de nouveau pour toute mise à jour des présentes
+				CGU.
+			</li>
+			<li>
+				Dans tous les cas, les présentes conditions générales sont réputées lues et applicables à la
+				date de l’acceptation des présentes par « l’Utilisateur » via une action positive.
+			</li>
+			<li>
+				Le Ministère se réserve le droit d’apporter aux présentes conditions générales toutes les
+				modifications ou suppressions qu’il jugera nécessaire et utile.
+			</li>
+			<li>
+				Les présentes conditions générales d’utilisation sont opposables pendant toute la durée
+				d’utilisation du « service » et jusqu’à ce que de nouvelles conditions générales
+				d’utilisation remplacent les présentes.
+			</li>
+			<li>Les conditions générales figurant en ligne prévalent sur toute autre version.</li>
+			<li>
+				« L’Utilisateur » peut à tout moment renoncer à utiliser le « service » mais reste
+				responsable de toute action effectuée sur « CARNET DE BORD » préalablement.
+			</li>
+		</ol>
+		<h4 dir="auto">Durée - entrée en vigueur</h4>
+		<ol start="17" dir="auto">
+			<li>
+				Les présentes conditions générales d’utilisation entrent en vigueur à compter de leur date
+				de mise en ligne sur « CARNET DE BORD ».
+			</li>
+		</ol>
+		<h4 dir="auto">Création ou suppression du compte / code d’accès</h4>
+		<ol start="18" dir="auto">
+			<li>
+				Procédure de création<br />
+				Administrateur de territoire : La personne, salarié ou agent d’un organisme mentionné aux articles
+				L.5312-1, L.5314-1 du code du travail, L.262-16 et L.115-2 alinéa 5 du code de l’action sociale
+				et des familles sollicite la création d’un accès Administrateur de territoire auprès du Groupement
+				d’Intérêt Public « Plateforme de l’Inclusion ». La demande est motivée.<br />
+				Chargé d’orientation : Le compte du chargé d’orientation est créé par un administrateur de territoire
+				depuis Carnet de Bord.<br />
+				Gestionnaire de structure : Le compte du gestionnaire de structure est créé par l’administrateur
+				de territoire lors de la création de la structure. D’autres cogestionnaires peuvent être ajouté
+				à une structure par l’un de ses gestionnaires.<br />
+				Professionnels : Le compte du professionnel est créé par le gestionnaire de structure ou par
+				le biais d’un traitement automatique.<br />
+				Bénéficiaires : La création d’un compte bénéficiaire est réalisée par un administrateur de territoire
+				ou par le biais d’un traitement automatisé
+			</li>
+			<li>
+				Procédure de suppression<br />
+				Administrateur de territoire : suppression du compte par le Groupement d’Intérêt public Plateforme
+				de l’inclusion après demande de l’utilisateur ou d’un autre administrateur de territoire.<br
+				/>
+				Gestionnaire de structure : Désactivation du compte de gestionnaire de structure par un autre
+				gestionnaire de la structure puis suppression après la période d’utilité administrative ou suppression
+				par le Groupement d’Intérêt Public Plateforme de l’Inclusion.<br />
+				Professionnel : désactivation du professionnel par le gestionnaire de structure ou un administrateur
+				de territoire et suppression après la durée d’utilité administrative. Suppression par le Groupement
+				d’Intérêt Public Plateforme de l’Inclusion.<br />
+				Bénéficiaire : suppression du compte du bénéficiaire après le délai d’utilité administrative
+				incluant une période de préarchivage allant jusqu’à 5 ans.
+			</li>
+			<li>« L’Utilisateur » doit indiquer une adresse électronique valide.</li>
+			<li>
+				Il incombe à « l’Utilisateur » de s’assurer qu’il a seul accès à son courrier électronique.
+			</li>
+			<li>
+				Tout accès à, et toute utilisation du « service » est présumée comme émanant exclusivement
+				de « l’Utilisateur ».
+			</li>
+			<li>
+				« L’Utilisateur » est responsable de la sincérité des informations qu’il fournit et s’engage
+				à mettre à jour les informations le concernant ou à aviser le Ministère sans délai de toute
+				modification affectant sa situation.
+			</li>
+			<li>
+				En cas d’utilisation frauduleuse de son compte, « l’Utilisateur » s’engage à prévenir
+				immédiatement les équipes habilitées via la rubrique « besoin d’aide » présente sur le site
+				Carnet de Bord.
+			</li>
+		</ol>
+		<h4 dir="auto">Présentation du service</h4>
+		<ol start="25" dir="auto">
+			<li>
+				Fonctionnalités de « CARNET DE BORD »<br />
+				CARNET DE BORD permet aux administrateurs de territoire, notamment :<br />
+				• D’inscrire une structure ;<br />
+				• D’inscrire un gestionnaire de structure ;<br />
+				• D’inscrire un usager ;<br />
+				• D’avoir accès à la liste des usagers de son territoire ;<br />
+				• De permettre le rattachement d’un usager de son territoire à un professionnel ou à une structure.
+			</li>
+		</ol>
+		<p dir="auto">
+			CARNET DE BORD permet aux gestionnaires de structure, notamment :<br />
+			• D’accéder à la liste des usagers rattaché à sa structure ;<br />
+			• D’inscrire un gestionnaire de structure<br />
+			• D’inscrire un professionnel de sa structure ;<br />
+			• De rattacher un usager orienté vers la structure à un référent de sa structure.
+		</p>
+		<p dir="auto">
+			CARNET DE BORD permet aux chargés d’orientation, notamment :<br />
+			• D’accéder à la liste des usagers à orienter et à réorienter ;<br />
+			• De rechercher un usager parmi ceux du département ;<br />
+			• De modifier une information sur le profil de l’usager ;<br />
+			• De consulter le parcours de l’usager ;<br />
+			• De prendre rendez-vous avec l’usager ;<br />
+			• De permettre le rattachement d’un usager à une structure et éventuellement à un référent.
+		</p>
+		<p dir="auto">
+			CARNET DE BORD permet aux professionnels, notamment :<br />
+			• De modifier les informations d’un usager lorsque celui-ci est membre du groupe de suivi ;<br
+			/>
+			• D’accéder à l’annuaire de ses bénéficiaires ;<br />
+			• De rechercher un usager ;<br />
+			• D’inviter un autre professionnel au groupe de suivi de l’usager ;<br />
+			• Modifier une information sur le profil de l’usager ;<br />
+			• Prendre rendez-vous avec un usager ;<br />
+			• Demander le rattachement à un usager ;<br />
+			• Lorsqu’ils sont référents, de demander la réorientation d’un bénéficiaire vers un autre accompagnement
+			ou lorsque le bénéficiaire ne relève plus d’un accompagnement, vers une fin de parcours.
+		</p>
+		<p dir="auto">
+			CARNET DE BORD permet également aux usagers disposant d’un email valide :<br />
+			• De modifier ses coordonnées ;<br />
+			• D’accéder aux informations de son carnet de bord
+		</p>
+		<ol start="26" dir="auto">
+			<li>
+				Les finalités de « CARNET DE BORD » sont notamment :<br />
+				1° La mise à disposition, au moyen de services numériques, des informations et des données nécessaires
+				à l’identification des personnes en insertion, à l'évaluation de leur situation, au suivi de
+				leur parcours d'insertion, ainsi que, le cas échéant, à la réalisation des actions d’accompagnement
+				social, socio-professionnel ou professionnel ;<br />
+				2° Le partage et l’enrichissement, entre les acteurs de l’insertion, des données strictement
+				nécessaires à la mise en œuvre de leurs missions ;<br />
+				3° L’accès des personnes en insertion aux informations relatives à leur parcours, par le biais
+				d’un compte personnel dédié dans le ou les services numériques correspondants, afin de favoriser
+				leur mobilisation et leur participation à la définition du parcours ;<br />
+				4° L’amélioration de la qualité du service rendu aux utilisateurs, notamment en leur évitant
+				de communiquer ou de saisir plusieurs fois les mêmes informations ;<br />
+				5° La communication d’informations aux personnes en insertion ou leur sollicitation à des fins
+				d’enquête ou d’évaluation ;<br />
+				6° La production de statistiques, nationales et locales, à des fins d’évaluation des politiques
+				publiques.
+			</li>
+		</ol>
+		<h4 dir="auto">Accès au « service »</h4>
+		<ol start="27" dir="auto">
+			<li>
+				L’accès à « CARNET DE BORD » est ouvert aux Utilisateurs et aux usagers de Carnet de Bord
+				dans les conditions définies par les présentes CGU.
+			</li>
+			<li>
+				La plateforme peut être accessible 7 jours sur 7, sur une plage horaire quotidienne 24 sur
+				24 mais peut faire l’objet d’arrêt pour des besoins de maintenance technique ou applicative.
+			</li>
+			<li>
+				Le Ministère se réserve le droit, sans préavis, ni indemnité, de fermer temporairement
+				l’accès à une ou plusieurs fonctionnalités de « CARNET DE BORD » pour effectuer une mise à
+				jour, des modifications ou changement sur les méthodes opérationnelles, les serveurs et les
+				heures d’accessibilité. Cette liste n’est pas limitative. Dans ce cas, le Ministère peut
+				indiquer une date de réouverture du compte ou d’accessibilité à une ou plusieurs
+				fonctionnalités.
+			</li>
+			<li>
+				En cas d’impossibilité d’accéder et/ou d’utiliser le « service », « l’Utilisateur » peut
+				toujours s’adresser aux équipes habilitées pour obtenir des informations via la rubrique «
+				besoin d’aide » présente sur le site Carnet de Bord.
+			</li>
+			<li>
+				Le Ministère se réserve la possibilité de mettre en place des hyperliens sur le site «
+				CARNET DE BORD » donnant accès à des pages internet autres que celles du site.
+			</li>
+			<li>
+				Le Ministère vérifie la qualité des sites qu’il recommande, néanmoins il ne saurait être
+				responsable, contrôler ou garantir l'actualité et l'exactitude des informations diffusées
+				sur les sites des sociétés, organismes ou personne privée vers lesquels il a établi des
+				liens.
+			</li>
+			<li>
+				Les Utilisateurs sont formellement informés que les sites auxquels ils peuvent accéder par
+				l’intermédiaire des liens hypertextes n’appartiennent pas tous au Ministère.
+			</li>
+			<li>
+				Le Ministère ne saurait être responsable de l’accès par les Utilisateurs via les liens
+				hypertextes mis en place dans le cadre de « CARNET DE BORD » à d’autres ressources présentes
+				sur le réseau.
+			</li>
+			<li>
+				La mise en place d’un hyperlien en direction de « CARNET DE BORD est interdite à défaut de
+				l’autorisation expresse et préalable du Ministère. Il est, en tout état de cause, interdit
+				d’imbriquer les pages de « CARNET DE BORD » à l’intérieur des pages d’un autre site.
+			</li>
+		</ol>
+		<h4 dir="auto">Assistance technique</h4>
+		<ol start="36" dir="auto">
+			<li>
+				Le Groupement d’intérêt public « Plateforme de l’inclusion » met à disposition de «
+				l’Utilisateur » un service utilisateur à même de répondre à tous les renseignements
+				nécessaires à l’accès ou à l’utilisation du « service » accessible via la rubrique « besoin
+				d’aide ».
+			</li>
+		</ol>
+		<h4 dir="auto">Confidentialité/sécurité</h4>
+		<ol start="37" dir="auto">
+			<li>
+				Le Ministère fait ses meilleurs efforts, conformément aux règles de l’art, pour sécuriser
+				les accès, données et traitements. Il ne saurait assurer une sécurité absolue.
+			</li>
+			<li>
+				L’Utilisateur est responsable de la confidentialité des informations permettant lui
+				permettant l’accès au service. Toute faille de sécurité ou violation de données résultant de
+				sa négligence, d’une imprudence favorisant un usage frauduleux ou d’un comportement fautif
+				concernant la confidentialité mentionnée présentement est de sa responsabilité, ou le cas
+				échéant de la responsabilité de l’organisme auquel elle est rattachée.
+			</li>
+			<li>
+				Il en est de même du maintien de l’altération et de l’entrave à un système de traitement
+				automatisé de données, ainsi que de l’introduction, de la suppression ou de la modification
+				frauduleuses de données.
+			</li>
+			<li>
+				« L’Utilisateur » reconnaît avoir connaissance de la nature du réseau internet, et en
+				particulier, de ses performances techniques et des temps de réponse pour consulter,
+				interroger ou transférer les données d’informations et des risques éventuels de
+				cybersécurité.
+			</li>
+			<li>
+				« L’Utilisateur » informe le GIP de l’inclusion de toute défaillance du « service » via la
+				rubrique « besoin d’aide ».
+			</li>
+			<li>
+				« L’Utilisateur » accepte de prendre toutes les mesures appropriées de façon à assurer la
+				sécurité des données contenues dans Carnet de Bord.
+			</li>
+			<li>
+				« L’Utilisateur » est informé que l’utilisation des ordinateurs accessibles au public
+				constitue une négligence, compte tenu des risques inhérents à ce type d’accès et, notamment,
+				la possibilité de compromission de la sécurité des codes d’accès (« key-loggers »)
+			</li>
+		</ol>
+		<h4 dir="auto">Responsabilité du ministère</h4>
+		<ol start="44" dir="auto">
+			<li>
+				Le Ministère ne saurait être tenu pour responsable des conséquences provoquées par le
+				caractère erroné ou frauduleux des informations fournies par « l’Utilisateur ».
+			</li>
+			<li>
+				Sauf faute ou négligence prouvée du Ministère, les atteintes à la confidentialité des
+				données personnelles de « l’Utilisateur » résultant de l’utilisation des informations lui
+				permettant l’accès au service, et utilisées par un tiers ne sauraient engager la
+				responsabilité du Ministère. Tout accès non autorisé au compte d’un « utilisateur » est
+				interdit et passible de sanctions pénales.
+			</li>
+			<li>Le Ministère ne saurait être responsable de :</li>
+		</ol>
+		<ul dir="auto">
+			<li>l’impossibilité d’utiliser le « service » ;</li>
+			<li>
+				des atteintes à la sécurité informatique pouvant causer des dommages aux matériels
+				informatiques des Utilisateurs ;
+			</li>
+			<li>
+				dommages directs ou indirects résultant de l’utilisation du « service », de l'attitude, de
+				la conduite ou du comportement d'un autre Utilisateur ;
+			</li>
+			<li>
+				faits dus à un cas de force majeure, un cas fortuit ou au fait d'un tiers ou de la victime
+				du dommage.
+			</li>
+		</ul>
+		<h4 dir="auto">Responsabilité des utilisateurs</h4>
+		<ol start="47" dir="auto">
+			<li>
+				« CARNET DE BORD » est un système de traitement automatisé de données. Tout accès frauduleux
+				à ce dernier est interdit et sanctionné pénalement. Il en est de même pour toute entrave ou
+				altération du fonctionnement de ce système, ou en cas d’introduction, de suppression ou de
+				modification des données qui y sont contenues.
+			</li>
+			<li>
+				« L’Utilisateur » reste, en toutes circonstances, responsable de l’utilisation qu’il fait du
+				« service ».
+			</li>
+			<li>« L’Utilisateur » s’engage à :</li>
+		</ol>
+		<ul dir="auto">
+			<li>
+				N’utiliser le « service » et les informations auxquelles il a accès que dans les seules
+				conditions définies aux présentes conditions générales d’utilisation et conformément aux
+				dispositions législatives et réglementaires en vigueur
+			</li>
+			<li>
+				Utiliser le « service » ainsi que l’ensemble des informations auxquelles il pourra avoir
+				accès dans un but conforme à l’ordre public, aux bonnes mœurs et aux droits des tiers ; Il
+				participe au fonctionnement normal du « service ».
+			</li>
+			<li>
+				Ne pas perturber le bon fonctionnement de ce système. Il veille notamment à ne pas
+				introduire de virus ou toute autre technologie nuisible aux fonctionnalités qui y sont
+				proposés ;
+			</li>
+			<li>
+				Ne commettre aucun acte pouvant mettre en cause la sécurité informatique du Ministère ou des
+				autres Utilisateurs.
+			</li>
+		</ul>
+		<ol start="50" dir="auto">
+			<li>
+				Toute autre utilisation donne droit au Ministère de fermer l’accès au « service » de «
+				l’Utilisateur », de supprimer les données et fichiers y figurant, de supprimer l'accès à ses
+				données ou fichiers, ou d'interdire à « l’Utilisateur » l'accès de tout ou partie du «
+				service ». Par ailleurs, toute utilisation en violation des présentes conditions générales
+				d’utilisation peut donner lieu à la fermeture de l’accès au service.
+			</li>
+			<li>Les utilisations suivantes du « service » sont formellement prohibées, notamment :</li>
+		</ol>
+		<ul dir="auto">
+			<li>
+				Le fait d’endommager, de désactiver, de surcharger l’infrastructure de « CARNET DE BORD » ou
+				encore d’entraver la jouissance du « service » par les autres Utilisateurs ;
+			</li>
+			<li>
+				Les tentatives d’accès non autorisé au « service », à d’autres comptes, aux systèmes
+				informatiques ou à d’autres réseaux connectés au « service » via le piratage ou toute autre
+				méthode ;
+			</li>
+			<li>
+				Une réutilisation ultérieure des données contraire aux dispositions légales et
+				réglementaires relatives à la protection des données personnelles, ou une réutilisation
+				incompatible avec les finalités initiales de « CARNET DE BORD ».
+			</li>
+		</ul>
+		<ol start="52" dir="auto">
+			<li>
+				Par ailleurs, « l’Utilisateur » s’engage à ne pas mettre en ligne des contenus inappropriés,
+				notamment :
+			</li>
+		</ol>
+		<ul dir="auto">
+			<li>sans rapport avec l’objet des fonctionnalités de « CARNET DE BORD » ;</li>
+			<li>comportant des opinions, politiques, religieuses ou philosophiques ;</li>
+			<li>contraires aux bonnes mœurs.</li>
+		</ul>
+		<ol start="53" dir="auto">
+			<li>
+				« L’Utilisateur » ne doit pas, sous peine de sanctions pénales, mettre en ligne des contenus
+				illégaux. Il veille à avoir des propos demeurent modérés et professionnels. Il s’engage
+				notamment à ne pas :
+			</li>
+		</ol>
+		<ul dir="auto">
+			<li>faire l’apologie de crimes contre l’humanité ;</li>
+			<li>inciter à la commission d’acte de terrorisme ou faire leur apologie ;</li>
+			<li>inciter à haine raciale ;</li>
+			<li>
+				inciter à la haine à l’égard de personnes à raison de leur sexe, de leur orientation ou
+				identité sexuelle ;
+			</li>
+			<li>inciter à la haine à l’égard de personnes à raison de leur handicap ;</li>
+			<li>diffuser de la pornographie, notamment enfantine ;</li>
+			<li>inciter à la violence, notamment, aux violences faites aux femmes ;</li>
+			<li>porter atteinte à la dignité humaine ;</li>
+			<li>proférer des injures ;</li>
+			<li>
+				alléguer ou imputer un fait qui porte atteinte à l'honneur ou à la considération d'une
+				personne (diffamation)
+			</li>
+		</ul>
+		<ol start="54" dir="auto">
+			<li>
+				L’Utilisateur s’engage à respecter la charte graphique de l’Etat, et à ne pas reprendre les
+				éléments de représentation.
+			</li>
+		</ol>
+		<h4 dir="auto">Propriété intellectuelle</h4>
+		<ol start="55" dir="auto">
+			<li>
+				« L’Utilisateur » reconnaît et accepte que le contenu de « CARNET DE BORD », et notamment
+				mais non exclusivement les textes, marques, photographies, vidéos, sons, musiques, mise en
+				page, charte graphique, logos, logiciels, les bases de données, design ou toute autre
+				information ou support présenté par le Ministère, sont protégés par leurs droits d'auteurs,
+				marque, brevet et tout autre droit de propriété intellectuelle ou industrielle qui leur sont
+				reconnus selon les lois en vigueur.
+			</li>
+		</ol>
+		<h4 dir="auto">Protection des données personnelles</h4>
+		<ol start="56" dir="auto">
+			<li>
+				La création de compte d’un « utilisateur » et son authentification nécessite la
+				communication par ce dernier de données à caractère personnel à des fins d’accès et
+				d’utilisation de l’application sécurisée ; à défaut aucun accès ou utilisation du « service
+				» n’est possible.
+			</li>
+			<li>
+				Les données à caractère personnel sont traitées dans l’application « CARNET DE BORD »
+				conformément aux dispositions du Règlement Général sur les Données Personnelles (RGPD), de
+				la Loi n° 78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés,
+				et des dispositions spécifiques du code de l’action sociale et des familles relatives à
+				l’échange de données entre acteurs de l’insertion.
+			</li>
+			<li>
+				Conformément à l’article L322-2 du code entre le public et l’administration, la
+				réutilisation éventuelle d'informations publiques comportant des données à caractère
+				personnel est subordonnée au respect des dispositions de la <a
+					href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000886460&amp;categorieLien=cid"
+					rel="nofollow"
+					class="rgh-seen--16452622714">loi n° 78-17 du 6 janvier 1978</a
+				> relative à l'informatique, aux fichiers et aux libertés.
+			</li>
+			<li>
+				« L’Utilisateur » s’engage à ne faire figurer aucune donnée sensible ou perçue comme
+				sensible au sens de l’article 9 et 10 du RGPD qui ne seraient pas nécessaires au traitement.
+			</li>
+			<li>
+				Pour plus d’information, veuillez-vous rendre sur notre politique de confidentialité
+				accessible sur le pied de page de la page d’accueil de « CARNET DE BORD », bouton «
+				protection des données personnelles »
+			</li>
+		</ol>
+		<h4 dir="auto">Résiliation - résolution</h4>
+		<ol start="61" dir="auto">
+			<li>
+				En cas de manquement aux obligations des présentes, « l’Utilisateur » ou le Ministère
+				pourront prononcer de plein droit la résiliation ou la résolution des présentes sans
+				préjudice de tous dommages et intérêts auxquels ils pourraient prétendre en vertu des
+				présentes.
+			</li>
+		</ol>
+		<h4 dir="auto">Durée de l’accord</h4>
+		<ol start="62" dir="auto">
+			<li>
+				L’Accord est conclu pour une durée indéterminée à compter de l’acceptation des présentes
+				conditions générales par « l’Utilisateur » des CGU.
+			</li>
+		</ol>
+		<h4 dir="auto">Résiliation de l’accord</h4>
+		<ol start="63" dir="auto">
+			<li>
+				En cas de non-respect des CGU, si, à l’issue d’un délai de huit (8) jours calendaires à
+				compter de la notification par le Ministère du manquement constaté, « l’Utilisateur » n’a
+				pas mis fin à ce manquement ou que ce dernier n’a pas été réparé, le Ministère pourra
+				résilier l’Accord immédiatement et de plein droit, indépendamment de tous dommages et
+				intérêts auxquels il pourrait prétendre.
+			</li>
+		</ol>
+		<h4 dir="auto">Convention de preuve</h4>
+		<ol start="64" dir="auto">
+			<li>
+				L’acceptation des conditions générales par voie électronique a, entre le Ministère et «
+				l’Utilisateur », la même valeur probante que l’accord sur support papier.
+			</li>
+			<li>
+				Les registres informatisés et conservés dans les systèmes informatiques seront conservés
+				dans des conditions raisonnables de sécurité et considérés comme des preuves de
+				communications intervenues entre les parties.
+			</li>
+		</ol>
+		<h4 dir="auto">Traçabilité</h4>
+		<ol start="66" dir="auto">
+			<li>
+				Le Ministère conserve l’historique des évènements des Utilisateurs de « CARNET DE BORD » et
+				des conditions générales d’utilisation successives, le cas échéant.
+			</li>
+			<li>
+				En outre, le Ministère pourra suivre la navigation de « l’Utilisateur » au sein du « service
+				» grâce à des mesures de traçabilité.
+			</li>
+			<li>
+				Ces données de traçabilité sont conservées, à des fins de sécurité, pour une durée d’un an.
+			</li>
+		</ol>
+		<h4 dir="auto">Nullité</h4>
+		<ol start="69" dir="auto">
+			<li>
+				Si une ou plusieurs stipulations des présentes sont tenues pour non valides ou déclarées
+				comme telles en application d’une loi, d’un règlement ou à la suite d’une décision passée en
+				force de chose jugée d’une juridiction compétente, les autres stipulations garderont toute
+				leur force et leur portée.
+			</li>
+		</ol>
+		<h4 dir="auto">Loi applicable</h4>
+		<ol start="70" dir="auto">
+			<li>Les présentes conditions générales sont régies par la loi française.</li>
+			<li>
+				Il en est ainsi pour les règles de fond et les règles de forme et ce, nonobstant les lieux
+				d’exécution des obligations substantielles ou accessoires
+			</li>
+		</ol>
+		<h4 dir="auto">CONFIGURATIONS REQUISES DES POSTES INFORMATIQUES</h4>
+		<p dir="auto">
+			Conditions d’accès au service « CARNET DE BORD » :<br />
+			Les utilisateurs de « CARNET DE BORD disposent d’un poste informatique équipé de :
+		</p>
+		<ul dir="auto">
+			<li>Un système d'exploitation maintenu par l'éditeur,</li>
+			<li>Un antivirus connecté à une console de gestion centralisée,</li>
+			<li>
+				Un navigateur mis à jour,<br />
+				Les utilisateurs « CARNET DE BORD » ne sont pas autorisés aux pratiques suivantes :
+			</li>
+			<li>
+				Utilisation d’outils de transfert de fichiers (WeTransfer/GoogleDrive) pour échanger des
+				données issues de « CARNET DE BORD »
+			</li>
+			<li>
+				Utilisation de logiciels d’emailing pour communiquer des données issues de « CARNET DE BORD
+				»<br />
+				Bonnes pratiques à l’attention des utilisateurs :
+			</li>
+			<li>Verrouiller le poste informatique en cas d’absence ou d’éloignement du poste</li>
+			<li>
+				Être attentif et vigilant lors de la réception de mail avant de cliquer sur un lien ou
+				d’ouvrir des pièces jointes.
+			</li>
+		</ul>
+	</div>
 </div>


### PR DESCRIPTION
## :wrench: Problème

Le texte des CGU dans le footer n'est pas à jour.

## :cake: Solution

On met à jour le texte avec la bonne version.

## :rotating_light:  Points d'attention / Remarques

Le produit étant en phase de maintenance, j'ai copié/collé le texte dans l'ancien template pour aller au plus vite.

## :desert_island: Comment tester

Se rendre sur la recette, cliquer dans le lien CGU du footer et constater que les CGU sont bien à jour.

fix #2057
