### PR TITLE
fix: add suffix to deleted accounts

### DIFF
--- a/app/src/lib/ui/ProfessionalList/List.svelte
+++ b/app/src/lib/ui/ProfessionalList/List.svelte
@@ -23,7 +23,20 @@
 	const deleteAccount = mutation(deleteAccountMutation);
 
 	async function removeProfessional(professional: Professional) {
-		await deleteAccount({ accountId: professional.account.id });
+		const dateObj = new Date();
+		const month = dateObj.getUTCMonth() + 1;
+		const day = dateObj.getUTCDate();
+		const year = dateObj.getUTCFullYear();
+		const suffix = '.deleted' + day + month + year;
+		const newEmail = professional.email + suffix;
+		const newUsername = professional.account.username + suffix;
+
+		await deleteAccount({
+			accountId: professional.account.id,
+			professionalId: professional.id,
+			newEmail: newEmail,
+			newUsername: newUsername,
+		});
 	}
 </script>
 

--- a/app/src/lib/ui/ProfessionalList/List.svelte
+++ b/app/src/lib/ui/ProfessionalList/List.svelte
@@ -27,7 +27,9 @@
 		const month = dateObj.getUTCMonth() + 1;
 		const day = dateObj.getUTCDate();
 		const year = dateObj.getUTCFullYear();
-		const suffix = '.deleted' + day + month + year;
+		const hours = dateObj.getHours();
+		const minutes = dateObj.getMinutes();
+		const suffix = '.deleted' + day + month + year + hours + minutes;
 		const newEmail = professional.email + suffix;
 		const newUsername = professional.account.username + suffix;
 

--- a/app/src/lib/ui/ProfessionalList/List.svelte
+++ b/app/src/lib/ui/ProfessionalList/List.svelte
@@ -23,13 +23,8 @@
 	const deleteAccount = mutation(deleteAccountMutation);
 
 	async function removeProfessional(professional: Professional) {
-		const dateObj = new Date();
-		const month = dateObj.getUTCMonth() + 1;
-		const day = dateObj.getUTCDate();
-		const year = dateObj.getUTCFullYear();
-		const hours = dateObj.getHours();
-		const minutes = dateObj.getMinutes();
-		const suffix = '.deleted' + day + month + year + hours + minutes;
+		const nowDate = new Date();
+		const suffix = '.deleted' + nowDate.toISOString();
 		const newEmail = professional.email + suffix;
 		const newUsername = professional.account.username + suffix;
 

--- a/app/src/lib/ui/ProfessionalList/_deleteAccount.gql
+++ b/app/src/lib/ui/ProfessionalList/_deleteAccount.gql
@@ -1,5 +1,16 @@
-mutation DeleteAccount($accountId: uuid!) {
-  update_account_by_pk(pk_columns: { id: $accountId }, _set: { deletedAt: now }) {
+mutation DeleteAccount(
+  $accountId: uuid!
+  $professionalId: uuid!
+  $newEmail: citext!
+  $newUsername: String!
+) {
+  update_account_by_pk(
+    pk_columns: { id: $accountId }
+    _set: { deletedAt: now, username: $newUsername }
+  ) {
+    id
+  }
+  update_professional_by_pk(pk_columns: { id: $professionalId }, _set: { email: $newEmail }) {
     id
   }
   update_notebook_member(

--- a/app/src/lib/ui/ProfessionalList/_getProfessionalsForStructure.gql
+++ b/app/src/lib/ui/ProfessionalList/_getProfessionalsForStructure.gql
@@ -11,6 +11,7 @@ query GetProfessionalsForStructure($structureId: uuid!) {
     position
     account {
       id
+      username
       onboardingDone
       notebooksWhereMember_aggregate(
         where: { active: { _eq: true }, memberType: { _eq: "referent" } }

--- a/hasura/metadata/databases/carnet_de_bord/tables/public_account.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_account.yaml
@@ -390,6 +390,7 @@ update_permissions:
         - cgu_validated_at
         - deleted_at
         - onboarding_done
+        - username
       filter:
         _or:
           - id:


### PR DESCRIPTION
## :wrench: Problème

Lorsque l'on supprime un professionnel, la valeur de son champ `deletedAt` est mise à la date du jour, mais aucun autre champ n'est modifié : cela rend impossible de recréer un utilisateur avec le même `username` ou le même `email`.

## :cake: Solution

Quand on supprime un professionnel, on ajoute le suffixe `.deleted` + date du jour à son username et son email.

## :rotating_light:  Points d'attention / Remarques

Aucun test n'existant sur cette fonctionnalité et le produit étant en fin de vie, aucun test n'a été ajouté.

## :desert_island: Comment tester

Se connecter en tant qu'admin de structure, supprimer un utilisateur et s'assurer dans la base que le `.deleted` a été ajouté au champ `username` de la table `account` et au champ `email` de la table `professional`.

fix #2030