### PR TITLE
fix: suspension de l'envoi des emails d'orientation/réorientation

### DIFF
--- a/backend/tests/api/test_notebooks_add_member.py
+++ b/backend/tests/api/test_notebooks_add_member.py
@@ -9,7 +9,6 @@ from cdb.api.db.crud.notebook import get_notebook_members_by_notebook_id
 from cdb.api.db.crud.notebook_info import get_notebook_info
 from cdb.api.db.models.notebook import Notebook
 from cdb.api.db.models.professional import Professional
-from tests.utils.approvaltests import verify, verify_as_json
 from tests.utils.assert_helpers import assert_member, assert_structure
 
 pytestmark = pytest.mark.graphql
@@ -112,9 +111,7 @@ async def test_add_notebook_member_as_no_referent(
     assert notebook_info.orientation_reason == former_notebook_info.orientation_reason
 
 
-@mock.patch("cdb.api.core.emails.send_mail")
 async def test_add_notebook_member_as_referent(
-    mock_send_email: mock.Mock,
     test_client: AsyncClient,
     notebook_sophie_tifour: Notebook,
     get_professional_paul_camara_jwt: str,
@@ -147,12 +144,6 @@ async def test_add_notebook_member_as_referent(
     assert_member(members, professional_pierre_chevalier, "referent", False)
     # Check that former referent is still an active member
     assert_member(members, professional_pierre_chevalier, "no_referent", True)
-    # Check that an email is sent to former referent
-    email_former_referent = mock_send_email.call_args_list[0][1]
-    verify(email_former_referent["message"], extension=".html")
-    verify_as_json(
-        {"subject": email_former_referent["subject"], "to": email_former_referent["to"]}
-    )
 
     structures = await get_structures_for_beneficiary(
         db_connection,

--- a/backend/tests/api/test_orientations.py
+++ b/backend/tests/api/test_orientations.py
@@ -15,7 +15,7 @@ from cdb.api.db.models.beneficiary import Beneficiary
 from cdb.api.db.models.notebook import Notebook
 from cdb.api.db.models.orientation_request import OrientationRequest
 from cdb.api.db.models.professional import Professional
-from tests.utils.approvaltests import verify, verify_as_json
+from tests.utils.approvaltests import verify_as_json
 from tests.utils.assert_helpers import assert_member, assert_structure
 
 pytestmark = pytest.mark.graphql
@@ -380,22 +380,7 @@ async def test_send_email_to_members_with_orientation_request(
         headers={"Authorization": "Bearer " + giulia_diaby_jwt},
     )
     assert response.status_code == 200
-    assert mock_send_email.call_count == 2
-
-    former_email_referent = mock_send_email.call_args_list[0]
-    assert former_email_referent.kwargs["to"] == professional_edith_orial.email
-    assert former_email_referent.kwargs["subject"] == "Réorientation d’un bénéficiaire"
-
-    email_new_referent = mock_send_email.call_args_list[1]
-    assert email_new_referent.kwargs["to"] == professional_paul_camara.email
-    assert email_new_referent.kwargs["subject"] == "Réorientation d’un bénéficiaire"
-
-    verify(
-        {
-            "former_email_referent": former_email_referent.kwargs["message"],
-            "email_new_referent": email_new_referent.kwargs["message"],
-        }
-    )
+    assert mock_send_email.call_count == 0
 
 
 @mock.patch("cdb.api.core.emails.send_mail")
@@ -419,22 +404,7 @@ async def test_send_email_to_members_without_orientation_request(
         headers={"Authorization": "Bearer " + giulia_diaby_jwt},
     )
     assert response.status_code == 200
-    assert mock_send_email.call_count == 2
-
-    former_email_referent = mock_send_email.call_args_list[0]
-    assert former_email_referent.kwargs["to"] == professional_pierre_chevalier.email
-    assert former_email_referent.kwargs["subject"] == "Réorientation d’un bénéficiaire"
-
-    email_new_referent = mock_send_email.call_args_list[1]
-    assert email_new_referent.kwargs["to"] == professional_paul_camara.email
-    assert email_new_referent.kwargs["subject"] == "Réorientation d’un bénéficiaire"
-
-    verify(
-        {
-            "former_email_referent": former_email_referent.kwargs["message"],
-            "email_new_referent": email_new_referent.kwargs["message"],
-        }
-    )
+    assert mock_send_email.call_count == 0
 
 
 @mock.patch("cdb.api.core.emails.send_mail")
@@ -457,12 +427,7 @@ async def test_send_email_to_members_first_orientation(
         headers={"Authorization": "Bearer " + giulia_diaby_jwt},
     )
     assert response.status_code == 200
-    assert mock_send_email.call_count == 1
-
-    email_new_referent = mock_send_email.call_args_list[0]
-    assert email_new_referent.kwargs["to"] == professional_paul_camara.email
-    assert email_new_referent.kwargs["subject"] == "Orientation d’un bénéficiaire"
-    verify(email_new_referent.kwargs["message"], extension=".html")
+    assert mock_send_email.call_count == 0
 
 
 @mock.patch("cdb.api.core.emails.send_mail")

--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -7,17 +7,3 @@
     - name: secret_token
       value_from_env: ACTION_SECRET
   comment: dahsboard report to matomo
-- name: notify_admin_structures
-  webhook: '{{BACKEND_API_URL}}/v1/admin_structures/notify'
-  schedule: 0 22 * * 0-4
-  include_in_metadata: true
-  payload: {}
-  retry_conf:
-    num_retries: 3
-    retry_interval_seconds: 10
-    timeout_seconds: 60
-    tolerance_seconds: 21600
-  headers:
-    - name: secret-token
-      value_from_env: ACTION_SECRET
-  comment: Periodic notification to send unfollowed beneficiaries to admin structures (by email)


### PR DESCRIPTION
## :wrench: Problème

cf https://github.com/gip-inclusion/carnet-de-bord/issues/2072

## :cake: Solution

On enlève le cronjob hasura de notification des admins de structure et on enlève le code relatif à l'envoi d'email lors des orientations / réorientations

## :desert_island: Comment tester

Se connecter en tant `giulia.diaby` 
1. mail suite à une demande de réorientation
  - Aller dans "Autres Bénéficiaire" "orientés"
  - chercher jennings
  - afficher le carner de Dee Jennings 
  - valider la demande d'orientation sur le carnet de Dee Jennings
  - Se rendre dans mailtrap et s'assurer qu'aucun nouveau mail n'a été envoyé
3. mails suite à une premier orientation
  - Aller dans "Autres Bénéficiaire" "orientés"
  - chercher  keller
  - afficher le carner de Noel Keller 
  - Se rendre dans mailtrap et s'assurer qu'aucun nouveau mail n'a été envoyé
4. mail suite à une réorientation 
  - Aller dans "Bénéficiaire" "orientés"
  - chercher Tifour
  - afficher le carner de Sofie Tifour
  - Se rendre dans mailtrap et s'assurer qu'aucun nouveau mail n'a été envoyé

fix #2072 
