### PR TITLE
fix: remove NIR

### DIFF
--- a/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoView.svelte
+++ b/app/src/lib/ui/ProNotebookPersonalInfo/ProNotebookPersonalInfoView.svelte
@@ -82,7 +82,6 @@
 			</h1>
 		</div>
 		<div class="-mt-2">Né le {formatDateLocale(beneficiary.dateOfBirth)}</div>
-		<div>NIR: {beneficiary.nir ?? 'Inconnu'}</div>
 	</div>
 
 	<h2 class="fr-h4 text-vert-cdb">Informations personnelles</h2>

--- a/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
+++ b/app/src/routes/(auth)/beneficiaire/_getNotebookByBeneficiaryId.gql
@@ -76,7 +76,6 @@ fragment notebookFragment on notebook {
     cafNumber
     city
     dateOfBirth
-    nir
     email
     firstname
     id


### PR DESCRIPTION
## :wrench: Problème

L'affichage du NIR dans le carnet de l'usager n'est pas conforme à la loi. En effet, il est visible de certains professionnels qui n'accompagnent pas les personnes (ex : les gestionnaires de structure et les pros qui effectuent une recherche usager de leur territoire).

## :cake: Solution

On supprime le NIR de l'interface et de la requête GQL.

## :desert_island: Comment tester

Se rendre sur le carnet de Sophie Tifour et constater que le NIR n'est plus affiché.

 fix #2069