### PR TITLE
Revert "fix: suspension de l'envoi des emails d'orientation/réorienta…

### DIFF
--- a/backend/cdb/api/v1/routers/notebooks_add_members.py
+++ b/backend/cdb/api/v1/routers/notebooks_add_members.py
@@ -14,6 +14,7 @@ from fastapi import (
 from gql.dsl import DSLField, DSLMutation, DSLSchema, dsl_gql
 from pydantic import BaseModel
 
+from cdb.api.core.emails import Member, Person, send_notebook_member_email
 from cdb.api.db.crud.beneficiary_structure import (
     get_deactivate_beneficiary_structure_mutation,
     get_insert_beneficiary_structure_mutation,
@@ -33,7 +34,10 @@ from cdb.api.db.models.member_type import MemberTypeEnum
 from cdb.api.db.models.orientation_info import OrientationInfo
 from cdb.api.db.models.role import RoleEnum
 from cdb.api.schema_gql import schema
-from cdb.api.v1.dependencies import allowed_jwt_roles, extract_authentified_account
+from cdb.api.v1.dependencies import (
+    allowed_jwt_roles,
+    extract_authentified_account,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(
@@ -139,4 +143,33 @@ async def add_notebook_members(
 
         await session.execute(dsl_gql(DSLMutation(**mutations)))
 
+        if (
+            data.member_type is MemberTypeEnum.referent
+            and orientation_info.former_referent_account_id
+        ):
+            notify_former_referents(background_tasks, orientation_info)
+
         return Response(status_code=204)
+
+
+def notify_former_referents(
+    background_tasks: BackgroundTasks, orientation_info: OrientationInfo
+) -> None:
+    beneficiary = Person.parse_from_gql(orientation_info.beneficiary)
+
+    former_referents = [
+        Member.parse_from_gql(member["account"]["professional"])
+        for member in orientation_info.former_referents
+    ]
+    for referent in former_referents:
+        background_tasks.add_task(
+            send_notebook_member_email,
+            to_email=referent.email,
+            beneficiary=beneficiary,
+            orientation_system=None,
+            former_referents=former_referents,
+            new_structure=orientation_info.new_structure["name"],
+            new_referent=Member.parse_from_gql(orientation_info.new_referent)
+            if orientation_info.new_referent is not None
+            else None,
+        )

--- a/backend/cdb/api/v1/routers/orientations.py
+++ b/backend/cdb/api/v1/routers/orientations.py
@@ -9,6 +9,7 @@ from gql.dsl import DSLField, DSLMutation, DSLSchema, dsl_gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from pydantic import BaseModel
 
+from cdb.api.core.emails import Member, Person, send_notebook_member_email
 from cdb.api.core.init import connection
 from cdb.api.core.settings import settings
 from cdb.api.db.crud.beneficiary_structure import (
@@ -232,6 +233,38 @@ async def change_beneficiary_orientation(
         )
 
         response = await session.execute(dsl_gql(DSLMutation(**mutations)))
+
+        former_referents = [
+            Member.parse_from_gql(member.get("account", {}).get("professional", {}))
+            for member in orientation_info.former_referents
+        ]
+        beneficiary = Person.parse_from_gql(orientation_info.beneficiary)
+
+        for referent in former_referents:
+            background_tasks.add_task(
+                send_notebook_member_email,
+                to_email=referent.email,
+                beneficiary=beneficiary,
+                orientation_system=orientation_system,
+                former_referents=former_referents,
+                new_structure=orientation_info.new_structure.get("name"),
+                new_referent=Member.parse_from_gql(orientation_info.new_referent)
+                if orientation_info.new_referent is not None
+                else None,
+            )
+
+        if orientation_info.new_referent is not None:
+            new_referent = Member.parse_from_gql(orientation_info.new_referent)
+
+            background_tasks.add_task(
+                send_notebook_member_email,
+                to_email=new_referent.email,
+                new_referent=new_referent,
+                beneficiary=beneficiary,
+                former_referents=former_referents,
+                orientation_system=orientation_system,
+                new_structure=orientation_info.new_structure["name"],
+            )
 
         return response
 

--- a/backend/tests/api/test_notebooks_add_member.py
+++ b/backend/tests/api/test_notebooks_add_member.py
@@ -9,6 +9,7 @@ from cdb.api.db.crud.notebook import get_notebook_members_by_notebook_id
 from cdb.api.db.crud.notebook_info import get_notebook_info
 from cdb.api.db.models.notebook import Notebook
 from cdb.api.db.models.professional import Professional
+from tests.utils.approvaltests import verify, verify_as_json
 from tests.utils.assert_helpers import assert_member, assert_structure
 
 pytestmark = pytest.mark.graphql
@@ -111,7 +112,9 @@ async def test_add_notebook_member_as_no_referent(
     assert notebook_info.orientation_reason == former_notebook_info.orientation_reason
 
 
+@mock.patch("cdb.api.core.emails.send_mail")
 async def test_add_notebook_member_as_referent(
+    mock_send_email: mock.Mock,
     test_client: AsyncClient,
     notebook_sophie_tifour: Notebook,
     get_professional_paul_camara_jwt: str,
@@ -144,6 +147,12 @@ async def test_add_notebook_member_as_referent(
     assert_member(members, professional_pierre_chevalier, "referent", False)
     # Check that former referent is still an active member
     assert_member(members, professional_pierre_chevalier, "no_referent", True)
+    # Check that an email is sent to former referent
+    email_former_referent = mock_send_email.call_args_list[0][1]
+    verify(email_former_referent["message"], extension=".html")
+    verify_as_json(
+        {"subject": email_former_referent["subject"], "to": email_former_referent["to"]}
+    )
 
     structures = await get_structures_for_beneficiary(
         db_connection,

--- a/backend/tests/api/test_orientations.py
+++ b/backend/tests/api/test_orientations.py
@@ -15,7 +15,7 @@ from cdb.api.db.models.beneficiary import Beneficiary
 from cdb.api.db.models.notebook import Notebook
 from cdb.api.db.models.orientation_request import OrientationRequest
 from cdb.api.db.models.professional import Professional
-from tests.utils.approvaltests import verify_as_json
+from tests.utils.approvaltests import verify, verify_as_json
 from tests.utils.assert_helpers import assert_member, assert_structure
 
 pytestmark = pytest.mark.graphql
@@ -380,7 +380,22 @@ async def test_send_email_to_members_with_orientation_request(
         headers={"Authorization": "Bearer " + giulia_diaby_jwt},
     )
     assert response.status_code == 200
-    assert mock_send_email.call_count == 0
+    assert mock_send_email.call_count == 2
+
+    former_email_referent = mock_send_email.call_args_list[0]
+    assert former_email_referent.kwargs["to"] == professional_edith_orial.email
+    assert former_email_referent.kwargs["subject"] == "Réorientation d’un bénéficiaire"
+
+    email_new_referent = mock_send_email.call_args_list[1]
+    assert email_new_referent.kwargs["to"] == professional_paul_camara.email
+    assert email_new_referent.kwargs["subject"] == "Réorientation d’un bénéficiaire"
+
+    verify(
+        {
+            "former_email_referent": former_email_referent.kwargs["message"],
+            "email_new_referent": email_new_referent.kwargs["message"],
+        }
+    )
 
 
 @mock.patch("cdb.api.core.emails.send_mail")
@@ -404,7 +419,22 @@ async def test_send_email_to_members_without_orientation_request(
         headers={"Authorization": "Bearer " + giulia_diaby_jwt},
     )
     assert response.status_code == 200
-    assert mock_send_email.call_count == 0
+    assert mock_send_email.call_count == 2
+
+    former_email_referent = mock_send_email.call_args_list[0]
+    assert former_email_referent.kwargs["to"] == professional_pierre_chevalier.email
+    assert former_email_referent.kwargs["subject"] == "Réorientation d’un bénéficiaire"
+
+    email_new_referent = mock_send_email.call_args_list[1]
+    assert email_new_referent.kwargs["to"] == professional_paul_camara.email
+    assert email_new_referent.kwargs["subject"] == "Réorientation d’un bénéficiaire"
+
+    verify(
+        {
+            "former_email_referent": former_email_referent.kwargs["message"],
+            "email_new_referent": email_new_referent.kwargs["message"],
+        }
+    )
 
 
 @mock.patch("cdb.api.core.emails.send_mail")
@@ -427,7 +457,12 @@ async def test_send_email_to_members_first_orientation(
         headers={"Authorization": "Bearer " + giulia_diaby_jwt},
     )
     assert response.status_code == 200
-    assert mock_send_email.call_count == 0
+    assert mock_send_email.call_count == 1
+
+    email_new_referent = mock_send_email.call_args_list[0]
+    assert email_new_referent.kwargs["to"] == professional_paul_camara.email
+    assert email_new_referent.kwargs["subject"] == "Orientation d’un bénéficiaire"
+    verify(email_new_referent.kwargs["message"], extension=".html")
 
 
 @mock.patch("cdb.api.core.emails.send_mail")

--- a/hasura/metadata/cron_triggers.yaml
+++ b/hasura/metadata/cron_triggers.yaml
@@ -7,3 +7,17 @@
     - name: secret_token
       value_from_env: ACTION_SECRET
   comment: dahsboard report to matomo
+- name: notify_admin_structures
+  webhook: '{{BACKEND_API_URL}}/v1/admin_structures/notify'
+  schedule: 0 22 * * 0-4
+  include_in_metadata: true
+  payload: {}
+  retry_conf:
+    num_retries: 3
+    retry_interval_seconds: 10
+    timeout_seconds: 60
+    tolerance_seconds: 21600
+  headers:
+    - name: secret-token
+      value_from_env: ACTION_SECRET
+  comment: Periodic notification to send unfollowed beneficiaries to admin structures (by email)


### PR DESCRIPTION
This reverts commit 0aef7615f824cf754c1e682a94f7d74af4d19095.

## :wrench: Problème

On doit réactiver les emails précédents désactivés dans https://github.com/gip-inclusion/carnet-de-bord/pull/2075

Pour plus de détails : https://github.com/gip-inclusion/carnet-de-bord/issues/2077

## :cake: Solution

On revert le commit de désactivation


## :desert_island: Comment tester

Se connecter en tant `giulia.diaby` 
1. mail suite à une demande de réorientation
  - Aller dans "Autres Bénéficiaire" "orientés"
  - chercher jennings
  - afficher le carner de Dee Jennings 
  - valider la demande d'orientation sur le carnet de Dee Jennings
  - Se rendre dans mailtrap et s'assurer qu'un mail a été envoyé
3. mails suite à une premier orientation
  - Aller dans "Autres Bénéficiaire" "orientés"
  - chercher  keller
  - afficher le carner de Noel Keller 
  - Se rendre dans mailtrap et s'assurer qu'un mail a été envoyé
4. mail suite à une réorientation 
  - Aller dans "Bénéficiaire" "orientés"
  - chercher Tifour
  - afficher le carner de Sofie Tifour
  - Se rendre dans mailtrap et s'assurer qu'un mail a été envoyé

fix #2077